### PR TITLE
RootBoneと同じボーンをExcludeBonesに指定してコンパイルすとクラッシュするバグを修正

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -163,7 +163,10 @@ void FAnimNode_KawaiiPhysics::InitModifyBones(FComponentSpacePoseContext& Output
 
 	ModifyBones.Empty();
 	AddModifyBone(Output, BoneContainer, RefSkeleton, RefSkeleton.FindBoneIndex(RootBone.BoneName));
-	CalcBoneLength( ModifyBones[0], RefSkeleton.GetRefBonePose());
+	if (ModifyBones.Num() > 0)
+	{
+		CalcBoneLength(ModifyBones[0], RefSkeleton.GetRefBonePose());
+	}
 }
 
 int FAnimNode_KawaiiPhysics::AddModifyBone(FComponentSpacePoseContext& Output, const FBoneContainer& BoneContainer, 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -160,7 +160,8 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 
 public:
 	UPROPERTY(EditAnywhere, Category = ModifyTarget)
-	FBoneReference RootBone;
+	TArray<FBoneReference> RootBones;
+
 	UPROPERTY(EditAnywhere, Category = ModifyTarget)
 	TArray<FBoneReference> ExcludeBones;
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -29,7 +29,10 @@ FText UAnimGraphNode_KawaiiPhysics::GetNodeTitle(ENodeTitleType::Type TitleType)
 	{
 		FFormatNamedArguments Args;
 		Args.Add(TEXT("ControllerDescription"), GetControllerDescription());
-		Args.Add(TEXT("RootBoneName"), FText::FromName(Node.RootBone.BoneName));
+		for (auto& RootBone : Node.RootBones)
+		{
+			Args.Add(TEXT("RootBoneName"), FText::FromName(RootBone.BoneName));
+		}
 
 		// FText::Format() is slow, so we cache this to save on performance
 		if (TitleType == ENodeTitleType::ListView || TitleType == ENodeTitleType::MenuTitle)


### PR DESCRIPTION
タイトルの通りRootBoneと同じボーンをExcludeBonesに指定するとModifyBones.Num()が
0になりModifyBones[0]アクセス時にクラッシュするようでしたので修正致しました。

簡単な修正で恐縮ですが、よろしければ御適応ください。