### PR TITLE
Fix compilation in 5.3

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -123,7 +123,7 @@ void FAnimNode_KawaiiPhysics::AnimDrawDebug(const FComponentSpacePoseContext& Ou
 					if (CVarAnimNodeKawaiiPhysicsDebugLengthRate.GetValueOnAnyThread())
 					{
 						AnimInstanceProxy->AnimDrawDebugInWorldMessage(
-							FString::Printf(TEXT("%.2f"), ModifyBone.LengthFromRoot / GetTotalBoneLength()),
+							FString::Printf(TEXT("%.2f"), ModifyBone.LengthFromRoot / ModifyBone.LengthRateFromRoot),
 							ModifyBone.Location, FColor::White, 1.0f);
 					}
 #endif


### PR DESCRIPTION
The GetTotalBoneLength() function has been removed, so I've modified it to compile in Unreal Engine 5.3 and later.