### PR TITLE
[perf] ホットパス最適化（カーブ空高速パス/形状キャッシュ他）

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -32,6 +32,12 @@
 #include "KawaiiPhysics.h"
 #include "AnimNode_KawaiiPhysicsInternal.h"
 
+// トレースはゲームスレッド上で実行されないため、TraceTag はデバッグトレースを描画しない
+FKawaiiWorldCollisionQuerySettings::FKawaiiWorldCollisionQuerySettings()
+	: Params(SCENE_QUERY_STAT(KawaiiCollision))
+{
+}
+
 void FAnimNode_KawaiiPhysics::ApplyLimitsDataAsset(const FBoneContainer& RequiredBones)
 {
 	auto Initialize = [&RequiredBones](auto& Targets)
@@ -314,8 +320,9 @@ void FAnimNode_KawaiiPhysics::UpdatePlanerLimits(TArray<FPlanarLimit>& Limits, F
 	}
 }
 
-void FAnimNode_KawaiiPhysics::AdjustByWorldCollision(FComponentSpacePoseContext& Output, FKawaiiPhysicsModifyBone& Bone,
-                                                     const USkeletalMeshComponent* OwningComp)
+void FAnimNode_KawaiiPhysics::AdjustByWorldCollision(
+	FComponentSpacePoseContext& Output, FKawaiiPhysicsModifyBone& Bone, const USkeletalMeshComponent* OwningComp,
+	const FKawaiiWorldCollisionQuerySettings& WorldCollisionQuerySettings)
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_WorldCollision);
 
@@ -331,24 +338,6 @@ void FAnimNode_KawaiiPhysics::AdjustByWorldCollision(FComponentSpacePoseContext&
 		return;
 	}
 
-
-	/** トレースはゲームスレッド上で実行されないため、TraceTag はデバッグトレースを描画しない */
-	FCollisionQueryParams Params(SCENE_QUERY_STAT(KawaiiCollision));
-
-	if (bIgnoreSelfComponent)
-	{
-		Params.AddIgnoredComponent(OwningComp);
-	}
-
-	// コンポーネントからコリジョン設定を取得
-	ECollisionChannel TraceChannel = bOverrideCollisionParams
-		                                 ? CollisionChannelSettings.GetObjectType()
-		                                 : OwningComp->GetCollisionObjectType();
-	FCollisionResponseParams ResponseParams = bOverrideCollisionParams
-		                                          ? FCollisionResponseParams(
-			                                          CollisionChannelSettings.GetResponseToChannels())
-		                                          : FCollisionResponseParams(
-			                                          OwningComp->GetCollisionResponseToChannels());
 	const UWorld* World = OwningComp->GetWorld();
 
 	const FVector TraceStartLocationWS =
@@ -364,7 +353,8 @@ void FAnimNode_KawaiiPhysics::AdjustByWorldCollision(FComponentSpacePoseContext&
 		FHitResult Result;
 		bool bHit = World->SweepSingleByChannel(
 			Result, TraceStartLocationWS, TraceEndLocationWS, FQuat::Identity,
-			TraceChannel, FCollisionShape::MakeSphere(Bone.PhysicsSettings.Radius), Params, ResponseParams);
+			WorldCollisionQuerySettings.TraceChannel, FCollisionShape::MakeSphere(Bone.PhysicsSettings.Radius),
+			WorldCollisionQuerySettings.Params, WorldCollisionQuerySettings.ResponseParams);
 		if (bHit)
 		{
 			if (Result.bStartPenetrating)
@@ -386,9 +376,11 @@ void FAnimNode_KawaiiPhysics::AdjustByWorldCollision(FComponentSpacePoseContext&
 		// sphere sweep（ヒット後に対象ボーンを除外）
 		WorldCollisionHitsScratch.Reset();
 		bool bHit = World->SweepMultiByChannel(WorldCollisionHitsScratch, TraceStartLocationWS,
-		                                       TraceEndLocationWS, FQuat::Identity, TraceChannel,
-		                                       FCollisionShape::MakeSphere(Bone.PhysicsSettings.Radius), Params,
-		                                       ResponseParams);
+		                                       TraceEndLocationWS, FQuat::Identity,
+		                                       WorldCollisionQuerySettings.TraceChannel,
+		                                       FCollisionShape::MakeSphere(Bone.PhysicsSettings.Radius),
+		                                       WorldCollisionQuerySettings.Params,
+		                                       WorldCollisionQuerySettings.ResponseParams);
 		if (!bHit)
 		{
 			return;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -513,6 +513,30 @@ void FAnimNode_KawaiiPhysics::AdjustBySphereCollision(FKawaiiPhysicsModifyBone& 
 	}
 }
 
+void FAnimNode_KawaiiPhysics::PrepareCollisionShapeCaches()
+{
+	auto UpdateEnabledCaches = [](auto& Limits)
+	{
+		for (auto& Limit : Limits)
+		{
+			if (Limit.bEnable)
+			{
+				Limit.UpdateRuntimeCache();
+			}
+		}
+	};
+
+	UpdateEnabledCaches(CapsuleLimits);
+	UpdateEnabledCaches(CapsuleLimitsData);
+	UpdateEnabledCaches(SharedCapsuleLimits);
+	UpdateEnabledCaches(BoxLimits);
+	UpdateEnabledCaches(BoxLimitsData);
+	UpdateEnabledCaches(SharedBoxLimits);
+	UpdateEnabledCaches(PlanarLimits);
+	UpdateEnabledCaches(PlanarLimitsData);
+	UpdateEnabledCaches(SharedPlanarLimits);
+}
+
 void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FCapsuleLimit>& Limits)
 {
 	for (auto& Capsule : Limits)
@@ -522,8 +546,8 @@ void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone&
 			continue;
 		}
 
-		FVector StartPoint = Capsule.Location + Capsule.Rotation.GetAxisZ() * Capsule.Length * 0.5f;
-		FVector EndPoint = Capsule.Location + Capsule.Rotation.GetAxisZ() * Capsule.Length * -0.5f;
+		FVector StartPoint = Capsule.CachedStartPoint;
+		FVector EndPoint = Capsule.CachedEndPoint;
 		const float DistSquared = FMath::PointDistToSegmentSquared(Bone.Location, StartPoint, EndPoint);
 
 		const float LimitDistance = Bone.PhysicsSettings.Radius + Capsule.Radius;
@@ -534,7 +558,7 @@ void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone&
 			if (PushDir.IsNearlyZero())
 			{
 				// ボーンがカプセル軸上に乗ると押し出し方向が消えるため軸直交方向を代替に使う
-				PushDir = Capsule.Rotation.GetAxisX();
+				PushDir = Capsule.CachedFallbackPushDir;
 			}
 			Bone.Location = ClosestPoint + PushDir * LimitDistance;
 		}
@@ -550,11 +574,11 @@ void FAnimNode_KawaiiPhysics::AdjustByBoxCollision(FKawaiiPhysicsModifyBone& Bon
 			continue;
 		}
 
-		FTransform BoxTransform(Box.Rotation, Box.Location);
+		FTransform BoxTransform = Box.CachedBoxTransform;
 		float SphereRadius = Bone.PhysicsSettings.Radius;
 
 		FVector LocalSphereCenter = BoxTransform.InverseTransformPosition(Bone.Location);
-		FBox LocalBox(-Box.Extent, Box.Extent);
+		FBox LocalBox = Box.CachedLocalBox;
 		if (FMath::SphereAABBIntersection(FSphere(LocalSphereCenter, SphereRadius), LocalBox))
 		{
 			// Sphere の中心に最も近い Box 上の点を計算
@@ -618,7 +642,7 @@ void FAnimNode_KawaiiPhysics::AdjustByPlanerCollision(FKawaiiPhysicsModifyBone& 
 		if (DistSquared < Bone.PhysicsSettings.Radius * Bone.PhysicsSettings.Radius ||
 			FMath::SegmentPlaneIntersection(Bone.Location, Bone.PrevLocation, Planar.Plane, IntersectionPoint))
 		{
-			Bone.Location = PointOnPlane + Planar.Rotation.GetUpVector() * Bone.PhysicsSettings.Radius;
+			Bone.Location = PointOnPlane + Planar.CachedNormal * Bone.PhysicsSettings.Radius;
 		}
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -715,6 +715,15 @@ void FAnimNode_KawaiiPhysics::AdjustByBoneConstraints()
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_AdjustByBoneConstraint);
 
+	// StepDt は本関数の実行中ずっと同一なので、制約毎の除算をやめて 1 回だけ表を作る。
+	// FMath::Max は極小 StepDt で compliance が発散しないためのガード。
+	const float StepDt = FMath::Max(GetStepDeltaTime(), KINDA_SMALL_NUMBER);
+	float CompliancePerDt2[UE_ARRAY_COUNT(XPBDComplianceValues)];
+	for (int32 i = 0; i < UE_ARRAY_COUNT(XPBDComplianceValues); ++i)
+	{
+		CompliancePerDt2[i] = XPBDComplianceValues[i] / (StepDt * StepDt);
+	}
+
 	for (FModifyBoneConstraint& BoneConstraint : MergedBoneConstraints)
 	{
 		// IsValid()はLength>0のみ確認するため、indexの範囲も明示的に検証（堅牢化）
@@ -748,10 +757,7 @@ void FAnimNode_KawaiiPhysics::AdjustByBoneConstraints()
 		// enum 値の破損や将来の追加に備え、インデックスを配列範囲内へクランプ。
 		const int32 ComplianceIndex = FMath::Clamp(static_cast<int32>(ComplianceType), 0,
 		                                           static_cast<int32>(UE_ARRAY_COUNT(XPBDComplianceValues)) - 1);
-		float Compliance = XPBDComplianceValues[ComplianceIndex];
-		// 極小 StepDt で compliance が発散しないようガード。
-		const float StepDt = FMath::Max(GetStepDeltaTime(), KINDA_SMALL_NUMBER);
-		Compliance /= StepDt * StepDt;
+		float Compliance = CompliancePerDt2[ComplianceIndex];
 		float DeltaLambda = (Constraint - Compliance * BoneConstraint.Lambda) / (2 + Compliance); // 2 = SumMass
 		Delta = (Delta / DeltaLength) * DeltaLambda;
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -837,6 +837,8 @@ void FAnimNode_KawaiiPhysics::ApplySimulateResult(FComponentSpacePoseContext& Ou
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_ApplySimulateResult);
 
+	OutBoneTransforms.Reserve(OutBoneTransforms.Num() + ModifyBones.Num());
+
 	for (int32 i = 0; i < ModifyBones.Num(); ++i)
 	{
 		FTransform PoseTransform = FTransform(ModifyBones[i].PoseRotation, ModifyBones[i].PoseLocation,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -389,6 +389,7 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 	// NOTE: 形状ごとにループを分けると ModifyBones を複数回走査してキャッシュ効率が落ちるため
 	// （ボーン数が多いケースで負荷増）、従来どおりボーン外側の1パスで全形状を処理する。
 	// World判定の時間は関数内の既存STAT（STAT_KawaiiPhysics_WorldCollision）で計測する。
+	PrepareCollisionShapeCaches();
 	int32 NumWorldChecks = 0;
 	for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -11,6 +11,7 @@
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
 #include "Animation/AnimInstanceProxy.h"
 #include "Curves/CurveFloat.h"
+#include "Misc/Optional.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "SceneInterface.h"
 #include "PhysicsEngine/PhysicsAsset.h"
@@ -434,6 +435,26 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 	// （ボーン数が多いケースで負荷増）、従来どおりボーン外側の1パスで全形状を処理する。
 	// World判定の時間は関数内の既存STAT（STAT_KawaiiPhysics_WorldCollision）で計測する。
 	PrepareCollisionShapeCaches();
+
+	TOptional<FKawaiiWorldCollisionQuerySettings> WorldCollisionQuerySettings;
+	if (bAllowWorldCollision && SkelComp)
+	{
+		WorldCollisionQuerySettings.Emplace();
+		if (bIgnoreSelfComponent)
+		{
+			WorldCollisionQuerySettings->Params.AddIgnoredComponent(SkelComp);
+		}
+
+		WorldCollisionQuerySettings->TraceChannel = bOverrideCollisionParams
+			                                            ? CollisionChannelSettings.GetObjectType()
+			                                            : SkelComp->GetCollisionObjectType();
+		WorldCollisionQuerySettings->ResponseParams = bOverrideCollisionParams
+			                                               ? FCollisionResponseParams(
+				                                               CollisionChannelSettings.GetResponseToChannels())
+			                                               : FCollisionResponseParams(
+				                                               SkelComp->GetCollisionResponseToChannels());
+	}
+
 	int32 NumWorldChecks = 0;
 	for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
 	{
@@ -464,7 +485,10 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 
 		if (bAllowWorldCollision)
 		{
-			AdjustByWorldCollision(Output, Bone, SkelComp);
+			if (WorldCollisionQuerySettings.IsSet())
+			{
+				AdjustByWorldCollision(Output, Bone, SkelComp, WorldCollisionQuerySettings.GetValue());
+			}
 			++NumWorldChecks; // 発行したワールドスイープ回数
 		}
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -636,6 +636,7 @@ void FAnimNode_KawaiiPhysics::Simulate(FKawaiiPhysicsModifyBone& Bone, const FSc
 	FVector Velocity = ComputeVerletStepVelocity(Bone, WindVelocity);
 
 	// ユーザー外力に実速度を渡す（gravity の後・位置更新の前）。ApplyToVelocity が InOutVelocity を読む実装もあり得るため実速度に対して呼ぶ。
+	// 注: Apply 内でユーザーコードが ExternalForces を変更しうるため、生ポインタを持ち回さず毎回 index で取得する。
 	for (int i = 0; i < ExternalForces.Num(); ++i)
 	{
 		if (ExternalForces[i].IsValid())
@@ -679,12 +680,19 @@ void FAnimNode_KawaiiPhysics::Simulate(FKawaiiPhysicsModifyBone& Bone, const FSc
 	}
 
 	// External Force
-	// 注: foreach を使うと問題が起きうる（ranged-for 中に配列が変化する）
+	// 注: foreach を使うと問題が起きうる（ranged-for 中に配列が変化する）。ユーザーの Apply が配列を変更しても
+	// 安全なよう index ループのまま。BoneTM だけはボーン内で不変なので初回のみ解決して使い回す。
+	FTransform BoneTM;
+	bool bBoneTMResolved = false;
 	for (int i = 0; i < CustomExternalForces.Num(); ++i)
 	{
 		if (CustomExternalForces[i] && CustomExternalForces[i]->bIsEnabled)
 		{
-			const FTransform BoneTM = ResolveExternalForceBoneTransform(Output, Bone, ParentBone);
+			if (!bBoneTMResolved)
+			{
+				BoneTM = ResolveExternalForceBoneTransform(Output, Bone, ParentBone);
+				bBoneTMResolved = true;
+			}
 			CustomExternalForces[i]->Apply(*this, Bone.Index, SkelComp, BoneTM);
 		}
 	}
@@ -698,7 +706,11 @@ void FAnimNode_KawaiiPhysics::Simulate(FKawaiiPhysicsModifyBone& Bone, const FSc
 			{
 				if (ExForce->ExternalForceSpace == EExternalForceSpace::BoneSpace)
 				{
-					const FTransform BoneTM = ResolveExternalForceBoneTransform(Output, Bone, ParentBone);
+					if (!bBoneTMResolved)
+					{
+						BoneTM = ResolveExternalForceBoneTransform(Output, Bone, ParentBone);
+						bBoneTMResolved = true;
+					}
 					ExForce->Apply(Bone, *this, Output, BoneTM);
 				}
 				else

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -234,6 +234,10 @@ void FAnimNode_KawaiiPhysics::SimulateModifyBones(FComponentSpacePoseContext& Ou
 	}
 	bSubstepPoseInitialized = true;
 
+	// コリジョン形状の派生値キャッシュはフレーム毎1回で足りる
+	// （各 Limits の Location/Rotation 更新は EvaluateSkeletalControl 内のフレーム毎1回で、substep 間に書き換える処理はない）。
+	PrepareCollisionShapeCaches();
+
 	if (!bUseFixedSubsteppingCached)
 	{
 		// ===== Legacy: 実フレーム時間で1ステップ（GetStepDeltaTime()==DeltaTime） =====
@@ -434,8 +438,6 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 	// NOTE: 形状ごとにループを分けると ModifyBones を複数回走査してキャッシュ効率が落ちるため
 	// （ボーン数が多いケースで負荷増）、従来どおりボーン外側の1パスで全形状を処理する。
 	// World判定の時間は関数内の既存STAT（STAT_KawaiiPhysics_WorldCollision）で計測する。
-	PrepareCollisionShapeCaches();
-
 	TOptional<FKawaiiWorldCollisionQuerySettings> WorldCollisionQuerySettings;
 	if (bAllowWorldCollision && SkelComp)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -713,10 +713,46 @@ void FAnimNode_KawaiiPhysics::ApplyWorldMoveFollowNonBaseBone(FKawaiiPhysicsModi
 void FAnimNode_KawaiiPhysics::ApplyStiffnessPull(FKawaiiPhysicsModifyBone& Bone,
                                                  const FKawaiiPhysicsModifyBone& ParentBone, float Exponent)
 {
-	// Pull to Pose Location
+	// ポーズ位置へ引き戻す
 	const FVector BaseLocation = ParentBone.Location + (Bone.PoseLocation - ParentBone.PoseLocation);
-	Bone.Location += (BaseLocation - Bone.Location) *
-		(1.0f - FMath::Pow(1.0f - Bone.PhysicsSettings.Stiffness, Exponent));
+	const float Stiffness = Bone.PhysicsSettings.Stiffness;
+	float PullAlpha;
+
+	// 固定サブステップ時は Exponent が厳密に 1.0f になり powf の y==1 特殊ケースで即返るため、
+	// メモ化しても速くならずキャッシュアクセス分だけ損をする。Exponent が 1.0f にならない legacy 経路でのみメモを使う。
+	if (bInSubstep)
+	{
+		PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
+	}
+	else
+	{
+		if (StiffnessPullMemos.Num() != ModifyBones.Num())
+		{
+			StiffnessPullMemos.SetNum(ModifyBones.Num());
+		}
+
+		if (StiffnessPullMemos.IsValidIndex(Bone.Index))
+		{
+			FStiffnessPullMemo& Memo = StiffnessPullMemos[Bone.Index];
+			if (Memo.Stiffness == Stiffness && Memo.Exponent == Exponent)
+			{
+				PullAlpha = Memo.PullAlpha;
+			}
+			else
+			{
+				PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
+				Memo.Stiffness = Stiffness;
+				Memo.Exponent = Exponent;
+				Memo.PullAlpha = PullAlpha;
+			}
+		}
+		else
+		{
+			PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
+		}
+	}
+
+	Bone.Location += (BaseLocation - Bone.Location) * PullAlpha;
 }
 
 FVector FAnimNode_KawaiiPhysics::GetWindVelocity(FComponentSpacePoseContext& Output, const FSceneInterface* Scene,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -796,44 +796,8 @@ void FAnimNode_KawaiiPhysics::ApplyStiffnessPull(FKawaiiPhysicsModifyBone& Bone,
 {
 	// ポーズ位置へ引き戻す
 	const FVector BaseLocation = ParentBone.Location + (Bone.PoseLocation - ParentBone.PoseLocation);
-	const float Stiffness = Bone.PhysicsSettings.Stiffness;
-	float PullAlpha;
-
-	// 固定サブステップ時は Exponent が厳密に 1.0f になり powf の y==1 特殊ケースで即返るため、
-	// メモ化しても速くならずキャッシュアクセス分だけ損をする。Exponent が 1.0f にならない legacy 経路でのみメモを使う。
-	if (bInSubstep)
-	{
-		PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
-	}
-	else
-	{
-		if (StiffnessPullMemos.Num() != ModifyBones.Num())
-		{
-			StiffnessPullMemos.SetNum(ModifyBones.Num());
-		}
-
-		if (StiffnessPullMemos.IsValidIndex(Bone.Index))
-		{
-			FStiffnessPullMemo& Memo = StiffnessPullMemos[Bone.Index];
-			if (Memo.Stiffness == Stiffness && Memo.Exponent == Exponent)
-			{
-				PullAlpha = Memo.PullAlpha;
-			}
-			else
-			{
-				PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
-				Memo.Stiffness = Stiffness;
-				Memo.Exponent = Exponent;
-				Memo.PullAlpha = PullAlpha;
-			}
-		}
-		else
-		{
-			PullAlpha = 1.0f - FMath::Pow(1.0f - Stiffness, Exponent);
-		}
-	}
-
-	Bone.Location += (BaseLocation - Bone.Location) * PullAlpha;
+	Bone.Location += (BaseLocation - Bone.Location) *
+		(1.0f - FMath::Pow(1.0f - Bone.PhysicsSettings.Stiffness, Exponent));
 }
 
 FVector FAnimNode_KawaiiPhysics::GetWindVelocity(FComponentSpacePoseContext& Output, const FSceneInterface* Scene,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -37,38 +37,82 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_UpdatePhysicsSetting);
 
+	const FRichCurve* DampingCurve = DampingCurveData.GetRichCurveConst();
+	const FRichCurve* WorldDampingLocationCurve = WorldDampingLocationCurveData.GetRichCurveConst();
+	const FRichCurve* WorldDampingRotationCurve = WorldDampingRotationCurveData.GetRichCurveConst();
+	const FRichCurve* StiffnessCurve = StiffnessCurveData.GetRichCurveConst();
+	const FRichCurve* RadiusCurve = RadiusCurveData.GetRichCurveConst();
+	const FRichCurve* LimitAngleCurve = LimitAngleCurveData.GetRichCurveConst();
+
+	const bool bAllCurvesEmpty =
+		DampingCurve->IsEmpty() &&
+		WorldDampingLocationCurve->IsEmpty() &&
+		WorldDampingRotationCurve->IsEmpty() &&
+		StiffnessCurve->IsEmpty() &&
+		RadiusCurve->IsEmpty() &&
+		LimitAngleCurve->IsEmpty();
+
+	if (bAllCurvesEmpty)
+	{
+		// 空カーブでも FRichCurve::DefaultValue が設定されている場合があるため、1.0f を決め打ちせず Eval の結果を使う。
+		const float Damping = FMath::Clamp(
+			PhysicsSettings.Damping * DampingCurve->Eval(0.0f, 1.0f), 0.0f, 1.0f);
+		const float WorldDampingLocation = FMath::Clamp(
+			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurve->Eval(0.0f, 1.0f), 0.0f, 1.0f);
+		const float WorldDampingRotation = FMath::Clamp(
+			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurve->Eval(0.0f, 1.0f), 0.0f, 1.0f);
+		const float Stiffness = FMath::Clamp(
+			PhysicsSettings.Stiffness * StiffnessCurve->Eval(0.0f, 1.0f), 0.0f, 1.0f);
+		const float Radius = FMath::Max(
+			PhysicsSettings.Radius * RadiusCurve->Eval(0.0f, 1.0f), 0.0f);
+		const float LimitAngle = FMath::Max(
+			PhysicsSettings.LimitAngle * LimitAngleCurve->Eval(0.0f, 1.0f), 0.0f);
+
+		for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
+		{
+			Bone.PhysicsSettings.Damping = Damping;
+			Bone.PhysicsSettings.WorldDampingLocation = WorldDampingLocation;
+			Bone.PhysicsSettings.WorldDampingRotation = WorldDampingRotation;
+			Bone.PhysicsSettings.Stiffness = Stiffness;
+			Bone.PhysicsSettings.Radius = Radius;
+			Bone.PhysicsSettings.LimitAngle = LimitAngle;
+		}
+
+		return;
+	}
+
 	for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
 	{
 		const float LengthRate = Bone.LengthRateFromRoot;
 
 		// Damping
 		Bone.PhysicsSettings.Damping = FMath::Clamp(
-			PhysicsSettings.Damping * DampingCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Damping * DampingCurve->Eval(
 				LengthRate, 1.0f), 0.0f, 1.0f);
 		
 		// WorldLocationDamping
 		Bone.PhysicsSettings.WorldDampingLocation = FMath::Clamp(
-			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurve->Eval(
 				LengthRate, 1.0f), 0.0f, 1.0f);
 		
 		// WorldRotationDamping
 		Bone.PhysicsSettings.WorldDampingRotation = FMath::Clamp(
-			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurve->Eval(
 				LengthRate, 1.0f), 0.0f, 1.0f);
 		
 		// Stiffness
 		Bone.PhysicsSettings.Stiffness = FMath::Clamp(
-			PhysicsSettings.Stiffness * StiffnessCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Stiffness * StiffnessCurve->Eval(
 				LengthRate, 1.0f), 0.0f, 1.0f);
 		
 		// Radius
 		Bone.PhysicsSettings.Radius = FMath::Max(
-			PhysicsSettings.Radius * RadiusCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Radius * RadiusCurve->Eval(
 				LengthRate, 1.0f), 0.0f);
 		
 		// LimitAngle
 		Bone.PhysicsSettings.LimitAngle = FMath::Max(
-			PhysicsSettings.LimitAngle * LimitAngleCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.LimitAngle * LimitAngleCurve->Eval(
 				LengthRate, 1.0f), 0.0f);
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Curve.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Curve.cpp
@@ -52,10 +52,22 @@ void FKawaiiPhysics_ExternalForce_Curve::PreApply(FAnimNode_KawaiiPhysics& Node,
 	}
 	else
 	{
-		TArray<FVector> CurveValues;
 		// SubstepCountが0以下でもゼロ除算しないよう最低1にクランプ
 		const int32 Steps = FMath::Max(SubstepCount, 1);
 		const float SubStep = Node.GetStepDeltaTime() * TimeScale / Steps;
+
+		Force = FVector::ZeroVector;
+		switch (CurveEvaluateType)
+		{
+		case EExternalForceCurveEvaluateType::Max:
+			Force = FVector(TNumericLimits<float>::Lowest());
+			break;
+		case EExternalForceCurveEvaluateType::Min:
+			Force = FVector(FLT_MAX);
+			break;
+		default:
+			break;
+		}
 
 		for (int i = 0; i < Steps; ++i)
 		{
@@ -64,34 +76,27 @@ void FKawaiiPhysics_ExternalForce_Curve::PreApply(FAnimNode_KawaiiPhysics& Node,
 			{
 				Time = FMath::Fmod(Time, MaxCurveTime);
 			}
-			CurveValues.Add(ForceCurve.GetValue(Time));
+			const FVector CurveValue = ForceCurve.GetValue(Time);
+			switch (CurveEvaluateType)
+			{
+			case EExternalForceCurveEvaluateType::Average:
+				Force += CurveValue;
+				break;
+			case EExternalForceCurveEvaluateType::Max:
+				Force = FVector::Max(Force, CurveValue);
+				break;
+			case EExternalForceCurveEvaluateType::Min:
+				Force = FVector::Min(Force, CurveValue);
+				break;
+			default:
+				break;
+			}
 		}
 
-		Force = FVector::ZeroVector;
 		switch (CurveEvaluateType)
 		{
 		case EExternalForceCurveEvaluateType::Average:
-			for (const auto& CurveValue : CurveValues)
-			{
-				Force += CurveValue;
-			}
 			Force /= static_cast<float>(Steps);
-
-			break;
-
-		case EExternalForceCurveEvaluateType::Max:
-			Force = FVector(TNumericLimits<float>::Lowest());
-			for (const auto& CurveValue : CurveValues)
-			{
-				Force = FVector::Max(Force, CurveValue);
-			}
-			break;
-		case EExternalForceCurveEvaluateType::Min:
-			Force = FVector(FLT_MAX);
-			for (const auto& CurveValue : CurveValues)
-			{
-				Force = FVector::Min(Force, CurveValue);
-			}
 			break;
 		default:
 			break;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -303,14 +303,26 @@ struct FKawaiiPhysicsTestAccessor
 	}
 	void CallCapsuleCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FCapsuleLimit>& Limits)
 	{
+		for (FCapsuleLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByCapsuleCollision(Bone, Limits);
 	}
 	void CallBoxCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FBoxLimit>& Limits)
 	{
+		for (FBoxLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByBoxCollision(Bone, Limits);
 	}
 	void CallPlanarCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits)
 	{
+		for (FPlanarLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByPlanerCollision(Bone, Limits);
 	}
 	void CallAngleLimit(FKawaiiPhysicsModifyBone& Bone, const FKawaiiPhysicsModifyBone& ParentBone)
@@ -506,6 +518,7 @@ private:
 		}
 
 		// コリジョン（SimulateOnce 413-445、AnimNode 側 limits のみ）
+		Node.PrepareCollisionShapeCaches();
 		for (FKawaiiPhysicsModifyBone& Bone : Node.ModifyBones)
 		{
 			if (Bone.bSkipSimulate)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -224,6 +224,8 @@ struct FKawaiiPhysicsTestAccessor
 		Node.DeltaTime = FrameDt;
 		Node.FrameDeltaTime = FrameDt;
 		PrepareFrame();
+		// 本番 SimulateModifyBones と同様、形状キャッシュはフレーム毎1回（substep 毎ではない）。
+		Node.PrepareCollisionShapeCaches();
 
 		if (!Node.bUseFixedSubsteppingCached)
 		{
@@ -517,8 +519,7 @@ private:
 			}
 		}
 
-		// コリジョン（SimulateOnce 413-445、AnimNode 側 limits のみ）
-		Node.PrepareCollisionShapeCaches();
+		// コリジョン（SimulateOnce 413-445、AnimNode 側 limits のみ。形状キャッシュは StepFrame 冒頭で更新済み）
 		for (FKawaiiPhysicsModifyBone& Bone : Node.ModifyBones)
 		{
 			if (Bone.bSkipSimulate)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -1195,6 +1195,14 @@ protected:
 	/** Pull to Pose Location（剛性）。 */
 	void ApplyStiffnessPull(FKawaiiPhysicsModifyBone& Bone, const FKawaiiPhysicsModifyBone& ParentBone, float Exponent);
 
+	// コリジョン形状の派生値をステップ毎に1回だけ更新する。
+	// Update derived collision-shape values once per simulation step.
+	// 代入経由でキャッシュを運ばない理由: FCollisionLimitBase 系は自前 operator= を持ち、
+	// 新フィールドの追記漏れが静かなキャッシュ陳腐化になるため、構造的に陳腐化しない毎ステップ再計算にする。
+	// Reason caches are not carried through assignment: FCollisionLimitBase-derived types have custom operator=,
+	// and missing a newly added cache field would silently stale the cache, so caches are recomputed every step.
+	void PrepareCollisionShapeCaches();
+
 	// 自動テスト用アクセサ。private/protected の sim 状態・物理計算・コリジョン関数へアクセスする。
 	// Shipping/Test（WITH_DEV_AUTOMATION_TESTS==0）では宣言ごと除外し、出荷ビルドにテスト表面を残さない。
 	// Test-only accessor for private/protected sim state, core functions, and collision functions.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -684,20 +684,6 @@ private:
 	FVector SimpleExternalForceInSimSpace = FVector::ZeroVector;
 
 	/**
-	* legacy 経路（非サブステップ）専用の Stiffness pull 係数 (1 - Pow(1 - Stiffness, Exponent)) のメモ。
-	* 固定サブステップ中は Exponent が 1.0f になり Pow が軽いため、このメモ配列には触れない。
-	* Memo for the stiffness pull coefficient (1 - Pow(1 - Stiffness, Exponent)), used only by the legacy path (non-substep).
-	* Fixed substeps do not touch this memo array because Exponent is 1.0f and Pow is already cheap.
-	*/
-	struct FStiffnessPullMemo
-	{
-		float Stiffness = TNumericLimits<float>::Max();
-		float Exponent = TNumericLimits<float>::Max();
-		float PullAlpha = 0.0f;
-	};
-	TArray<FStiffnessPullMemo> StiffnessPullMemos;
-	
-	/**
 	 *	 The last simulation space used for the physics simulation.
 	 */
 	EKawaiiPhysicsSimulationSpace LastSimulationSpace = EKawaiiPhysicsSimulationSpace::ComponentSpace;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -669,6 +669,20 @@ private:
 
 	// Cached simple external force in current SimulationSpace (computed once per SimulateModifyBones)
 	FVector SimpleExternalForceInSimSpace = FVector::ZeroVector;
+
+	/**
+	* legacy 経路（非サブステップ）専用の Stiffness pull 係数 (1 - Pow(1 - Stiffness, Exponent)) のメモ。
+	* 固定サブステップ中は Exponent が 1.0f になり Pow が軽いため、このメモ配列には触れない。
+	* Memo for the stiffness pull coefficient (1 - Pow(1 - Stiffness, Exponent)), used only by the legacy path (non-substep).
+	* Fixed substeps do not touch this memo array because Exponent is 1.0f and Pow is already cheap.
+	*/
+	struct FStiffnessPullMemo
+	{
+		float Stiffness = TNumericLimits<float>::Max();
+		float Exponent = TNumericLimits<float>::Max();
+		float PullAlpha = 0.0f;
+	};
+	TArray<FStiffnessPullMemo> StiffnessPullMemos;
 	
 	/**
 	 *	 The last simulation space used for the physics simulation.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -8,6 +8,8 @@
 #include "GameplayTagContainer.h"
 #include "BoneControllers/AnimNode_AnimDynamics.h"
 #include "BoneControllers/AnimNode_SkeletalControlBase.h"
+#include "CollisionQueryParams.h"
+#include "Engine/EngineTypes.h"
 #include "Engine/HitResult.h"
 
 #if !UE_VERSION_OLDER_THAN(5, 5, 0)
@@ -31,6 +33,17 @@
 class UKawaiiPhysics_CustomExternalForce;
 class UKawaiiPhysicsLimitsDataAsset;
 class UKawaiiPhysicsBoneConstraintsDataAsset;
+
+// ボーンに依存しない World Collision のクエリ設定。SimulateOnce のボーンループ前に1回だけ作る。
+// Bone-independent query settings for World Collision. Built once before the SimulateOnce bone loop.
+struct KAWAIIPHYSICS_API FKawaiiWorldCollisionQuerySettings
+{
+	FKawaiiWorldCollisionQuerySettings();
+
+	FCollisionQueryParams Params;
+	FCollisionResponseParams ResponseParams;
+	ECollisionChannel TraceChannel = ECC_WorldStatic;
+};
 
 #if ENABLE_ANIM_DEBUG
 extern KAWAIIPHYSICS_API TAutoConsoleVariable<bool> CVarAnimNodeKawaiiPhysicsEnable;
@@ -1222,9 +1235,11 @@ protected:
 	 *
 	 * @param Bone The bone to adjust.
 	 * @param OwningComp The owning skeletal mesh component.
+	 * @param WorldCollisionQuerySettings The per-step world collision query settings.
 	 */
 	void AdjustByWorldCollision(FComponentSpacePoseContext& Output, FKawaiiPhysicsModifyBone& Bone,
-	                            const USkeletalMeshComponent* OwningComp);
+	                            const USkeletalMeshComponent* OwningComp,
+	                            const FKawaiiWorldCollisionQuerySettings& WorldCollisionQuerySettings);
 
 	/**
 	 * Adjusts the bone position based on spherical collision limits.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
@@ -161,6 +161,25 @@ struct FCapsuleLimit : public FCollisionLimitBase
 	UPROPERTY(EditAnywhere, Category = CapsuleLimit, meta = (ClampMin = "0"))
 	float Length = 10.0f;
 
+	/**
+	 * ランタイム専用キャッシュ。非UPROPERTYのためシリアライズされない。
+	 * 既存の自前operator=には意図的に追加しない。キャッシュを代入で運ぶと新フィールド追記漏れが
+	 * 静かな陳腐化になるため、毎ステップUpdateRuntimeCache()で再計算する。
+	 * Runtime-only cache. Not serialized because it is intentionally not a UPROPERTY.
+	 * It is intentionally excluded from the custom operator=. Carrying caches through assignment could silently
+	 * leave stale values when new fields are added, so caches are recomputed every step with UpdateRuntimeCache().
+	 */
+	FVector CachedStartPoint = FVector::ZeroVector;
+	FVector CachedEndPoint = FVector::ZeroVector;
+	FVector CachedFallbackPushDir = FVector::ZeroVector;
+
+	void UpdateRuntimeCache()
+	{
+		CachedStartPoint = Location + Rotation.GetAxisZ() * Length * 0.5f;
+		CachedEndPoint = Location + Rotation.GetAxisZ() * Length * -0.5f;
+		CachedFallbackPushDir = Rotation.GetAxisX();
+	}
+
 	/** Assignment operator */
 	FCapsuleLimit& operator=(const FCapsuleLimit& Other)
 	{
@@ -192,6 +211,25 @@ struct FBoxLimit : public FCollisionLimitBase
 	UPROPERTY(EditAnywhere, Category = BoxLimit)
 	FVector Extent = FVector(5.0f, 5.0f, 5.0f);
 
+	/**
+	 * ランタイム専用キャッシュ。非UPROPERTYのためシリアライズされない。
+	 * 既存の自前operator=には意図的に追加しない。キャッシュを代入で運ぶと新フィールド追記漏れが
+	 * 静かな陳腐化になるため、毎ステップUpdateRuntimeCache()で再計算する。
+	 * Runtime-only cache. Not serialized because it is intentionally not a UPROPERTY.
+	 * It is intentionally excluded from the custom operator=. Carrying caches through assignment could silently
+	 * leave stale values when new fields are added, so caches are recomputed every step with UpdateRuntimeCache().
+	 */
+	FTransform CachedBoxTransform = FTransform::Identity;
+	// FBox のデフォルト構築は Min/Max を初期化しないため ForceInit で明示的にゼロ化する。
+	// FBox's default constructor leaves Min/Max uninitialized, so zero them explicitly.
+	FBox CachedLocalBox = FBox(ForceInit);
+
+	void UpdateRuntimeCache()
+	{
+		CachedBoxTransform = FTransform(Rotation, Location);
+		CachedLocalBox = FBox(-Extent, Extent);
+	}
+
 	/** Assignment operator */
 	FBoxLimit& operator=(const FBoxLimit& Other)
 	{
@@ -221,6 +259,21 @@ struct FPlanarLimit : public FCollisionLimitBase
 	/** The plane defining the planar limit */
 	UPROPERTY()
 	FPlane Plane = FPlane(0, 0, 0, 0);
+
+	/**
+	 * ランタイム専用キャッシュ。非UPROPERTYのためシリアライズされない。
+	 * 既存の自前operator=には意図的に追加しない。キャッシュを代入で運ぶと新フィールド追記漏れが
+	 * 静かな陳腐化になるため、毎ステップUpdateRuntimeCache()で再計算する。
+	 * Runtime-only cache. Not serialized because it is intentionally not a UPROPERTY.
+	 * It is intentionally excluded from the custom operator=. Carrying caches through assignment could silently
+	 * leave stale values when new fields are added, so caches are recomputed every step with UpdateRuntimeCache().
+	 */
+	FVector CachedNormal = FVector::ZeroVector;
+
+	void UpdateRuntimeCache()
+	{
+		CachedNormal = Rotation.GetUpVector();
+	}
 
 	/** Assignment operator */
 	FPlanarLimit& operator=(const FPlanarLimit& Other)


### PR DESCRIPTION
## 概要

AnimNode のホットループ（Simulation / Collision）に対する実効性能の最適化。本命は Step3' カーブ空高速パス（`5b647e3`）と Step4' コリジョン形状キャッシュのフレーム単位化（`5c03fc5`）。ゴールデンテスト（PR1）でツリー等価を担保しつつ実施。

## 含まれるコミット

- `18f6997` / `8bc7d04` [perf]/[refactor] Stiffness pull メモ化 → 効果ゼロにつき revert（**相殺ペア**、正味の挙動変化なし）
- `9dcaed2` [perf] コリジョン形状の派生値をステップ単位で1回計算
- `0e34395` [refactor] XPBD compliance dt 正規化をループ外へ
- `cc7b731` [perf] 毎フレームのヒープ確保2箇所を除去
- `5b647e3` [perf] ★ カーブ評価をループ外へホイスト＋全カーブ空の高速パス
- `30b750d` [perf] WorldCollision クエリ設定をボーンループ外で1回構築
- `c4dfb32` [perf] 外力の BoneTM をボーン単位で1回解決
- `527c6c4` [perf] ★ コリジョン形状キャッシュをフレーム単位で更新

※ SHA は cherry-pick により元ブランチから採番し直されています（メッセージ・著者は原文保持）。

## スタック構成

本PRは **#207（tests）にスタック**しています。マージ順は **#207 → 本PR → refactor**。#207 をマージすると本PRの base は自動で master に付け替わります。

## テスト

ヘッドレス自動テスト green（元 `perf/hotpath-optimization` と同一ツリー、UE5.8 ビルド + 25 テスト green を確認済み）。
