### PR TITLE
World Damping系を従来処理に差し戻し

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -494,11 +494,11 @@ void FAnimNode_KawaiiPhysics::SimulateModfyBones(FComponentSpacePoseContext& Out
 		}
 
 		// Follow Translation
-		Bone.Location += SkelCompMoveVector * (1.0f - FMath::Pow(Bone.PhysicsSettings.WorldDampingLocation, Exponent));
+        Bone.Location += SkelCompMoveVector * (1.0f - Bone.PhysicsSettings.WorldDampingLocation);
 
 		// Follow Rotation
 		Bone.Location += (SkelCompMoveRotation.RotateVector(Bone.PrevLocation) - Bone.PrevLocation)
-			* (1.0f - FMath::Pow(Bone.PhysicsSettings.WorldDampingRotation, Exponent));
+			* (1.0f - Bone.PhysicsSettings.WorldDampingRotation);
 
 		// Gravity
 		// TODO:Migrate if there are more good method (Currently copying AnimDynamics implementation)


### PR DESCRIPTION
StretchはFrame毎に割合で詰めていたのでFPS調整の必要がありましたが、
WorldDamping系は親Componentの移動や回転に対する相対処理なので
従来の様に割合で処理した方が良い結果になる様です。
