### PR TITLE
Fix Crashes Related to Editing KawaiiPhysics Nodes in AnimationBlueprints

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLimitsDataAsset.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLimitsDataAsset.cpp
@@ -105,6 +105,8 @@ void UKawaiiPhysicsLimitsDataAsset::PostEditChangeProperty(struct FPropertyChang
 	}
 
 	Sync();
+	// Trigger FCoreUObjectDelegates::OnObjectPropertyChanged
+	Super::PostEditChangeProperty(PropertyChangedEvent);
 }
 
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditMode.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditMode.cpp
@@ -108,8 +108,11 @@ void FKawaiiPhysicsEditMode::Render(const FSceneView* View, FViewport* Viewport,
 				FTransform BoneTransform = FTransform::Identity;
 				if (Collision->DrivingBone.BoneIndex >= 0)
 				{
-					BoneTransform = RuntimeNode->ForwardedPose.GetComponentSpaceTransform(
-						Collision->DrivingBone.GetCompactPoseIndex(RuntimeNode->ForwardedPose.GetPose().GetBoneContainer()));
+					if (RuntimeNode->ForwardedPose.GetPose().GetNumBones() > 0)
+					{
+						BoneTransform = RuntimeNode->ForwardedPose.GetComponentSpaceTransform(
+							Collision->DrivingBone.GetCompactPoseIndex(RuntimeNode->ForwardedPose.GetPose().GetBoneContainer()));
+					}
 				}
 				PDI->DrawPoint(BoneTransform.GetLocation(), FLinearColor::White, 10.0f, SDPG_Foreground);
 				DrawDashedLine(PDI, Collision->Location, BoneTransform.GetLocation(),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEditMode.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEditMode.h
@@ -48,6 +48,7 @@ public:
 protected:
 	void OnExternalNodePropertyChange(FPropertyChangedEvent& InPropertyEvent);
 	FDelegateHandle NodePropertyDelegateHandle;
+	void OnObjectPropertyChanged(UObject* ObjectBeingModified, FPropertyChangedEvent& PropertyChangedEvent) const;
 
 private:
 


### PR DESCRIPTION
Hi @pafuhana1213, thanks for the amazing plugin!
We have encountered two crashes while using UE-5.3.2 with KawaiiPhysics-1.14.0.

First, there is a crash that occurs when editing a Kawaii capsule limits object in the preview window after adding capsule limits data to the data asset.
This crash can be reproduced by following these steps:
1. Open an AnimationBlueprint that contains a KawaiiPhysics node.
2. Select a KawaiiPhysics node, which allows the capsule limit object to be rendered in the preview window.
3. Open the KawaiiPhysicsLimitsDataAsset that the selected KawaiiPhysics node uses.
4. Add a new 'Capsule Limits Data' array element and set a valid 'Driving Bone Name'. The newly created capsule limit object will then be rendered in the AnimationBlueprint preview window.
5. Select the newly created capsule limit object and attempt to change its location or rotation. Doing so causes the Unreal Editor to crash unexpectedly.

The crash occurs in the function `FKawaiiPhysicsEditMode::GetSelectCollisionLimitGraph()` within KawaiiPhysicsEditMode.cpp, when attempting to access the newly created capsule limits data from `GraphNode->Node.CapsuleLimitsData`, which is not found in GraphNode.
My PR includes dummy code that can fix this crash, provided for your reference.



The second issue is a random crash that occurs when clicking the 'Compile' button.
Reproducing it is quite simple:
1. Open an AnimationBlueprint that contains a KawaiiPhysics node.
2. Select a KawaiiPhysics node, which enables the rendering of capsule limit objects in the preview window.
3. In the preview window, select a capsule object to display the gizmo.
4. Repeatedly click the 'Compile' button at a slow pace. The Unreal Editor will crash after several clicks.
The crash can be traced to the `FKawaiiPhysicsEditMode::Render()` function in KawaiiPhysicsEditMode.cpp, specifically when executing `RuntimeNode->ForwardedPose.GetComponentSpaceTransform()`, at which time `RuntimeNode->ForwardedPose` is completely empty.

The `ForwardedPose` variable is populated by the `FAnimNode_SkeletalControlBase::EvaluateComponentSpace_AnyThread()` function in AnimNode_SkeletalControlBase.cpp after clicking the compile button. The `FKawaiiPhysicsEditMode::Render()` function should only use the variable after it has been fully populated. However, `FAnimNode_SkeletalControlBase::EvaluateComponentSpace_AnyThread()` may be called from a different thread than `FKawaiiPhysicsEditMode::Render()`, and this can cause a situation where the execution of `FAnimNode_SkeletalControlBase::EvaluateComponentSpace_AnyThread()` occurs later than `FKawaiiPhysicsEditMode::Render()` following a blueprint compilation, leading to the crash.
And my PR have also provided code that can fix this crash, hoping it can be of help.

Thanks again to @pafuhana1213 and the maintainers.

