### PR TITLE
Change gravity simulation space from Component to World

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -1086,7 +1086,7 @@ void FAnimNode_KawaiiPhysics::SimulateModifyBones(FComponentSpacePoseContext& Ou
 	}
 
 	// External Force : PreApply
-	GravityInSimSpace = ConvertSimulationSpaceVector(Output, EKawaiiPhysicsSimulationSpace::ComponentSpace,
+	GravityInSimSpace = ConvertSimulationSpaceVector(Output, EKawaiiPhysicsSimulationSpace::WorldSpace,
 	                                                 SimulationSpace, Gravity);
 	
 	// NOTE: if use foreach, you may get issue ( Array has changed during ranged-for iteration )


### PR DESCRIPTION
gravity calculated from component space by default, then bone location updated gravity in component space.  gravity rotated with component,  which is not right.