### PR TITLE
Update AnimNode_KawaiiPhysics: Params when update skel comp move vector

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -359,6 +359,21 @@ void FAnimNode_KawaiiPhysics::PreUpdate(const UAnimInstance* InAnimInstance)
 #endif
 }
 
+const FVector& FAnimNode_KawaiiPhysics::GetSkelCompMoveVector() const
+{
+	return this->SkelCompMoveVector;
+}
+
+const FQuat& FAnimNode_KawaiiPhysics::GetSkelCompMoveRotation() const
+{
+	return this->SkelCompMoveRotation;
+}
+
+float FAnimNode_KawaiiPhysics::GetDeltaTimeOld() const
+{
+	return this->DeltaTimeOld;
+}
+
 void FAnimNode_KawaiiPhysics::InitializeBoneReferences(const FBoneContainer& RequiredBones)
 {
 	auto Initialize = [&RequiredBones](auto& Targets)
@@ -908,6 +923,7 @@ void FAnimNode_KawaiiPhysics::UpdateModifyBonesPoseTransform(FComponentSpacePose
 void FAnimNode_KawaiiPhysics::UpdateSkelCompMove(const FTransform& ComponentTransform)
 {
 	SkelCompMoveVector = ComponentTransform.InverseTransformPosition(PreSkelCompTransform.GetLocation());
+	SkelCompMoveVector = SkelCompMoveVector * SkeletalComponentMoveScale + SkeletalComponentFixedMoveOffset;
 	if (SkelCompMoveVector.SizeSquared() > TeleportDistanceThreshold * TeleportDistanceThreshold)
 	{
 		SkelCompMoveVector = FVector::ZeroVector;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -903,6 +903,24 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 		meta=(DisplayName="CustomExternalForces(EXPERIMENTAL)"))
 	TArray<TObjectPtr<UKawaiiPhysics_CustomExternalForce>> CustomExternalForces;
 
+	/**
+	 * 移動ベクトルを計算するときに適用するスケルトン コンポーネントの移動スケール。
+	 * 
+	 * The skeletal component move scale to apply when calculate the move vector.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ExternalForce",
+		meta = (PinHiddenByDefault))
+	FVector SkeletalComponentMoveScale = FVector::One();
+
+	/**
+	 * 移動ベクトルをスケーリングした後に適用されるボーン コンポーネントの固定移動オフセット。
+	 * 
+	 * The fixed skeletal component move offset to apply after the scaled the move vector.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ExternalForce",
+		meta = (PinHiddenByDefault))
+	FVector SkeletalComponentFixedMoveOffset = FVector::ZeroVector;
+
 	/** 
 	* レベル上の各コリジョンとの判定を行うフラグ。有効にすると物理処理の負荷が大幅に上がります
 	* Flag for collision detection with each collision on the level. Enabling this will significantly increase the load of physics processing.
@@ -1020,6 +1038,27 @@ public:
 		return (FPlatformTime::Seconds() - LastEvaluatedTime) < 0.1;
 	}
 #endif
+
+	/**
+	 * Gets the vector representing the movement of the skeletal component.
+	 *
+	 * @return The vector representing the movement of the skeletal component.
+	 */
+	const FVector& GetSkelCompMoveVector() const;
+
+	/**
+	 * Gets the quaternion representing the rotation of the skeletal component.
+	 *
+	 * @return The quaternion representing the rotation of the skeletal component.
+	 */
+	const FQuat& GetSkelCompMoveRotation() const;
+
+	/**
+	 * Gets the delta time from the previous frame.
+	 *
+	 * @return The delta time from the previous frame.
+	 */
+	float GetDeltaTimeOld() const;
 
 protected:
 	/**


### PR DESCRIPTION
Thank you for the amazing plugin to make characters so cute.

When I was using this plugin in my game, I found that sometimes when the character stood on some moving platform (e.g., an elevator), the physics result might be hard to predict. I have tried to use `UKawaiiPhysics_CustomExternalForce` but I cannot get some vector.

I added `SkeletalComponentMoveScale` and `SkeletalComponentFixedMoveOffset` to adjust the standing platform physics.

Also write getters to get skeletal comp vector and rotation.

I tried to fix it in this commit. Thanks for your time reviewing this pull request.