### PR TITLE
macOSでプラグインをビルドできません

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -85,17 +85,17 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSettings
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), category="Kawaii")
 	float Damping = 0.1f;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), category="Kawaii")
 	float WorldDampingLocation = 0.8f;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), category="Kawaii")
 	float WorldDampingRotation = 0.8f;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), category="Kawaii")
 	float Stiffness = 0.05f;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), category="Kawaii")
 	float Radius = 3.0f;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (PinHiddenByDefault, ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (PinHiddenByDefault, ClampMin = "0"), category="Kawaii")
 	float LimitAngle = 0.0f;
 };
 


### PR DESCRIPTION
Macでは4.24.2でビルドできませんでしたが、次のエラーが発生します。

```ruby
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(89) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(91) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(93) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(95) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(97) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
./Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h(99) : Compile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
```

このプルリクエストは問題を解決します。ありがとう