### PR TITLE
[refactor] TMap ルックアップ / Transient 化

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -764,24 +764,26 @@ void FAnimNode_KawaiiPhysics::InitBoneConstraints()
 	MergedBoneConstraints = BoneConstraints;
 	MergedBoneConstraints.Append(BoneConstraintsData);
 
+	TMap<FName, int32> BoneNameToModifyIndex;
+	BoneNameToModifyIndex.Reserve(ModifyBones.Num());
+	for (int32 i = 0; i < ModifyBones.Num(); ++i)
+	{
+		// IndexOfByPredicate と同じく、重複 BoneName は最初に見つかった index を使う
+		BoneNameToModifyIndex.FindOrAdd(ModifyBones[i].BoneRef.BoneName, i);
+	}
+
 	TArray<FModifyBoneConstraint> DummyBoneConstraint;
 	for (FModifyBoneConstraint& Constraint : MergedBoneConstraints)
 	{
-		Constraint.ModifyBoneIndex1 =
-			ModifyBones.IndexOfByPredicate([Constraint](const FKawaiiPhysicsModifyBone& ModifyBone)
-			{
-				return ModifyBone.BoneRef == Constraint.Bone1;
-			});
+		const int32* FoundModifyBoneIndex1 = BoneNameToModifyIndex.Find(Constraint.Bone1.BoneName);
+		Constraint.ModifyBoneIndex1 = FoundModifyBoneIndex1 ? *FoundModifyBoneIndex1 : INDEX_NONE;
 		if (Constraint.ModifyBoneIndex1 < 0)
 		{
 			continue;
 		}
 
-		Constraint.ModifyBoneIndex2 =
-			ModifyBones.IndexOfByPredicate([Constraint](const FKawaiiPhysicsModifyBone& ModifyBone)
-			{
-				return ModifyBone.BoneRef == Constraint.Bone2;
-			});
+		const int32* FoundModifyBoneIndex2 = BoneNameToModifyIndex.Find(Constraint.Bone2.BoneName);
+		Constraint.ModifyBoneIndex2 = FoundModifyBoneIndex2 ? *FoundModifyBoneIndex2 : INDEX_NONE;
 		if (Constraint.ModifyBoneIndex2 < 0)
 		{
 			continue;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce.h
@@ -107,16 +107,23 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce
 #endif
 
 protected:
-	/** Randomized scale of the force */
-	UPROPERTY()
+	/**
+	 * 実行時状態。RandomizedForceScale と ComponentTransform は基底 PreApply、Force は各サブクラス PreApply で毎フレーム必ず上書きされる。
+	 * 保存された値は次の PreApply で破棄され、ユーザー編集用の乱数範囲は RandomForceScaleRange に保存する。
+	 * 副作用は初回評価前のエディタデバッグ描画が保存値ではなくゼロから始まることのみ。
+	 * Runtime state. Base PreApply always overwrites RandomizedForceScale and ComponentTransform, and subclass PreApply overwrites Force every frame.
+	 * Saved values are discarded by the next PreApply, while the user-editable random range is stored in RandomForceScaleRange.
+	 * The only side effect is that editor debug drawing before the first evaluation starts from zero instead of saved values.
+	 */
+	UPROPERTY(Transient)
 	float RandomizedForceScale = 0.0f;
 
 	/** The force vector */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	FVector Force = FVector::Zero();
 
 	/** Transform of the component */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	FTransform ComponentTransform;
 
 	/** Whether the force space can be selected */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsBoneConstraintTypes.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsBoneConstraintTypes.h
@@ -53,24 +53,31 @@ struct FModifyBoneConstraint
 	UPROPERTY(EditAnywhere, category = "KawaiiPhysics")
 	bool bExcludeFromSubdivision = false;
 
-	/** Index of the first modify bone */
-	UPROPERTY()
+	/**
+	 * 実行時状態。InitBoneConstraints は MergedBoneConstraints 上で ModifyBoneIndex1/2 と Length を毎回再計算し、bIsDummy は動的生成の dummy constraint にのみ設定する。
+	 * Lambda は SimulateOnce で毎ステップ 0 にリセットされる。
+	 * これらは全て実行時に再構築される MergedBoneConstraints 経由で読まれ、保存された BoneConstraints 配列の値を読む経路はない。
+	 * Runtime state. InitBoneConstraints recalculates ModifyBoneIndex1/2 and Length on MergedBoneConstraints each time, and bIsDummy is set only for dynamically generated dummy constraints.
+	 * Lambda is reset to 0 on every SimulateOnce step.
+	 * These values are read only through runtime-rebuilt MergedBoneConstraints, with no path that reads saved values from the BoneConstraints array.
+	 */
+	UPROPERTY(Transient)
 	int32 ModifyBoneIndex1 = -1;
 
 	/** Index of the second modify bone */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	int32 ModifyBoneIndex2 = -1;
 
 	/** Length of the constraint */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	float Length = -1.0f;
 
 	/** Flag indicating if this is a dummy constraint */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	bool bIsDummy = false;
 
 	/** Lambda value for the constraint */
-	UPROPERTY()
+	UPROPERTY(Transient)
 	float Lambda = 0.0f;
 
 	/** Equality operator to compare two constraints */


### PR DESCRIPTION
## 概要

性能に直接効かない構造的なリファクタリング2件。

## 含まれるコミット

- `e771906` [refactor] InitBoneConstraints のボーン探索を TMap 経由に変更
- `3ff0d5c` [refactor] ランタイム再計算される状態を Transient 化し、アセットに保存しない

※ SHA は cherry-pick により採番し直し（メッセージ・著者は原文保持）。

## スタック構成

本PRは **#208（perf）にスタック**しています。マージ順は **#207 → #208 → 本PR**。先行PRのマージに伴い、本PRの base は自動で付け替わります。この3本をすべてマージすると、元 `perf/hotpath-optimization` と完全に等価なツリーになります。

## テスト

元 `perf/hotpath-optimization` と同一ツリー（UE5.8 ビルド + 25 テスト green を確認済み）。
