### PR TITLE
元のBone Scaleを考慮するように修正

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -631,7 +631,6 @@ void FAnimNode_KawaiiPhysics::ApplySimuateResult(FComponentSpacePoseContext& Out
 	{
 		OutBoneTransforms.Add(FBoneTransform(ModifyBones[i].BoneRef.GetCompactPoseIndex(BoneContainer), 
 			FTransform(ModifyBones[i].PoseRotation, ModifyBones[i].PoseLocation, ModifyBones[i].PoseScale)));
-		ModifyBones[i].PoseScale = OutBoneTransforms[i].Transform.GetScale3D();
 	}	
 
 	for (int i = 1; i < ModifyBones.Num(); ++i)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -126,25 +126,30 @@ public:
 	UPROPERTY()
 	FQuat PoseRotation;
 	UPROPERTY()
+	FVector PoseScale;
+	UPROPERTY()
 	float LengthFromRoot;
 	UPROPERTY()
 	bool bDummy = false;
 
+
 public:
 
-	void UpdatePoseLocationAndRotation(const FBoneContainer& BoneContainer, FCSPose<FCompactPose>& Pose)
+	void UpdatePoseTranform(const FBoneContainer& BoneContainer, FCSPose<FCompactPose>& Pose)
 	{
 		auto CompactPoseIndex = BoneRef.GetCompactPoseIndex(BoneContainer);
 		if (CompactPoseIndex < 0)
 		{
 			PoseLocation = FVector::ZeroVector;
 			PoseRotation = FQuat::Identity;
+			PoseScale = FVector::OneVector;
 			return;
 		}
 
 		auto ComponentSpaceTransform = Pose.GetComponentSpaceTransform(CompactPoseIndex);
 		PoseLocation = ComponentSpaceTransform.GetLocation();
 		PoseRotation = ComponentSpaceTransform.GetRotation();
+		PoseScale = ComponentSpaceTransform.GetScale3D();
 	}
 };
 


### PR DESCRIPTION
モデルの仕様により BoneのScaleが FVector::OneVector でない場合があるっぽい？
そのため ApplySimuateResult 関数にて OutBoneTransforms.Add するときに 
元のBoneScaleを考慮してあげると意図したとおりに動きました

検証環境
Ver: UE4.22
モデル: https://bowlroll.net/file/4576

