### PR TITLE
[fix] SphereCollision LimitType Inner correct collision distance

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -1795,19 +1795,20 @@ void FAnimNode_KawaiiPhysics::AdjustBySphereCollision(FKawaiiPhysicsModifyBone& 
 			continue;
 		}
 
-		const float LimitDistance = Bone.PhysicsSettings.Radius + Sphere.Radius;
 		if (Sphere.LimitType == ESphericalLimitType::Outer)
 		{
-			if ((Bone.Location - Sphere.Location).SizeSquared() > LimitDistance * LimitDistance)
+			const float LimitDistanceOuter = Sphere.Radius + Bone.PhysicsSettings.Radius;
+			if ((Bone.Location - Sphere.Location).SizeSquared() > LimitDistanceOuter * LimitDistanceOuter)
 			{
 				continue;
 			}
-			Bone.Location += (LimitDistance - (Bone.Location - Sphere.Location).Size())
+			Bone.Location += (LimitDistanceOuter - (Bone.Location - Sphere.Location).Size())
 				* (Bone.Location - Sphere.Location).GetSafeNormal();
 		}
 		else
 		{
-			if ((Bone.Location - Sphere.Location).SizeSquared() < LimitDistance * LimitDistance)
+			const float LimitDistanceInner = Sphere.Radius - Bone.PhysicsSettings.Radius;
+			if ((Bone.Location - Sphere.Location).SizeSquared() < LimitDistanceInner * LimitDistanceInner)
 			{
 				continue;
 			}


### PR DESCRIPTION
I just found this plugin and it's awesome but I wanted to put a helmet on my character and noticed the SphereCollision Limit Inner was making the physics jump.

Turns out the collision distance was being calculated from the outside not the inside.
Here's a drawing that explains my thought process.

![inner_coll_calc](https://github.com/user-attachments/assets/b736d19d-c280-4b66-ba73-0cc9bbf10ba0)

This change fixed it on my end, hope this helps and thank you for your time.