### PR TITLE
Add a button for exporting node limits data to a Data Asset.

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLimitsDataAsset.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLimitsDataAsset.cpp
@@ -44,7 +44,7 @@ void UKawaiiPhysicsLimitsDataAsset::UpdateLimit(FCollisionLimitBase* Limit)
 }
 
 template <typename CollisionLimitDataType, typename CollisionLimitType>
-void SyncCollisionLimits(TArray<CollisionLimitDataType>& CollisionLimitData, TArray<CollisionLimitType>& CollisionLimits)
+void SyncCollisionLimits(const TArray<CollisionLimitDataType>& CollisionLimitData, TArray<CollisionLimitType>& CollisionLimits)
 {
 	CollisionLimits.Empty();
 	for (const auto& Data : CollisionLimitData)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
@@ -9,7 +9,7 @@ public class KawaiiPhysicsEd : ModuleRules
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "KawaiiPhysics" });
-        PrivateDependencyModuleNames.AddRange(new string[] { "AnimGraph", "BlueprintGraph", "Persona", "UnrealEd", "AnimGraphRuntime", "SlateCore"});
+        PrivateDependencyModuleNames.AddRange(new string[] { "AnimGraph", "BlueprintGraph", "Persona", "UnrealEd", "AnimGraphRuntime", "Slate", "SlateCore"});
 
         BuildVersion Version;
         if (BuildVersion.TryRead(BuildVersion.GetDefaultFileName(), out Version))

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -44,6 +44,7 @@ protected:
 	virtual FEditorModeID GetEditorMode() const override;
 	virtual void ValidateAnimNodePostCompile(FCompilerResultsLog& MessageLog, UAnimBlueprintGeneratedClass* CompiledClass, int32 CompiledNodeIndex) override;
 	virtual void CopyNodeDataToPreviewNode(FAnimNode_Base* AnimNode) override;
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
 	// End of UAnimGraphNode_Base interface
 
 	//virtual FText GetControllerDescription() const override;
@@ -59,4 +60,6 @@ protected:
 private:
 	/** Constructing FText strings can be costly, so we cache the node's title */
 	FNodeTitleTextTable CachedNodeTitles;
+
+	void ExportLimitsDataAsset();
 };


### PR DESCRIPTION
I added a button in the details panel for exporting node limits data as a `UKawaiiPhysicsLimitsDataAsset`, making it easier for users to create `UKawaiiPhysicsLimitsDataAsset` instances.