### PR TITLE
カーブアセットを作らなくても、カーブでのパラメーター編集ができるように。

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -348,49 +348,49 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 
 		// Damping
 		Bone.PhysicsSettings.Damping = PhysicsSettings.Damping;
-		if (TotalBoneLength > 0 && DampingCurve && DampingCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !DampingCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.Damping *= DampingCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.Damping *= DampingCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.Damping = FMath::Clamp<float>(Bone.PhysicsSettings.Damping, 0.0f, 1.0f);
 
 		// WorldLocationDamping
 		Bone.PhysicsSettings.WorldDampingLocation = PhysicsSettings.WorldDampingLocation;
-		if (TotalBoneLength > 0 && WorldDampingLocationCurve && WorldDampingLocationCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !WorldDampingLocationCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.WorldDampingLocation *= WorldDampingLocationCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.WorldDampingLocation *= WorldDampingLocationCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.WorldDampingLocation = FMath::Clamp<float>(Bone.PhysicsSettings.WorldDampingLocation, 0.0f, 1.0f);
 
 		// WorldRotationDamping
 		Bone.PhysicsSettings.WorldDampingRotation = PhysicsSettings.WorldDampingRotation;
-		if (TotalBoneLength > 0 && WorldDampingRotationCurve && WorldDampingRotationCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !WorldDampingRotationCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.WorldDampingRotation *= WorldDampingRotationCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.WorldDampingRotation *= WorldDampingRotationCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.WorldDampingRotation = FMath::Clamp<float>(Bone.PhysicsSettings.WorldDampingRotation, 0.0f, 1.0f);
 
 		// Stiffness
 		Bone.PhysicsSettings.Stiffness = PhysicsSettings.Stiffness;
-		if (TotalBoneLength > 0 && StiffnessCurve && StiffnessCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !StiffnessCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.Stiffness *= StiffnessCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.Stiffness *= StiffnessCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.Stiffness = FMath::Clamp<float>(Bone.PhysicsSettings.Stiffness, 0.0f, 1.0f);
 
 		// Radius
 		Bone.PhysicsSettings.Radius = PhysicsSettings.Radius;
-		if (TotalBoneLength > 0 && RadiusCurve && RadiusCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !RadiusCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.Radius *= RadiusCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.Radius *= RadiusCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.Radius = FMath::Max<float>(Bone.PhysicsSettings.Radius, 0.0f);
 
 		// LimitAngle
 		Bone.PhysicsSettings.LimitAngle = PhysicsSettings.LimitAngle;
-		if (TotalBoneLength > 0 && LimitAngleCurve && LimitAngleCurve->GetCurves().Num() > 0)
+		if (TotalBoneLength > 0 && !LimitAngleCurveData.GetRichCurve()->IsEmpty())
 		{
-			Bone.PhysicsSettings.LimitAngle *= LimitAngleCurve->GetFloatValue(LengthRate);
+			Bone.PhysicsSettings.LimitAngle *= LimitAngleCurveData.GetRichCurve()->Eval(LengthRate);
 		}
 		Bone.PhysicsSettings.LimitAngle = FMath::Max<float>(Bone.PhysicsSettings.LimitAngle, 0.0f);
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -234,28 +234,53 @@ public:
 	FKawaiiPhysicsSettings PhysicsSettings;
 	
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* DampingCurve_DEPRECATED = nullptr;
+
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* WorldDampingLocationCurve_DEPRECATED = nullptr;
+
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* WorldDampingRotationCurve_DEPRECATED = nullptr;
+
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* StiffnessCurve_DEPRECATED = nullptr;
+
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* RadiusCurve_DEPRECATED = nullptr;
+
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
+	UPROPERTY()
+	UCurveFloat* LimitAngleCurve_DEPRECATED = nullptr;
+
+	//  START SKYBLUE MOD
+	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* DampingCurve = nullptr;
+	FRuntimeFloatCurve DampingCurveData;
 
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* WorldDampingLocationCurve = nullptr;
+	FRuntimeFloatCurve WorldDampingLocationCurveData;
 
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* WorldDampingRotationCurve = nullptr;
+	FRuntimeFloatCurve WorldDampingRotationCurveData;
 
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* StiffnessCurve = nullptr;
+	FRuntimeFloatCurve StiffnessCurveData;
 
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* RadiusCurve = nullptr;
+	FRuntimeFloatCurve RadiusCurveData;
 
 	/** Curve for adjusting the set value of physical behavior. Use rate of bone length from Root */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
-	UCurveFloat* LimitAngleCurve = nullptr;
+	FRuntimeFloatCurve LimitAngleCurveData;
 
 	/** Flag to update each frame physical parameter. Disable to improve performance */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Advanced Physics Settings", meta = (PinHiddenByDefault))

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -128,5 +128,43 @@ void UAnimGraphNode_KawaiiPhysics::ValidateAnimNodePostCompile(FCompilerResultsL
 	
 }
 
+struct FKawaiiPhysicsVersion
+{
+	enum Type
+	{
+		BeforeCustomVersionWasAdded,
+		// -----<new versions can be added above this line>-------------------------------------------------
+		VersionPlusOne,
+		LatestVersion = VersionPlusOne - 1
+	};
+
+	// The GUID for this custom version number
+	const static FGuid GUID;
+
+private:
+	FKawaiiPhysicsVersion() {};
+};
+
+const FGuid FKawaiiPhysicsVersion::GUID(0x4B2D3E25, 0xCD681D29, 0x2DB298D7, 0xAD3E55FA);
+
+const FCustomVersionRegistration GRegisterKawaiiPhysCustomVersion(FKawaiiPhysicsVersion::GUID, FKawaiiPhysicsVersion::LatestVersion, TEXT("Kawaii-Phys"));
+
+void UAnimGraphNode_KawaiiPhysics::Serialize(FArchive& Ar)
+{
+	Super::Serialize(Ar);
+
+	Ar.UsingCustomVersion(FKawaiiPhysicsVersion::GUID);
+
+	if (Ar.CustomVer(FKawaiiPhysicsVersion::GUID) < FKawaiiPhysicsVersion::BeforeCustomVersionWasAdded)
+	{
+		Node.DampingCurveData.ExternalCurve = Node.DampingCurve_DEPRECATED;
+		Node.WorldDampingLocationCurveData.ExternalCurve = Node.WorldDampingLocationCurve_DEPRECATED;
+		Node.WorldDampingRotationCurveData.ExternalCurve = Node.WorldDampingRotationCurve_DEPRECATED;
+		Node.StiffnessCurveData.ExternalCurve = Node.StiffnessCurve_DEPRECATED;
+		Node.RadiusCurveData.ExternalCurve = Node.RadiusCurve_DEPRECATED;
+		Node.LimitAngleCurveData.ExternalCurve = Node.LimitAngleCurve_DEPRECATED;
+	}
+
+}
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -133,6 +133,7 @@ struct FKawaiiPhysicsVersion
 	enum Type
 	{
 		BeforeCustomVersionWasAdded,
+		UseRuntimeFloatCurve,
 		// -----<new versions can be added above this line>-------------------------------------------------
 		VersionPlusOne,
 		LatestVersion = VersionPlusOne - 1
@@ -155,7 +156,7 @@ void UAnimGraphNode_KawaiiPhysics::Serialize(FArchive& Ar)
 
 	Ar.UsingCustomVersion(FKawaiiPhysicsVersion::GUID);
 
-	if (Ar.CustomVer(FKawaiiPhysicsVersion::GUID) < FKawaiiPhysicsVersion::BeforeCustomVersionWasAdded)
+	if (Ar.CustomVer(FKawaiiPhysicsVersion::GUID) < FKawaiiPhysicsVersion::UseRuntimeFloatCurve)
 	{
 		Node.DampingCurveData.ExternalCurve = Node.DampingCurve_DEPRECATED;
 		Node.WorldDampingLocationCurveData.ExternalCurve = Node.WorldDampingLocationCurve_DEPRECATED;
@@ -164,6 +165,7 @@ void UAnimGraphNode_KawaiiPhysics::Serialize(FArchive& Ar)
 		Node.RadiusCurveData.ExternalCurve = Node.RadiusCurve_DEPRECATED;
 		Node.LimitAngleCurveData.ExternalCurve = Node.LimitAngleCurve_DEPRECATED;
 	}
+
 
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -49,6 +49,10 @@ protected:
 	virtual void Draw(FPrimitiveDrawInterface* PDI, USkeletalMeshComponent* SkelMeshComp) const override;
 	// End of UAnimGraphNode_SkeletalControlBase interface
 
+	// UObject interface
+	virtual void Serialize(FArchive& Ar) override;
+	// End of UObject interface
+
 private:
 	/** Constructing FText strings can be costly, so we cache the node's title */
 	FNodeTitleTextTable CachedNodeTitles;


### PR DESCRIPTION
カーブアセットを作らなくても、カーブでのパラメーター編集ができるように。
カーブアセットプロパティの参照先を変更するので、AnimNodeのFCustomVersionRegistrationでバージョン管理をするようにしました。