### PR TITLE
Rootと同じボーンをExcludeBoneに指定するとクラッシュするバグを修正

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -163,7 +163,10 @@ void FAnimNode_KawaiiPhysics::InitModifyBones(FComponentSpacePoseContext& Output
 
 	ModifyBones.Empty();
 	AddModifyBone(Output, BoneContainer, RefSkeleton, RefSkeleton.FindBoneIndex(RootBone.BoneName));
-	CalcBoneLength( ModifyBones[0], RefSkeleton.GetRefBonePose());
+	if (ModifyBones.Num() > 0)
+	{
+		CalcBoneLength(ModifyBones[0], RefSkeleton.GetRefBonePose());
+	}
 }
 
 int FAnimNode_KawaiiPhysics::AddModifyBone(FComponentSpacePoseContext& Output, const FBoneContainer& BoneContainer, 


### PR DESCRIPTION
よろしければご適応ください。