### PR TITLE
Add Procedural Wind external force with Wind Scope preview window and wind preset DataAsset 

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
@@ -1,0 +1,40 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h"
+
+#include "KawaiiPhysicsLibrary.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(AnimNotify_KawaiiPhysicsTriggerGust)
+
+#define LOCTEXT_NAMESPACE "KawaiiPhysics_AnimNotify"
+
+UAnimNotify_KawaiiPhysicsTriggerGust::UAnimNotify_KawaiiPhysicsTriggerGust(
+	const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+#if WITH_EDITORONLY_DATA
+	NotifyColor = FColor(120, 210, 255, 255);
+#endif
+}
+
+FString UAnimNotify_KawaiiPhysicsTriggerGust::GetNotifyName_Implementation() const
+{
+	return FString(TEXT("KP: Trigger Gust"));
+}
+
+void UAnimNotify_KawaiiPhysicsTriggerGust::Notify(USkeletalMeshComponent* MeshComp,
+                                                  UAnimSequenceBase* Animation,
+                                                  const FAnimNotifyEventReference& EventReference)
+{
+	if (!MeshComp)
+	{
+		return;
+	}
+
+	UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(MeshComp, Strength, RiseTime, DecayTime,
+	                                                            FilterTags, bFilterExactMatch);
+
+	Super::Notify(MeshComp, Animation, EventReference);
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
@@ -31,6 +31,7 @@ void UAnimNotify_KawaiiPhysicsTriggerGust::Notify(USkeletalMeshComponent* MeshCo
 		return;
 	}
 
+	// タグでフィルタしつつ、Component内の対象ノードのProceduralWindへ突風をキューイングする
 	UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(MeshComp, Strength, RiseTime, DecayTime,
 	                                                            FilterTags, bFilterExactMatch);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce.cpp
@@ -68,6 +68,7 @@ FVector FKawaiiPhysics_ExternalForce::ConvertExternalForceToSimulationSpace(FAni
                                                                             FComponentSpacePoseContext& PoseContext,
                                                                             const FVector& InForce) const
 {
+	// ExternalForceSpaceに対応する変換元のSimulationSpaceを決定
 	EKawaiiPhysicsSimulationSpace From = EKawaiiPhysicsSimulationSpace::ComponentSpace;
 	if (ExternalForceSpace == EExternalForceSpace::WorldSpace)
 	{
@@ -78,6 +79,7 @@ FVector FKawaiiPhysics_ExternalForce::ConvertExternalForceToSimulationSpace(FAni
 		From = EKawaiiPhysicsSimulationSpace::BaseBoneSpace;
 	}
 
+	// 変換元からNode.SimulationSpaceへ変換して返す
 	return Node.ConvertSimulationSpaceVector(PoseContext, From,
 	                                         Node.SimulationSpace, InForce);
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce.cpp
@@ -64,6 +64,24 @@ bool FKawaiiPhysics_ExternalForce::IsDebugEnabled(bool bInPersona)
 	return false;
 }
 
+FVector FKawaiiPhysics_ExternalForce::ConvertExternalForceToSimulationSpace(FAnimNode_KawaiiPhysics& Node,
+                                                                            FComponentSpacePoseContext& PoseContext,
+                                                                            const FVector& InForce) const
+{
+	EKawaiiPhysicsSimulationSpace From = EKawaiiPhysicsSimulationSpace::ComponentSpace;
+	if (ExternalForceSpace == EExternalForceSpace::WorldSpace)
+	{
+		From = EKawaiiPhysicsSimulationSpace::WorldSpace;
+	}
+	else if (ExternalForceSpace == EExternalForceSpace::BoneSpace)
+	{
+		From = EKawaiiPhysicsSimulationSpace::BaseBoneSpace;
+	}
+
+	return Node.ConvertSimulationSpaceVector(PoseContext, From,
+	                                         Node.SimulationSpace, InForce);
+}
+
 #if ENABLE_ANIM_DEBUG
 void FKawaiiPhysics_ExternalForce::AnimDrawDebug(FKawaiiPhysicsModifyBone& Bone, FAnimNode_KawaiiPhysics& Node,
                                                  const FComponentSpacePoseContext& PoseContext)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Basic.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Basic.cpp
@@ -32,19 +32,7 @@ void FKawaiiPhysics_ExternalForce_Basic::PreApply(FAnimNode_KawaiiPhysics& Node,
 		Force = ForceDir * RandomizedForceScale;
 	}
 
-	// TODO : Merge EExternalForceSpace and EKawaiiPhysicsSimulationSpace
-	EKawaiiPhysicsSimulationSpace From = EKawaiiPhysicsSimulationSpace::ComponentSpace;
-	if (ExternalForceSpace == EExternalForceSpace::WorldSpace)
-	{
-		From = EKawaiiPhysicsSimulationSpace::WorldSpace;
-	}
-	else if (ExternalForceSpace == EExternalForceSpace::BoneSpace)
-	{
-		From = EKawaiiPhysicsSimulationSpace::BaseBoneSpace;
-	}
-
-	Force = Node.ConvertSimulationSpaceVector(PoseContext, From,
-	                                          Node.SimulationSpace, Force);
+	Force = ConvertExternalForceToSimulationSpace(Node, PoseContext, Force);
 }
 
 void FKawaiiPhysics_ExternalForce_Basic::Apply(FKawaiiPhysicsModifyBone& Bone, FAnimNode_KawaiiPhysics& Node,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Curve.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_Curve.cpp
@@ -100,19 +100,7 @@ void FKawaiiPhysics_ExternalForce_Curve::PreApply(FAnimNode_KawaiiPhysics& Node,
 		Force *= RandomizedForceScale;
 	}
 
-	// TODO : Merge EExternalForceSpace and EKawaiiPhysicsSimulationSpace
-	EKawaiiPhysicsSimulationSpace From = EKawaiiPhysicsSimulationSpace::ComponentSpace;
-	if (ExternalForceSpace == EExternalForceSpace::WorldSpace)
-	{
-		From = EKawaiiPhysicsSimulationSpace::WorldSpace;
-	}
-	else if (ExternalForceSpace == EExternalForceSpace::BoneSpace)
-	{
-		From = EKawaiiPhysicsSimulationSpace::BaseBoneSpace;
-	}
-
-	Force = Node.ConvertSimulationSpaceVector(PoseContext, From,
-	                                          Node.SimulationSpace, Force);
+	Force = ConvertExternalForceToSimulationSpace(Node, PoseContext, Force);
 }
 
 void FKawaiiPhysics_ExternalForce_Curve::Apply(FKawaiiPhysicsModifyBone& Bone, FAnimNode_KawaiiPhysics& Node,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -108,6 +108,105 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
 #endif
 }
 
+void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
+	const FKawaiiProceduralWindDynamicParams& Params)
+{
+	if (Params.bOverrideWindDirection)
+	{
+		WindDirection = Params.WindDirection;
+	}
+	if (Params.bOverrideSteadyForce)
+	{
+		SteadyForce = FMath::Max(Params.SteadyForce, 0.0f);
+	}
+	if (Params.bOverrideOscillationForce)
+	{
+		OscillationForce = FMath::Max(Params.OscillationForce, 0.0f);
+	}
+	if (Params.bOverrideOscillationPeriod)
+	{
+		OscillationPeriod = FMath::Max(Params.OscillationPeriod, 0.01f);
+	}
+	if (Params.bOverrideWaveAmplitude)
+	{
+		WaveAmplitude = FMath::Max(Params.WaveAmplitude, 0.0f);
+	}
+	if (Params.bOverrideWavePeriod)
+	{
+		WavePeriod = FMath::Max(Params.WavePeriod, 0.01f);
+	}
+	if (Params.bOverrideWavePhase)
+	{
+		WavePhase = Params.WavePhase;
+	}
+	if (Params.bOverrideWaveSpatialOffset)
+	{
+		WaveSpatialOffset = Params.WaveSpatialOffset;
+	}
+	if (Params.bOverrideEnvelopeMax)
+	{
+		EnvelopeMax = FMath::Max(Params.EnvelopeMax, 0.0f);
+	}
+	if (Params.bOverrideEnvelopeMin)
+	{
+		EnvelopeMin = FMath::Max(Params.EnvelopeMin, 0.0f);
+	}
+	if (Params.bOverrideEnvelopeFrequency)
+	{
+		EnvelopeFrequency = FMath::Max(Params.EnvelopeFrequency, 0.0f);
+	}
+	if (Params.bOverrideEnvelopePhase)
+	{
+		EnvelopePhase = Params.EnvelopePhase;
+	}
+	if (Params.bOverrideRandomForce)
+	{
+		RandomForce = FMath::Max(Params.RandomForce, 0.0f);
+	}
+	if (Params.bOverrideRandomPeriod)
+	{
+		RandomPeriod = FMath::Max(Params.RandomPeriod, 0.01f);
+	}
+	if (Params.bOverrideDirectionNoiseAngle)
+	{
+		DirectionNoiseAngle = FMath::Max(Params.DirectionNoiseAngle, 0.0f);
+	}
+	if (Params.bOverrideDirectionNoisePeriod)
+	{
+		DirectionNoisePeriod = FMath::Max(Params.DirectionNoisePeriod, 0.01f);
+	}
+	if (Params.bOverrideTimeScale)
+	{
+		TimeScale = FMath::Max(Params.TimeScale, 0.0f);
+	}
+}
+
+void FKawaiiPhysics_ExternalForce_ProceduralWind::ConsumePendingRequests()
+{
+	if (!RuntimeState.IsValid())
+	{
+		ResetRuntimeState();
+	}
+
+	FScopeLock Lock(&RuntimeState->Mutex);
+	if (RuntimeState->PendingParams.IsSet())
+	{
+		ApplyDynamicParams(RuntimeState->PendingParams.GetValue());
+		RuntimeState->PendingParams.Reset();
+	}
+
+	if (RuntimeState->PendingGust.IsSet())
+	{
+		const FKawaiiProceduralWindGustRequest& PendingGust = RuntimeState->PendingGust.GetValue();
+		RuntimeState->ActiveGust.StartTime = RuntimeState->Time;
+		RuntimeState->ActiveGust.Strength = PendingGust.Strength;
+		RuntimeState->ActiveGust.RiseTime = PendingGust.RiseTime;
+		RuntimeState->ActiveGust.DecayTime = PendingGust.DecayTime;
+		RuntimeState->ActiveGust.bIsActive = true;
+		RuntimeState->PendingGust.Reset();
+	}
+}
+
 FKawaiiPhysicsProceduralWindSample FKawaiiPhysics_ExternalForce_ProceduralWind::ComputeWindSample(
 	const float InTime, const float InLengthRate) const
 {
@@ -190,19 +289,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::PreApply(FAnimNode_KawaiiPhysi
 		ResetRuntimeState();
 	}
 
-	{
-		FScopeLock Lock(&RuntimeState->Mutex);
-		if (RuntimeState->PendingGust.IsSet())
-		{
-			const FKawaiiProceduralWindGustRequest& PendingGust = RuntimeState->PendingGust.GetValue();
-			RuntimeState->ActiveGust.StartTime = RuntimeState->Time;
-			RuntimeState->ActiveGust.Strength = PendingGust.Strength;
-			RuntimeState->ActiveGust.RiseTime = PendingGust.RiseTime;
-			RuntimeState->ActiveGust.DecayTime = PendingGust.DecayTime;
-			RuntimeState->ActiveGust.bIsActive = true;
-			RuntimeState->PendingGust.Reset();
-		}
-	}
+	ConsumePendingRequests();
 
 	RuntimeState->Time += Node.GetStepDeltaTime() * TimeScale;
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -12,6 +12,8 @@ DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_ExternalForce_ProceduralWind_Apply"),
 namespace
 {
 constexpr float TwoPi = UE_PI * 2.0f;
+
+// WindScope プレビュー用のリングバッファサイズ。SKawaiiPhysicsWindScopeWindow の描画解像度と対応する
 constexpr int32 ScopeBufferSize = 512;
 
 // 正規化に失敗した場合は前方ベクトルへフォールバックする（GetSafeNormal の2引数版は UE バージョン間で挙動差があるため不使用）
@@ -21,6 +23,8 @@ FVector SafeDirectionOrForward(const FVector& InVector)
 	return Normalized.IsNearlyZero() ? FVector::ForwardVector : Normalized;
 }
 
+// アクティブな gust envelope を経過時間から評価する（0 → Strength → 0 の線形 rise/decay）。
+// Strength/RiseTime/DecayTime は TriggerProceduralWindGust API 経由で ActiveGust にセットされる
 float EvaluateActiveGust(const FKawaiiProceduralWindActiveGust& ActiveGust, const float InTime)
 {
 	if (!ActiveGust.bIsActive)
@@ -36,16 +40,19 @@ float EvaluateActiveGust(const FKawaiiProceduralWindActiveGust& ActiveGust, cons
 
 	const float RiseTime = FMath::Max(ActiveGust.RiseTime, 0.0f);
 	const float DecayTime = FMath::Max(ActiveGust.DecayTime, 0.0f);
+	// rise フェーズ: 0 から Strength へ線形に立ち上がる
 	if (RiseTime > KINDA_SMALL_NUMBER && ElapsedTime < RiseTime)
 	{
 		return ActiveGust.Strength * (ElapsedTime / RiseTime);
 	}
 
+	// DecayTime が実質ゼロならここで即終了（ゼロ除算防止）
 	if (DecayTime <= KINDA_SMALL_NUMBER)
 	{
 		return 0.0f;
 	}
 
+	// decay フェーズ: Strength から 0 へ線形に収束
 	const float DecayElapsedTime = ElapsedTime - RiseTime;
 	if (DecayElapsedTime < DecayTime)
 	{
@@ -55,15 +62,18 @@ float EvaluateActiveGust(const FKawaiiProceduralWindActiveGust& ActiveGust, cons
 	return 0.0f;
 }
 
+// 基準方向 InDirection を軸とする円錐内で、(NoiseX, NoiseY) の向きへ ConeHalfAngleDegrees を上限にぶれさせる
 FVector ApplyConeNoiseToDirection(const FVector& InDirection, const float NoiseX, const float NoiseY,
                                   const float ConeHalfAngleDegrees)
 {
+	// 半角がほぼ0なら揺らぎ無効。基準方向をそのまま返す
 	const float ConeHalfAngleRadians = FMath::DegreesToRadians(FMath::Max(ConeHalfAngleDegrees, 0.0f));
 	if (ConeHalfAngleRadians <= KINDA_SMALL_NUMBER)
 	{
 		return SafeDirectionOrForward(InDirection);
 	}
 
+	// (NoiseX, NoiseY) を単位円板上のオフセットとみなす
 	FVector UnitDisk = FVector(NoiseX, NoiseY, 0.0f);
 	const float DiskLength = UnitDisk.Size2D();
 	if (DiskLength <= KINDA_SMALL_NUMBER)
@@ -71,43 +81,53 @@ FVector ApplyConeNoiseToDirection(const FVector& InDirection, const float NoiseX
 		return SafeDirectionOrForward(InDirection);
 	}
 
+	// 単位円の外に出た場合は円周上へクランプ
 	if (DiskLength > 1.0f)
 	{
 		UnitDisk /= DiskLength;
 	}
 
+	// 基準方向に直交する2軸を求め、その平面内でオフセット方向を構成する
 	const FVector BaseDirection = SafeDirectionOrForward(InDirection);
 	FVector AxisX;
 	FVector AxisY;
 	BaseDirection.FindBestAxisVectors(AxisX, AxisY);
 
+	// 円錐の半角とディスク上のオフセット長から、基準方向を軸とした円錐内のベクトルを合成する
 	const FVector OffsetDirection = (AxisX * UnitDisk.X + AxisY * UnitDisk.Y).GetSafeNormal();
 	const float NoiseAngle = ConeHalfAngleRadians * FMath::Min(DiskLength, 1.0f);
 	return (BaseDirection * FMath::Cos(NoiseAngle) + OffsetDirection * FMath::Sin(NoiseAngle)).GetSafeNormal();
 }
 
+// EditMode のデバッグ矢印の長さを Total の相対的な大きさで正規化する（0〜1目安の比率を返す）
 float ComputeDebugTotalRate(const FKawaiiPhysics_ExternalForce_ProceduralWind& Force, const float Total)
 {
+	// パラメータ設定から起こりうる最大振幅を基準値として概算する
 	const float MaxSine = FMath::Abs(Force.SteadyForce) + FMath::Abs(Force.OscillationForce) +
 		FMath::Abs(Force.WaveAmplitude);
 	const float MaxEnvelope = FMath::Max(FMath::Abs(Force.EnvelopeMin), FMath::Abs(Force.EnvelopeMax));
 	const float MaxRandom = FMath::Abs(Force.RandomForce);
+	// 基準値が0にならないよう下限1.0を保証（ゼロ除算防止）
 	const float Reference = FMath::Max(MaxSine * MaxEnvelope + MaxRandom, 1.0f);
 	return FMath::Abs(Total) / Reference;
 }
 }
 
+// RuntimeState を新規に作り直す。Initialize時、または未初期化のままアクセスされた際の遅延生成に使う
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
 {
 	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
 
 #if WITH_EDITOR
+	// WindScope プレビュー用のリングバッファを確保
 	RuntimeState->ScopeBuffer.SetNum(FMath::Max(ScopeBufferSize, 1));
 	RuntimeState->ScopeWriteIndex = 0;
 	RuntimeState->ScopeSampleCount = 0;
 #endif
 }
 
+// ランタイムAPI（BP/C++）経由で送られた上書きパラメータを反映する。bOverride が立っている項目のみ適用し、
+// 各値は下限（周期系は0.01などゼロ除算回避のためのクランプ）を通す
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 	const FKawaiiProceduralWindDynamicParams& Params)
 {
@@ -181,6 +201,8 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 	}
 }
 
+// 他スレッド（Game Thread の BP API など）から積まれた Pending 要求を Worker 側の PreApply で取り込む。
+// Mutex で RuntimeState を保護し、書き込み側（Set*/TriggerGust API）とのスレッドセーフ性を確保する
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ConsumePendingRequests()
 {
 	if (!RuntimeState.IsValid())
@@ -189,12 +211,14 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ConsumePendingRequests()
 	}
 
 	FScopeLock Lock(&RuntimeState->Mutex);
+	// パラメータ上書き要求を適用
 	if (RuntimeState->PendingParams.IsSet())
 	{
 		ApplyDynamicParams(RuntimeState->PendingParams.GetValue());
 		RuntimeState->PendingParams.Reset();
 	}
 
+	// gust 要求を ActiveGust として起動する（StartTime は現在のシミュレーション内時間を基準にする）
 	if (RuntimeState->PendingGust.IsSet())
 	{
 		const FKawaiiProceduralWindGustRequest& PendingGust = RuntimeState->PendingGust.GetValue();
@@ -207,36 +231,52 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ConsumePendingRequests()
 	}
 }
 
+// 時刻 InTime とボーンの長さ率 InLengthRate から風力の各成分を計算する。
+// PreApply（フレーム単位のキャッシュ生成）と SKawaiiPhysicsWindScopeWindow（理論波形プレビュー）の
+// 両方から呼ばれる共有関数のため、ここでの合成式を変更する場合は両者の見た目が一致することを確認する
 FKawaiiPhysicsProceduralWindSample FKawaiiPhysics_ExternalForce_ProceduralWind::ComputeWindSample(
 	const float InTime, const float InLengthRate) const
 {
 	FKawaiiPhysicsProceduralWindSample Sample;
 
+	// 周期パラメータのゼロ除算防止クランプ
 	const float SafeOscillationPeriod = FMath::Max(OscillationPeriod, 0.01f);
 	const float SafeWavePeriod = FMath::Max(WavePeriod, 0.01f);
 	const float SafeRandomPeriod = FMath::Max(RandomPeriod, 0.01f);
 
+	// 定常成分
 	Sample.Steady = SteadyForce;
+	// 周期振動成分
 	Sample.Oscillation = OscillationForce * FMath::Sin(TwoPi * InTime / SafeOscillationPeriod);
+	// ボーン列に沿って伝わる空間波。InLengthRate（毛先方向の距離率）ぶんだけ位相をずらし、根元から毛先へ
+	// 波が伝播しているように見せる
 	Sample.Wave = WaveAmplitude * FMath::Sin(TwoPi * InTime / SafeWavePeriod -
 		FMath::DegreesToRadians(InLengthRate * WaveSpatialOffset) + FMath::DegreesToRadians(WavePhase));
+	// 低周波の強弱うねり（envelope）。sin を [0,1] に正規化してから EnvelopeMin-Max 間を補間する
 	Sample.Envelope = FMath::Lerp(EnvelopeMin, EnvelopeMax,
 		0.5f * (1.0f + FMath::Sin(TwoPi * EnvelopeFrequency * InTime + FMath::DegreesToRadians(EnvelopePhase))));
+	// seeded smooth noise によるランダム成分。同一 RandomSeed なら実行のたびに同じ揺らぎを再現する
 	Sample.Random = RandomForce * SampleSmoothNoise(InTime / SafeRandomPeriod, RandomSeed, 0);
 
+	// アクティブな gust があれば加算
 	if (RuntimeState.IsValid())
 	{
 		Sample.Gust = EvaluateActiveGust(RuntimeState->ActiveGust, InTime);
 	}
 
+	// 最終合成: (定常 + 振動 + 波) × envelope + random + gust
 	Sample.Total = (Sample.Steady + Sample.Oscillation + Sample.Wave) * Sample.Envelope +
 		Sample.Random + Sample.Gust;
 	return Sample;
 }
 
+// (Seed, GridIndex, Channel) から決定論的なハッシュ値を作る（FNV-1aベースのミックス + fmix32相当の追加撹拌）。
+// RandomStream の内部状態を跨いで持ち回さず、都度この値から種を作ることで実行順序やスレッドに依存しない
+// 再現性を持たせている
 uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed, const int32 GridIndex,
                                                                const int32 Channel)
 {
+	// FNV-1a
 	uint32 Hash = 0x811C9DC5u;
 	Hash ^= static_cast<uint32>(Seed);
 	Hash *= 0x01000193u;
@@ -245,6 +285,7 @@ uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed,
 	Hash ^= static_cast<uint32>(Channel);
 	Hash *= 0x01000193u;
 
+	// 追加の bit mixing（アバランシェ効果を高める）
 	Hash ^= Hash >> 16;
 	Hash *= 0x7FEB352Du;
 	Hash ^= Hash >> 15;
@@ -253,6 +294,8 @@ uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed,
 	return Hash;
 }
 
+// グリッド点 GridIndex における疑似ランダム値 [-1, 1] を返す。StableHash を種にすることで、
+// 呼び出し順序に関係なく同じ GridIndex なら常に同じ値になる
 float FKawaiiPhysics_ExternalForce_ProceduralWind::NoiseValueAt(const int32 GridIndex, const int32 Seed,
                                                                 const int32 Channel)
 {
@@ -260,14 +303,18 @@ float FKawaiiPhysics_ExternalForce_ProceduralWind::NoiseValueAt(const int32 Grid
 	return RandomStream.FRandRange(-1.0f, 1.0f);
 }
 
+// 1次元の smooth value noise。整数グリッド点のランダム値をスムーズステップで補間して滑らかな連続波形にする
 float FKawaiiPhysics_ExternalForce_ProceduralWind::SampleSmoothNoise(const float U, const int32 Seed,
                                                                      const int32 Channel)
 {
+	// U の整数部をグリッドインデックス、小数部を補間係数にする
 	const float GridFloat = FMath::FloorToFloat(U);
 	const int32 GridIndex = static_cast<int32>(GridFloat);
 	const float Alpha = U - GridFloat;
+	// 3α²-2α³ のスムーズステップ補間（両端で微分が0になり、線形補間のような折れ目が出ない）
 	const float SmoothAlpha = Alpha * Alpha * (3.0f - 2.0f * Alpha);
 
+	// 隣接グリッド点のランダム値を補間して返す
 	return FMath::Lerp(NoiseValueAt(GridIndex, Seed, Channel),
 	                   NoiseValueAt(GridIndex + 1, Seed, Channel), SmoothAlpha);
 }
@@ -276,6 +323,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::Initialize(const FAnimationIni
 {
 	Super::Initialize(Context);
 
+	// ノード初期化時に RuntimeState を新規生成し、前回の再生状態（Time/ActiveGust等）を引き継がない
 	ResetRuntimeState();
 }
 
@@ -284,21 +332,28 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::PreApply(FAnimNode_KawaiiPhysi
 {
 	Super::PreApply(Node, PoseContext);
 
+	// RuntimeState未生成なら遅延生成（Resetや複製直後などInitializeを経ない経路への保険）
 	if (!RuntimeState.IsValid())
 	{
 		ResetRuntimeState();
 	}
 
+	// 他スレッドからのランタイム上書き・gust要求を取り込む
 	ConsumePendingRequests();
 
+	// TimeScale を考慮したシミュレーション内時間を進める
 	RuntimeState->Time += Node.GetStepDeltaTime() * TimeScale;
 
+	// ボーンに依存しない成分（Steady/Oscillation/Envelope/Random/Gust）はここで1回だけ計算してキャッシュする。
+	// Apply は全ボーンで呼ばれるため、毎ボーン再計算しないための最適化（Waveのみボーン依存で Apply 側が再計算する）
 	const FKawaiiPhysicsProceduralWindSample Sample = ComputeWindSample(RuntimeState->Time, 0.0f);
 	RuntimeState->CachedSinesWithoutWave = Sample.Steady + Sample.Oscillation;
 	RuntimeState->CachedEnvelope = Sample.Envelope;
 	RuntimeState->CachedRandom = Sample.Random;
 	RuntimeState->CachedGust = Sample.Gust;
 
+	// 風向きに円錐状の揺らぎを加える（DirectionNoiseAngle>0のときのみ）。X/Y で異なる Channel を使い、
+	// 独立した2軸のノイズ系列にする
 	const FVector BaseWindDirection = SafeDirectionOrForward(WindDirection.Vector());
 	FVector NoisyWindDirection = BaseWindDirection;
 	if (DirectionNoiseAngle > 0.0f)
@@ -309,10 +364,12 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::PreApply(FAnimNode_KawaiiPhysi
 		const float NoiseY = SampleSmoothNoise(DirectionNoiseU, RandomSeed, 2);
 		NoisyWindDirection = ApplyConeNoiseToDirection(BaseWindDirection, NoiseX, NoiseY, DirectionNoiseAngle);
 	}
+	// シミュレーション空間へ変換してフレーム単位でキャッシュ（BoneSpace指定時は Apply 側で更にボーンのTMを掛ける）
 	RuntimeState->CachedWindVector = ConvertExternalForceToSimulationSpace(Node, PoseContext, NoisyWindDirection);
 
 #if WITH_EDITOR
 	{
+		// WindScope の「live」表示用にサンプルをリングバッファへ記録する。Mutex は描画側スレッドとの競合を防ぐため
 		FScopeLock Lock(&RuntimeState->Mutex);
 		if (RuntimeState->ScopeBuffer.Num() != ScopeBufferSize)
 		{
@@ -339,6 +396,8 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::Apply(FKawaiiPhysicsModifyBone
 
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_ExternalForce_ProceduralWind_Apply);
 
+	// Wave はボーンごとの LengthRateFromRoot に依存するためここで個別に計算し、PreApply でキャッシュした
+	// 他成分と合算する。式は ComputeWindSample の Sample.Wave 計算と一致させること
 	const float Wave = WaveAmplitude * FMath::Sin(TwoPi * RuntimeState->Time / FMath::Max(WavePeriod, 0.01f) -
 		FMath::DegreesToRadians(Bone.LengthRateFromRoot * WaveSpatialOffset) + FMath::DegreesToRadians(WavePhase));
 	const float Total = (RuntimeState->CachedSinesWithoutWave + Wave) * RuntimeState->CachedEnvelope +
@@ -351,6 +410,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::Apply(FKawaiiPhysicsModifyBone
 	}
 
 	// RandomizedForceScale は _Wind と同じく Apply 側でスカラーにだけ掛け、方向キャッシュとの二重掛けを避ける。
+	// BoneSpace 指定時はキャッシュ済みの風ベクトルに各ボーンのTMを掛けて向きをボーンローカルへ変換する
 	if (ExternalForceSpace == EExternalForceSpace::BoneSpace)
 	{
 		const FVector BoneForce = BoneTM.TransformVector(RuntimeState->CachedWindVector);
@@ -377,6 +437,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::Apply(FKawaiiPhysicsModifyBone
 }
 
 #if WITH_EDITOR
+// EditMode（Persona）でボーンごとの風向き・強さを矢印で可視化する
 void FKawaiiPhysics_ExternalForce_ProceduralWind::AnimDrawDebugForEditMode(
 	const FKawaiiPhysicsModifyBone& ModifyBone, const FAnimNode_KawaiiPhysics& Node, FPrimitiveDrawInterface* PDI)
 {
@@ -386,6 +447,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::AnimDrawDebugForEditMode(
 		return;
 	}
 
+	// Wave/Total の再計算は Apply と同じ式（ComputeWindSample の Sample.Wave と一致させること）
 	const float Wave = WaveAmplitude * FMath::Sin(TwoPi * RuntimeState->Time / FMath::Max(WavePeriod, 0.01f) -
 		FMath::DegreesToRadians(ModifyBone.LengthRateFromRoot * WaveSpatialOffset) +
 		FMath::DegreesToRadians(WavePhase));
@@ -398,6 +460,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::AnimDrawDebugForEditMode(
 		ForceRate = Curve->Eval(ModifyBone.LengthRateFromRoot);
 	}
 
+	// 風向きの矢印を該当ボーン位置に描画。BaseBoneSpace の場合はコンポーネント空間へ変換してから配置する
 	FVector ArrowLocation = ModifyBone.Location + DebugArrowOffset;
 	FQuat ArrowRotation = RuntimeState->CachedWindVector.GetSafeNormal().ToOrientationQuat();
 	if (Node.SimulationSpace == EKawaiiPhysicsSimulationSpace::BaseBoneSpace)
@@ -407,11 +470,13 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::AnimDrawDebugForEditMode(
 		ArrowRotation = BaseBoneSpace2ComponentSpace.TransformRotation(ArrowRotation);
 	}
 
+	// 矢印長は ForceRate と TotalRate（実際の力の相対的な大きさ）で見た目のスケールを調整する
 	const float TotalRate = ComputeDebugTotalRate(*this, Total);
 	const FTransform ArrowTransform(ArrowRotation, ArrowLocation);
 	DrawDirectionalArrow(PDI, ArrowTransform.ToMatrixNoScale(), FColor::Cyan,
 	                     DebugArrowLength * ForceRate * TotalRate, DebugArrowSize, SDPG_Foreground);
 
+	// ルートボーンにはさらに大きめの矢印を重ねて風全体の向き・強さの目安を分かりやすくする
 	if (ModifyBone.Index == 0)
 	{
 		FVector RootArrowLocation = ModifyBone.Location + DebugArrowOffset * 2.0f;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -1,0 +1,344 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+
+#include "Math/RotationMatrix.h"
+
+#include UE_INLINE_GENERATED_CPP_BY_NAME(KawaiiPhysicsExternalForce_ProceduralWind)
+
+DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_ExternalForce_ProceduralWind_Apply"),
+                   STAT_KawaiiPhysics_ExternalForce_ProceduralWind_Apply, STATGROUP_Anim);
+
+namespace
+{
+constexpr float TwoPi = UE_PI * 2.0f;
+constexpr int32 ScopeBufferSize = 512;
+
+// 正規化に失敗した場合は前方ベクトルへフォールバックする（GetSafeNormal の2引数版は UE バージョン間で挙動差があるため不使用）
+FVector SafeDirectionOrForward(const FVector& InVector)
+{
+	const FVector Normalized = InVector.GetSafeNormal();
+	return Normalized.IsNearlyZero() ? FVector::ForwardVector : Normalized;
+}
+
+float EvaluateActiveGust(const FKawaiiProceduralWindActiveGust& ActiveGust, const float InTime)
+{
+	if (!ActiveGust.bIsActive)
+	{
+		return 0.0f;
+	}
+
+	const float ElapsedTime = InTime - ActiveGust.StartTime;
+	if (ElapsedTime < 0.0f)
+	{
+		return 0.0f;
+	}
+
+	const float RiseTime = FMath::Max(ActiveGust.RiseTime, 0.0f);
+	const float DecayTime = FMath::Max(ActiveGust.DecayTime, 0.0f);
+	if (RiseTime > KINDA_SMALL_NUMBER && ElapsedTime < RiseTime)
+	{
+		return ActiveGust.Strength * (ElapsedTime / RiseTime);
+	}
+
+	if (DecayTime <= KINDA_SMALL_NUMBER)
+	{
+		return 0.0f;
+	}
+
+	const float DecayElapsedTime = ElapsedTime - RiseTime;
+	if (DecayElapsedTime < DecayTime)
+	{
+		return ActiveGust.Strength * (1.0f - DecayElapsedTime / DecayTime);
+	}
+
+	return 0.0f;
+}
+
+FVector ApplyConeNoiseToDirection(const FVector& InDirection, const float NoiseX, const float NoiseY,
+                                  const float ConeHalfAngleDegrees)
+{
+	const float ConeHalfAngleRadians = FMath::DegreesToRadians(FMath::Max(ConeHalfAngleDegrees, 0.0f));
+	if (ConeHalfAngleRadians <= KINDA_SMALL_NUMBER)
+	{
+		return SafeDirectionOrForward(InDirection);
+	}
+
+	FVector UnitDisk = FVector(NoiseX, NoiseY, 0.0f);
+	const float DiskLength = UnitDisk.Size2D();
+	if (DiskLength <= KINDA_SMALL_NUMBER)
+	{
+		return SafeDirectionOrForward(InDirection);
+	}
+
+	if (DiskLength > 1.0f)
+	{
+		UnitDisk /= DiskLength;
+	}
+
+	const FVector BaseDirection = SafeDirectionOrForward(InDirection);
+	FVector AxisX;
+	FVector AxisY;
+	BaseDirection.FindBestAxisVectors(AxisX, AxisY);
+
+	const FVector OffsetDirection = (AxisX * UnitDisk.X + AxisY * UnitDisk.Y).GetSafeNormal();
+	const float NoiseAngle = ConeHalfAngleRadians * FMath::Min(DiskLength, 1.0f);
+	return (BaseDirection * FMath::Cos(NoiseAngle) + OffsetDirection * FMath::Sin(NoiseAngle)).GetSafeNormal();
+}
+
+float ComputeDebugTotalRate(const FKawaiiPhysics_ExternalForce_ProceduralWind& Force, const float Total)
+{
+	const float MaxSine = FMath::Abs(Force.SteadyForce) + FMath::Abs(Force.OscillationForce) +
+		FMath::Abs(Force.WaveAmplitude);
+	const float MaxEnvelope = FMath::Max(FMath::Abs(Force.EnvelopeMin), FMath::Abs(Force.EnvelopeMax));
+	const float MaxRandom = FMath::Abs(Force.RandomForce);
+	const float Reference = FMath::Max(MaxSine * MaxEnvelope + MaxRandom, 1.0f);
+	return FMath::Abs(Total) / Reference;
+}
+}
+
+void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
+{
+	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
+
+#if WITH_EDITOR
+	RuntimeState->ScopeBuffer.SetNum(FMath::Max(ScopeBufferSize, 1));
+	RuntimeState->ScopeWriteIndex = 0;
+	RuntimeState->ScopeSampleCount = 0;
+#endif
+}
+
+FKawaiiPhysicsProceduralWindSample FKawaiiPhysics_ExternalForce_ProceduralWind::ComputeWindSample(
+	const float InTime, const float InLengthRate) const
+{
+	FKawaiiPhysicsProceduralWindSample Sample;
+
+	const float SafeOscillationPeriod = FMath::Max(OscillationPeriod, 0.01f);
+	const float SafeWavePeriod = FMath::Max(WavePeriod, 0.01f);
+	const float SafeRandomPeriod = FMath::Max(RandomPeriod, 0.01f);
+
+	Sample.Steady = SteadyForce;
+	Sample.Oscillation = OscillationForce * FMath::Sin(TwoPi * InTime / SafeOscillationPeriod);
+	Sample.Wave = WaveAmplitude * FMath::Sin(TwoPi * InTime / SafeWavePeriod -
+		FMath::DegreesToRadians(InLengthRate * WaveSpatialOffset) + FMath::DegreesToRadians(WavePhase));
+	Sample.Envelope = FMath::Lerp(EnvelopeMin, EnvelopeMax,
+		0.5f * (1.0f + FMath::Sin(TwoPi * EnvelopeFrequency * InTime + FMath::DegreesToRadians(EnvelopePhase))));
+	Sample.Random = RandomForce * SampleSmoothNoise(InTime / SafeRandomPeriod, RandomSeed, 0);
+
+	if (RuntimeState.IsValid())
+	{
+		Sample.Gust = EvaluateActiveGust(RuntimeState->ActiveGust, InTime);
+	}
+
+	Sample.Total = (Sample.Steady + Sample.Oscillation + Sample.Wave) * Sample.Envelope +
+		Sample.Random + Sample.Gust;
+	return Sample;
+}
+
+uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed, const int32 GridIndex,
+                                                               const int32 Channel)
+{
+	uint32 Hash = 0x811C9DC5u;
+	Hash ^= static_cast<uint32>(Seed);
+	Hash *= 0x01000193u;
+	Hash ^= static_cast<uint32>(GridIndex);
+	Hash *= 0x01000193u;
+	Hash ^= static_cast<uint32>(Channel);
+	Hash *= 0x01000193u;
+
+	Hash ^= Hash >> 16;
+	Hash *= 0x7FEB352Du;
+	Hash ^= Hash >> 15;
+	Hash *= 0x846CA68Bu;
+	Hash ^= Hash >> 16;
+	return Hash;
+}
+
+float FKawaiiPhysics_ExternalForce_ProceduralWind::NoiseValueAt(const int32 GridIndex, const int32 Seed,
+                                                                const int32 Channel)
+{
+	FRandomStream RandomStream(StableHash(Seed, GridIndex, Channel));
+	return RandomStream.FRandRange(-1.0f, 1.0f);
+}
+
+float FKawaiiPhysics_ExternalForce_ProceduralWind::SampleSmoothNoise(const float U, const int32 Seed,
+                                                                     const int32 Channel)
+{
+	const float GridFloat = FMath::FloorToFloat(U);
+	const int32 GridIndex = static_cast<int32>(GridFloat);
+	const float Alpha = U - GridFloat;
+	const float SmoothAlpha = Alpha * Alpha * (3.0f - 2.0f * Alpha);
+
+	return FMath::Lerp(NoiseValueAt(GridIndex, Seed, Channel),
+	                   NoiseValueAt(GridIndex + 1, Seed, Channel), SmoothAlpha);
+}
+
+void FKawaiiPhysics_ExternalForce_ProceduralWind::Initialize(const FAnimationInitializeContext& Context)
+{
+	Super::Initialize(Context);
+
+	ResetRuntimeState();
+}
+
+void FKawaiiPhysics_ExternalForce_ProceduralWind::PreApply(FAnimNode_KawaiiPhysics& Node,
+                                                           FComponentSpacePoseContext& PoseContext)
+{
+	Super::PreApply(Node, PoseContext);
+
+	if (!RuntimeState.IsValid())
+	{
+		ResetRuntimeState();
+	}
+
+	{
+		FScopeLock Lock(&RuntimeState->Mutex);
+		if (RuntimeState->PendingGust.IsSet())
+		{
+			const FKawaiiProceduralWindGustRequest& PendingGust = RuntimeState->PendingGust.GetValue();
+			RuntimeState->ActiveGust.StartTime = RuntimeState->Time;
+			RuntimeState->ActiveGust.Strength = PendingGust.Strength;
+			RuntimeState->ActiveGust.RiseTime = PendingGust.RiseTime;
+			RuntimeState->ActiveGust.DecayTime = PendingGust.DecayTime;
+			RuntimeState->ActiveGust.bIsActive = true;
+			RuntimeState->PendingGust.Reset();
+		}
+	}
+
+	RuntimeState->Time += Node.GetStepDeltaTime() * TimeScale;
+
+	const FKawaiiPhysicsProceduralWindSample Sample = ComputeWindSample(RuntimeState->Time, 0.0f);
+	RuntimeState->CachedSinesWithoutWave = Sample.Steady + Sample.Oscillation;
+	RuntimeState->CachedEnvelope = Sample.Envelope;
+	RuntimeState->CachedRandom = Sample.Random;
+	RuntimeState->CachedGust = Sample.Gust;
+
+	const FVector BaseWindDirection = SafeDirectionOrForward(WindDirection.Vector());
+	FVector NoisyWindDirection = BaseWindDirection;
+	if (DirectionNoiseAngle > 0.0f)
+	{
+		const float SafeDirectionNoisePeriod = FMath::Max(DirectionNoisePeriod, 0.01f);
+		const float DirectionNoiseU = RuntimeState->Time / SafeDirectionNoisePeriod;
+		const float NoiseX = SampleSmoothNoise(DirectionNoiseU, RandomSeed, 1);
+		const float NoiseY = SampleSmoothNoise(DirectionNoiseU, RandomSeed, 2);
+		NoisyWindDirection = ApplyConeNoiseToDirection(BaseWindDirection, NoiseX, NoiseY, DirectionNoiseAngle);
+	}
+	RuntimeState->CachedWindVector = ConvertExternalForceToSimulationSpace(Node, PoseContext, NoisyWindDirection);
+
+#if WITH_EDITOR
+	{
+		FScopeLock Lock(&RuntimeState->Mutex);
+		if (RuntimeState->ScopeBuffer.Num() != ScopeBufferSize)
+		{
+			RuntimeState->ScopeBuffer.SetNum(ScopeBufferSize);
+			RuntimeState->ScopeWriteIndex = 0;
+			RuntimeState->ScopeSampleCount = 0;
+		}
+
+		RuntimeState->ScopeBuffer[RuntimeState->ScopeWriteIndex] = {RuntimeState->Time, Sample};
+		RuntimeState->ScopeWriteIndex = (RuntimeState->ScopeWriteIndex + 1) % ScopeBufferSize;
+		++RuntimeState->ScopeSampleCount;
+	}
+#endif
+}
+
+void FKawaiiPhysics_ExternalForce_ProceduralWind::Apply(FKawaiiPhysicsModifyBone& Bone, FAnimNode_KawaiiPhysics& Node,
+                                                        FComponentSpacePoseContext& PoseContext,
+                                                        const FTransform& BoneTM)
+{
+	if (!CanApply(Bone) || !RuntimeState.IsValid())
+	{
+		return;
+	}
+
+	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_ExternalForce_ProceduralWind_Apply);
+
+	const float Wave = WaveAmplitude * FMath::Sin(TwoPi * RuntimeState->Time / FMath::Max(WavePeriod, 0.01f) -
+		FMath::DegreesToRadians(Bone.LengthRateFromRoot * WaveSpatialOffset) + FMath::DegreesToRadians(WavePhase));
+	const float Total = (RuntimeState->CachedSinesWithoutWave + Wave) * RuntimeState->CachedEnvelope +
+		RuntimeState->CachedRandom + RuntimeState->CachedGust;
+
+	float ForceRate = 1.0f;
+	if (const auto Curve = ForceRateByBoneLengthRate.GetRichCurve(); !Curve->IsEmpty())
+	{
+		ForceRate = Curve->Eval(Bone.LengthRateFromRoot);
+	}
+
+	// RandomizedForceScale は _Wind と同じく Apply 側でスカラーにだけ掛け、方向キャッシュとの二重掛けを避ける。
+	if (ExternalForceSpace == EExternalForceSpace::BoneSpace)
+	{
+		const FVector BoneForce = BoneTM.TransformVector(RuntimeState->CachedWindVector);
+		Bone.Location += BoneForce * Total * ForceRate * RandomizedForceScale * Node.GetStepDeltaTime();
+
+#if ENABLE_ANIM_DEBUG
+		BoneForceMap.Add(Bone.BoneRef.BoneName, BoneForce * Total * ForceRate * RandomizedForceScale);
+#endif
+	}
+	else
+	{
+		Bone.Location += RuntimeState->CachedWindVector * Total * ForceRate * RandomizedForceScale *
+			Node.GetStepDeltaTime();
+
+#if ENABLE_ANIM_DEBUG
+		BoneForceMap.Add(Bone.BoneRef.BoneName,
+		                 RuntimeState->CachedWindVector * Total * ForceRate * RandomizedForceScale);
+#endif
+	}
+
+#if ENABLE_ANIM_DEBUG
+	AnimDrawDebug(Bone, Node, PoseContext);
+#endif
+}
+
+#if WITH_EDITOR
+void FKawaiiPhysics_ExternalForce_ProceduralWind::AnimDrawDebugForEditMode(
+	const FKawaiiPhysicsModifyBone& ModifyBone, const FAnimNode_KawaiiPhysics& Node, FPrimitiveDrawInterface* PDI)
+{
+	if (!IsDebugEnabled(true) || !CanApply(ModifyBone) || !RuntimeState.IsValid() ||
+		RuntimeState->CachedWindVector.IsNearlyZero())
+	{
+		return;
+	}
+
+	const float Wave = WaveAmplitude * FMath::Sin(TwoPi * RuntimeState->Time / FMath::Max(WavePeriod, 0.01f) -
+		FMath::DegreesToRadians(ModifyBone.LengthRateFromRoot * WaveSpatialOffset) +
+		FMath::DegreesToRadians(WavePhase));
+	const float Total = (RuntimeState->CachedSinesWithoutWave + Wave) * RuntimeState->CachedEnvelope +
+		RuntimeState->CachedRandom + RuntimeState->CachedGust;
+
+	float ForceRate = 1.0f;
+	if (const auto Curve = ForceRateByBoneLengthRate.GetRichCurve(); !Curve->IsEmpty())
+	{
+		ForceRate = Curve->Eval(ModifyBone.LengthRateFromRoot);
+	}
+
+	FVector ArrowLocation = ModifyBone.Location + DebugArrowOffset;
+	FQuat ArrowRotation = RuntimeState->CachedWindVector.GetSafeNormal().ToOrientationQuat();
+	if (Node.SimulationSpace == EKawaiiPhysicsSimulationSpace::BaseBoneSpace)
+	{
+		const FTransform& BaseBoneSpace2ComponentSpace = Node.GetBaseBoneSpace2ComponentSpace();
+		ArrowLocation = BaseBoneSpace2ComponentSpace.TransformPosition(ArrowLocation);
+		ArrowRotation = BaseBoneSpace2ComponentSpace.TransformRotation(ArrowRotation);
+	}
+
+	const float TotalRate = ComputeDebugTotalRate(*this, Total);
+	const FTransform ArrowTransform(ArrowRotation, ArrowLocation);
+	DrawDirectionalArrow(PDI, ArrowTransform.ToMatrixNoScale(), FColor::Cyan,
+	                     DebugArrowLength * ForceRate * TotalRate, DebugArrowSize, SDPG_Foreground);
+
+	if (ModifyBone.Index == 0)
+	{
+		FVector RootArrowLocation = ModifyBone.Location + DebugArrowOffset * 2.0f;
+		FQuat RootArrowRotation = RuntimeState->CachedWindVector.GetSafeNormal().ToOrientationQuat();
+		if (Node.SimulationSpace == EKawaiiPhysicsSimulationSpace::BaseBoneSpace)
+		{
+			const FTransform& BaseBoneSpace2ComponentSpace = Node.GetBaseBoneSpace2ComponentSpace();
+			RootArrowLocation = BaseBoneSpace2ComponentSpace.TransformPosition(RootArrowLocation);
+			RootArrowRotation = BaseBoneSpace2ComponentSpace.TransformRotation(RootArrowRotation);
+		}
+
+		const FTransform RootArrowTransform(RootArrowRotation, RootArrowLocation);
+		DrawDirectionalArrow(PDI, RootArrowTransform.ToMatrixNoScale(), FColor::Cyan,
+		                     DebugArrowLength * TotalRate, DebugArrowSize * 2.0f, SDPG_Foreground);
+	}
+}
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -13,6 +13,7 @@
 #include "Components/SkeletalMeshComponent.h"
 #include "Engine/World.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 #include "GameFramework/Actor.h"
 #include "HAL/IConsoleManager.h"
 #include "KawaiiPhysics.h"
@@ -61,6 +62,47 @@ namespace
 	{
 		return PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, ExternalForces) ||
 			PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, CustomExternalForces);
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind* GetMutableProceduralWind(FInstancedStruct& InstancedStruct)
+	{
+		if (!InstancedStruct.IsValid() ||
+			InstancedStruct.GetScriptStruct() != FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
+		{
+			return nullptr;
+		}
+
+		return InstancedStruct.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	}
+
+	bool QueueProceduralWindGust(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
+	                             const float Strength, const float RiseTime, const float DecayTime)
+	{
+		if (!ProceduralWind.RuntimeState.IsValid())
+		{
+			ProceduralWind.ResetRuntimeState();
+		}
+
+		FScopeLock Lock(&ProceduralWind.RuntimeState->Mutex);
+		ProceduralWind.RuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{
+			Strength,
+			RiseTime,
+			DecayTime
+		};
+		return true;
+	}
+
+	bool QueueProceduralWindParams(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
+	                               const FKawaiiProceduralWindDynamicParams& Params)
+	{
+		if (!ProceduralWind.RuntimeState.IsValid())
+		{
+			ProceduralWind.ResetRuntimeState();
+		}
+
+		FScopeLock Lock(&ProceduralWind.RuntimeState->Mutex);
+		ProceduralWind.RuntimeState->PendingParams = Params;
+		return true;
 	}
 
 #if !UE_BUILD_SHIPPING
@@ -568,6 +610,136 @@ bool UKawaiiPhysicsLibrary::RemoveExternalForcesFromComponent(USkeletalMeshCompo
 	}
 
 	return bResult;
+}
+
+FKawaiiPhysicsReference UKawaiiPhysicsLibrary::TriggerProceduralWindGust(
+	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+	const FKawaiiPhysicsReference& KawaiiPhysics,
+	const int32 ExternalForceIndex,
+	const float Strength,
+	const float RiseTime,
+	const float DecayTime)
+{
+	ExecResult = EKawaiiPhysicsAccessExternalForceResult::NotValid;
+
+	KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+		TEXT("TriggerProceduralWindGust"),
+		[&ExecResult, ExternalForceIndex, Strength, RiseTime, DecayTime](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+		{
+			if (!InKawaiiPhysics.ExternalForces.IsValidIndex(ExternalForceIndex))
+			{
+				return;
+			}
+
+			if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+				GetMutableProceduralWind(InKawaiiPhysics.ExternalForces[ExternalForceIndex]))
+			{
+				if (QueueProceduralWindGust(*ProceduralWind, Strength, RiseTime, DecayTime))
+				{
+					ExecResult = EKawaiiPhysicsAccessExternalForceResult::Valid;
+				}
+			}
+		});
+
+	return KawaiiPhysics;
+}
+
+FKawaiiPhysicsReference UKawaiiPhysicsLibrary::SetProceduralWindParameters(
+	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+	const FKawaiiPhysicsReference& KawaiiPhysics,
+	const int32 ExternalForceIndex,
+	const FKawaiiProceduralWindDynamicParams& Params)
+{
+	ExecResult = EKawaiiPhysicsAccessExternalForceResult::NotValid;
+
+	KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+		TEXT("SetProceduralWindParameters"),
+		[&ExecResult, ExternalForceIndex, &Params](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+		{
+			if (!InKawaiiPhysics.ExternalForces.IsValidIndex(ExternalForceIndex))
+			{
+				return;
+			}
+
+			if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+				GetMutableProceduralWind(InKawaiiPhysics.ExternalForces[ExternalForceIndex]))
+			{
+				if (QueueProceduralWindParams(*ProceduralWind, Params))
+				{
+					ExecResult = EKawaiiPhysicsAccessExternalForceResult::Valid;
+				}
+			}
+		});
+
+	return KawaiiPhysics;
+}
+
+int32 UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(
+	USkeletalMeshComponent* MeshComp,
+	const float Strength,
+	const float RiseTime,
+	const float DecayTime,
+	const FGameplayTagContainer& FilterTags,
+	const bool bFilterExactMatch)
+{
+	int32 AppliedForceCount = 0;
+
+	TArray<FKawaiiPhysicsReference> KawaiiPhysicsReferences;
+	CollectKawaiiPhysicsNodes(KawaiiPhysicsReferences, MeshComp, FilterTags, bFilterExactMatch);
+	for (auto& KawaiiPhysicsReference : KawaiiPhysicsReferences)
+	{
+		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+			TEXT("TriggerProceduralWindGustOnComponent"),
+			[&AppliedForceCount, Strength, RiseTime, DecayTime](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+			{
+				for (FInstancedStruct& InstancedStruct : InKawaiiPhysics.ExternalForces)
+				{
+					if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+						GetMutableProceduralWind(InstancedStruct))
+					{
+						if (QueueProceduralWindGust(*ProceduralWind, Strength, RiseTime, DecayTime))
+						{
+							++AppliedForceCount;
+						}
+					}
+				}
+			});
+	}
+
+	return AppliedForceCount;
+}
+
+int32 UKawaiiPhysicsLibrary::SetProceduralWindParametersOnComponent(
+	USkeletalMeshComponent* MeshComp,
+	const FKawaiiProceduralWindDynamicParams& Params,
+	const FGameplayTagContainer& FilterTags,
+	const bool bFilterExactMatch)
+{
+	int32 AppliedForceCount = 0;
+
+	TArray<FKawaiiPhysicsReference> KawaiiPhysicsReferences;
+	CollectKawaiiPhysicsNodes(KawaiiPhysicsReferences, MeshComp, FilterTags, bFilterExactMatch);
+	for (auto& KawaiiPhysicsReference : KawaiiPhysicsReferences)
+	{
+		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+			TEXT("SetProceduralWindParametersOnComponent"),
+			[&AppliedForceCount, &Params](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+			{
+				for (FInstancedStruct& InstancedStruct : InKawaiiPhysics.ExternalForces)
+				{
+					if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+						GetMutableProceduralWind(InstancedStruct))
+					{
+						if (QueueProceduralWindParams(*ProceduralWind, Params))
+						{
+							++AppliedForceCount;
+						}
+					}
+				}
+			});
+	}
+
+	return AppliedForceCount;
 }
 
 bool UKawaiiPhysicsLibrary::SetAlphaToComponent(USkeletalMeshComponent* MeshComp, float Alpha,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -17,6 +17,7 @@
 #include "GameFramework/Actor.h"
 #include "HAL/IConsoleManager.h"
 #include "KawaiiPhysics.h"
+#include "KawaiiPhysicsWindPresetDataAsset.h"
 #include "UObject/UObjectIterator.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(KawaiiPhysicsLibrary)
@@ -732,6 +733,85 @@ int32 UKawaiiPhysicsLibrary::SetProceduralWindParametersOnComponent(
 		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
 			TEXT("SetProceduralWindParametersOnComponent"),
 			[&AppliedForceCount, &Params](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+			{
+				for (FInstancedStruct& InstancedStruct : InKawaiiPhysics.ExternalForces)
+				{
+					if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+						GetMutableProceduralWind(InstancedStruct))
+					{
+						if (QueueProceduralWindParams(*ProceduralWind, Params))
+						{
+							++AppliedForceCount;
+						}
+					}
+				}
+			});
+	}
+
+	return AppliedForceCount;
+}
+
+// DataAssetのプリセットから指定したExternalForceIndexのProceduralWindへ動的パラメータ更新をリクエストする
+FKawaiiPhysicsReference UKawaiiPhysicsLibrary::ApplyProceduralWindPreset(
+	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+	const FKawaiiPhysicsReference& KawaiiPhysics,
+	const int32 ExternalForceIndex,
+	const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset,
+	const FGameplayTag PresetTag)
+{
+	ExecResult = EKawaiiPhysicsAccessExternalForceResult::NotValid;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	if (!UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(PresetDataAsset, PresetTag, Params))
+	{
+		return KawaiiPhysics;
+	}
+
+	KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+		TEXT("ApplyProceduralWindPreset"),
+		[&ExecResult, ExternalForceIndex, Params](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+		{
+			if (!InKawaiiPhysics.ExternalForces.IsValidIndex(ExternalForceIndex))
+			{
+				return;
+			}
+
+			if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
+				GetMutableProceduralWind(InKawaiiPhysics.ExternalForces[ExternalForceIndex]))
+			{
+				if (QueueProceduralWindParams(*ProceduralWind, Params))
+				{
+					ExecResult = EKawaiiPhysicsAccessExternalForceResult::Valid;
+				}
+			}
+		});
+
+	return KawaiiPhysics;
+}
+
+// DataAssetのプリセットからComponent内の対象ノード（Tagフィルタ適用）のProceduralWindへ一括でパラメータ更新をリクエストする
+int32 UKawaiiPhysicsLibrary::ApplyProceduralWindPresetOnComponent(
+	USkeletalMeshComponent* MeshComp,
+	const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset,
+	const FGameplayTag PresetTag,
+	const FGameplayTagContainer& FilterTags,
+	const bool bFilterExactMatch)
+{
+	FKawaiiProceduralWindDynamicParams Params;
+	if (!UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(PresetDataAsset, PresetTag, Params))
+	{
+		return 0;
+	}
+
+	int32 AppliedForceCount = 0;
+
+	TArray<FKawaiiPhysicsReference> KawaiiPhysicsReferences;
+	CollectKawaiiPhysicsNodes(KawaiiPhysicsReferences, MeshComp, FilterTags, bFilterExactMatch);
+	for (auto& KawaiiPhysicsReference : KawaiiPhysicsReferences)
+	{
+		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+			TEXT("ApplyProceduralWindPresetOnComponent"),
+			[&AppliedForceCount, Params](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
 			{
 				for (FInstancedStruct& InstancedStruct : InKawaiiPhysics.ExternalForces)
 				{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -64,6 +64,7 @@ namespace
 			PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, CustomExternalForces);
 	}
 
+	// InstancedStructがProceduralWindであれば可変ポインタを返す（型不一致・無効ならnullptr）
 	FKawaiiPhysics_ExternalForce_ProceduralWind* GetMutableProceduralWind(FInstancedStruct& InstancedStruct)
 	{
 		if (!InstancedStruct.IsValid() ||
@@ -75,9 +76,11 @@ namespace
 		return InstancedStruct.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
 	}
 
+	// 突風リクエストをMutex経由でキューイングする（GameThread側の呼び出しをWorker側のPreApplyへスレッドセーフに橋渡し）
 	bool QueueProceduralWindGust(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
 	                             const float Strength, const float RiseTime, const float DecayTime)
 	{
+		// RuntimeState未初期化（PreApply未実行）でもリクエストを取りこぼさないよう先に生成しておく
 		if (!ProceduralWind.RuntimeState.IsValid())
 		{
 			ProceduralWind.ResetRuntimeState();
@@ -92,6 +95,7 @@ namespace
 		return true;
 	}
 
+	// 動的パラメータ更新も同様にMutex経由でキューイングする
 	bool QueueProceduralWindParams(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
 	                               const FKawaiiProceduralWindDynamicParams& Params)
 	{
@@ -612,6 +616,7 @@ bool UKawaiiPhysicsLibrary::RemoveExternalForcesFromComponent(USkeletalMeshCompo
 	return bResult;
 }
 
+// 指定したExternalForceIndexのProceduralWindへ突風をトリガーする（実体は上記ヘルパーでのキューイング）
 FKawaiiPhysicsReference UKawaiiPhysicsLibrary::TriggerProceduralWindGust(
 	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
 	const FKawaiiPhysicsReference& KawaiiPhysics,
@@ -644,6 +649,7 @@ FKawaiiPhysicsReference UKawaiiPhysicsLibrary::TriggerProceduralWindGust(
 	return KawaiiPhysics;
 }
 
+// 指定したExternalForceIndexのProceduralWindへ動的パラメータ更新をリクエストする
 FKawaiiPhysicsReference UKawaiiPhysicsLibrary::SetProceduralWindParameters(
 	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
 	const FKawaiiPhysicsReference& KawaiiPhysics,
@@ -674,6 +680,7 @@ FKawaiiPhysicsReference UKawaiiPhysicsLibrary::SetProceduralWindParameters(
 	return KawaiiPhysics;
 }
 
+// Component内の対象ノード（Tagフィルタ適用）を走査し、ProceduralWindへ一括で突風をトリガーする
 int32 UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(
 	USkeletalMeshComponent* MeshComp,
 	const float Strength,
@@ -709,6 +716,7 @@ int32 UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(
 	return AppliedForceCount;
 }
 
+// Component内の対象ノード（Tagフィルタ適用）を走査し、ProceduralWindへ一括でパラメータ更新をリクエストする
 int32 UKawaiiPhysicsLibrary::SetProceduralWindParametersOnComponent(
 	USkeletalMeshComponent* MeshComp,
 	const FKawaiiProceduralWindDynamicParams& Params,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsWindPresetDataAsset.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsWindPresetDataAsset.cpp
@@ -1,0 +1,249 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsWindPresetDataAsset.h"
+
+#include "KawaiiPhysicsWindPresetTags.h"
+
+#if WITH_EDITOR
+#include "Misc/DataValidation.h"
+#endif
+
+#define LOCTEXT_NAMESPACE "KawaiiPhysicsWindPresetDataAsset"
+
+FKawaiiProceduralWindDynamicParams FKawaiiProceduralWindPreset::ToDynamicParams() const
+{
+	FKawaiiProceduralWindDynamicParams Params;
+
+	Params.bOverrideSteadyForce = true;
+	Params.SteadyForce = SteadyForce;
+	Params.bOverrideOscillationForce = true;
+	Params.OscillationForce = OscillationForce;
+	Params.bOverrideOscillationPeriod = true;
+	Params.OscillationPeriod = OscillationPeriod;
+	Params.bOverrideWaveAmplitude = true;
+	Params.WaveAmplitude = WaveAmplitude;
+	Params.bOverrideWavePeriod = true;
+	Params.WavePeriod = WavePeriod;
+	Params.bOverrideWaveSpatialOffset = true;
+	Params.WaveSpatialOffset = WaveSpatialOffset;
+	Params.bOverrideEnvelopeMin = true;
+	Params.EnvelopeMin = EnvelopeMin;
+	Params.bOverrideEnvelopeMax = true;
+	Params.EnvelopeMax = EnvelopeMax;
+	Params.bOverrideEnvelopeFrequency = true;
+	Params.EnvelopeFrequency = EnvelopeFrequency;
+	Params.bOverrideRandomForce = true;
+	Params.RandomForce = RandomForce;
+	Params.bOverrideRandomPeriod = true;
+	Params.RandomPeriod = RandomPeriod;
+	Params.bOverrideDirectionNoiseAngle = true;
+	Params.DirectionNoiseAngle = DirectionNoiseAngle;
+
+	return Params;
+}
+
+const FKawaiiProceduralWindPreset* UKawaiiPhysicsWindPresetDataAsset::FindPresetByTag(FGameplayTag PresetTag) const
+{
+	if (!PresetTag.IsValid())
+	{
+		return nullptr;
+	}
+
+	for (const FKawaiiProceduralWindPreset& Preset : Presets)
+	{
+		if (Preset.PresetTag.IsValid() && Preset.PresetTag.MatchesTagExact(PresetTag))
+		{
+			return &Preset;
+		}
+	}
+
+	return nullptr;
+}
+
+bool UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+	const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset,
+	FGameplayTag PresetTag,
+	FKawaiiProceduralWindDynamicParams& OutParams)
+{
+	// 無効タグは DataAsset と組み込み既定のどちらも照合せず失敗扱いにする。
+	if (!PresetTag.IsValid())
+	{
+		return false;
+	}
+
+	// 明示的にプリセットを持つ DataAsset は、その DataAsset 内だけを照合対象にする。
+	// 見つからない場合も組み込み既定へはフォールバックしない。
+	if (PresetDataAsset && PresetDataAsset->Presets.Num() > 0)
+	{
+		if (const FKawaiiProceduralWindPreset* Preset = PresetDataAsset->FindPresetByTag(PresetTag))
+		{
+			OutParams = Preset->ToDynamicParams();
+			return true;
+		}
+
+		return false;
+	}
+
+	// DataAsset が未指定、または空配列の場合のみ組み込み既定の3件から照合する。
+	const TArray<FKawaiiProceduralWindPreset> DefaultPresets = GetDefaultPresets();
+	for (const FKawaiiProceduralWindPreset& Preset : DefaultPresets)
+	{
+		if (Preset.PresetTag.IsValid() && Preset.PresetTag.MatchesTagExact(PresetTag))
+		{
+			OutParams = Preset.ToDynamicParams();
+			return true;
+		}
+	}
+
+	return false;
+}
+
+namespace
+{
+	FKawaiiProceduralWindPreset MakeWindPreset(
+		const FGameplayTag& PresetTag,
+		const FText& PresetName,
+		float SteadyForce,
+		float OscillationForce,
+		float OscillationPeriod,
+		float WaveAmplitude,
+		float WavePeriod,
+		float WaveSpatialOffset,
+		float EnvelopeMin,
+		float EnvelopeMax,
+		float EnvelopeFrequency,
+		float RandomForce,
+		float RandomPeriod,
+		float DirectionNoiseAngle)
+	{
+		FKawaiiProceduralWindPreset Preset;
+		Preset.PresetTag = PresetTag;
+		Preset.PresetName = PresetName;
+		Preset.SteadyForce = SteadyForce;
+		Preset.OscillationForce = OscillationForce;
+		Preset.OscillationPeriod = OscillationPeriod;
+		Preset.WaveAmplitude = WaveAmplitude;
+		Preset.WavePeriod = WavePeriod;
+		Preset.WaveSpatialOffset = WaveSpatialOffset;
+		Preset.EnvelopeMin = EnvelopeMin;
+		Preset.EnvelopeMax = EnvelopeMax;
+		Preset.EnvelopeFrequency = EnvelopeFrequency;
+		Preset.RandomForce = RandomForce;
+		Preset.RandomPeriod = RandomPeriod;
+		Preset.DirectionNoiseAngle = DirectionNoiseAngle;
+		return Preset;
+	}
+
+#if WITH_EDITOR
+	void ForEachWindPresetValidationWarning(
+		const TArray<FKawaiiProceduralWindPreset>& Presets,
+		const TFunctionRef<void(const FText&)>& AddWarning)
+	{
+		TSet<FGameplayTag> SeenTags;
+		for (int32 Index = 0; Index < Presets.Num(); ++Index)
+		{
+			const FKawaiiProceduralWindPreset& Preset = Presets[Index];
+			if (!Preset.PresetTag.IsValid())
+			{
+				AddWarning(FText::Format(
+					LOCTEXT("InvalidPresetTagWarning", "Wind preset at index {0} has an invalid PresetTag."),
+					FText::AsNumber(Index)));
+				continue;
+			}
+
+			if (SeenTags.Contains(Preset.PresetTag))
+			{
+				AddWarning(FText::Format(
+					LOCTEXT("DuplicatePresetTagWarning", "Wind preset at index {0} has a duplicate PresetTag: {1}."),
+					FText::AsNumber(Index),
+					FText::FromName(Preset.PresetTag.GetTagName())));
+				continue;
+			}
+
+			SeenTags.Add(Preset.PresetTag);
+		}
+	}
+#endif
+}
+
+#if WITH_EDITOR
+#if UE_VERSION_OLDER_THAN(5, 3, 0)
+EDataValidationResult UKawaiiPhysicsWindPresetDataAsset::IsDataValid(TArray<FText>& ValidationErrors)
+{
+	ForEachWindPresetValidationWarning(Presets, [&ValidationErrors](const FText& Warning)
+	{
+		ValidationErrors.Add(Warning);
+	});
+
+	return EDataValidationResult::Valid;
+}
+#else
+EDataValidationResult UKawaiiPhysicsWindPresetDataAsset::IsDataValid(FDataValidationContext& Context) const
+{
+	ForEachWindPresetValidationWarning(Presets, [&Context](const FText& Warning)
+	{
+		Context.AddWarning(Warning);
+	});
+
+	return EDataValidationResult::Valid;
+}
+#endif
+#endif
+
+TArray<FKawaiiProceduralWindPreset> UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets()
+{
+	TArray<FKawaiiProceduralWindPreset> DefaultPresets;
+	DefaultPresets.Reserve(3);
+
+	DefaultPresets.Add(MakeWindPreset(
+		TAG_KawaiiPhysics_WindPreset_Breeze,
+		NSLOCTEXT("KawaiiPhysicsWindPresetDataAsset", "BreezePresetName", "Breeze / そよ風"),
+		2.0f,
+		1.0f,
+		2.0f,
+		1.0f,
+		1.5f,
+		90.0f,
+		0.6f,
+		1.0f,
+		0.05f,
+		0.5f,
+		0.8f,
+		5.0f));
+
+	DefaultPresets.Add(MakeWindPreset(
+		TAG_KawaiiPhysics_WindPreset_Strong,
+		NSLOCTEXT("KawaiiPhysicsWindPresetDataAsset", "StrongPresetName", "Strong / 強風"),
+		8.0f,
+		4.0f,
+		0.8f,
+		3.0f,
+		0.6f,
+		120.0f,
+		0.7f,
+		1.3f,
+		0.08f,
+		2.0f,
+		0.5f,
+		10.0f));
+
+	DefaultPresets.Add(MakeWindPreset(
+		TAG_KawaiiPhysics_WindPreset_Storm,
+		NSLOCTEXT("KawaiiPhysicsWindPresetDataAsset", "StormPresetName", "Storm / 嵐"),
+		15.0f,
+		10.0f,
+		0.4f,
+		8.0f,
+		0.35f,
+		180.0f,
+		0.5f,
+		1.6f,
+		0.15f,
+		6.0f,
+		0.3f,
+		20.0f));
+
+	return DefaultPresets;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsWindPresetTags.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsWindPresetTags.cpp
@@ -1,0 +1,7 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsWindPresetTags.h"
+
+KAWAIIPHYSICS_API UE_DEFINE_GAMEPLAY_TAG(TAG_KawaiiPhysics_WindPreset_Breeze, "KawaiiPhysics.WindPreset.Breeze");
+KAWAIIPHYSICS_API UE_DEFINE_GAMEPLAY_TAG(TAG_KawaiiPhysics_WindPreset_Strong, "KawaiiPhysics.WindPreset.Strong");
+KAWAIIPHYSICS_API UE_DEFINE_GAMEPLAY_TAG(TAG_KawaiiPhysics_WindPreset_Storm, "KawaiiPhysics.WindPreset.Storm");

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -350,6 +350,97 @@ bool FKawaiiPhysicsProceduralWindGustEnvelopeTest::RunTest(const FString& Parame
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindDynamicParamsTest,
+                                 "KawaiiPhysics.ProceduralWind.DynamicParams",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindDynamicParamsTest::RunTest(const FString& Parameters)
+{
+	// 上書き指定された項目だけが反映され、下限付き項目は安全化されることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.WindDirection = FRotator(1.0f, 2.0f, 3.0f);
+	Wind.SteadyForce = 2.0f;
+	Wind.OscillationForce = 3.0f;
+	Wind.OscillationPeriod = 1.0f;
+	Wind.WaveAmplitude = 4.0f;
+	Wind.WavePhase = 10.0f;
+	Wind.DirectionNoiseAngle = 5.0f;
+	Wind.TimeScale = 1.0f;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	Params.bOverrideWindDirection = false;
+	Params.WindDirection = FRotator(10.0f, 20.0f, 30.0f);
+	Params.bOverrideSteadyForce = true;
+	Params.SteadyForce = -5.0f;
+	Params.bOverrideOscillationForce = false;
+	Params.OscillationForce = 99.0f;
+	Params.bOverrideOscillationPeriod = true;
+	Params.OscillationPeriod = -10.0f;
+	Params.bOverrideWaveAmplitude = false;
+	Params.WaveAmplitude = 99.0f;
+	Params.bOverrideWavePhase = true;
+	Params.WavePhase = -45.0f;
+	Params.bOverrideDirectionNoiseAngle = true;
+	Params.DirectionNoiseAngle = -20.0f;
+	Params.bOverrideTimeScale = true;
+	Params.TimeScale = -1.0f;
+
+	Wind.ApplyDynamicParams(Params);
+
+	TestTrue(TEXT("WindDirection unchanged"), Wind.WindDirection.Equals(FRotator(1.0f, 2.0f, 3.0f)));
+	TestSampleNear(*this, TEXT("SteadyForce clamped"), Wind.SteadyForce, 0.0f);
+	TestSampleNear(*this, TEXT("OscillationForce unchanged"), Wind.OscillationForce, 3.0f);
+	TestSampleNear(*this, TEXT("OscillationPeriod clamped"), Wind.OscillationPeriod, 0.01f);
+	TestSampleNear(*this, TEXT("WaveAmplitude unchanged"), Wind.WaveAmplitude, 4.0f);
+	TestSampleNear(*this, TEXT("WavePhase unclamped"), Wind.WavePhase, -45.0f);
+	TestSampleNear(*this, TEXT("DirectionNoiseAngle clamped"), Wind.DirectionNoiseAngle, 0.0f);
+	TestSampleNear(*this, TEXT("TimeScale clamped"), Wind.TimeScale, 0.0f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindPendingConsumptionTest,
+                                 "KawaiiPhysics.ProceduralWind.PendingConsumption",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindPendingConsumptionTest::RunTest(const FString& Parameters)
+{
+	// 保留中のパラメータと突風が一度の消費で反映され、保留欄が空になることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.ResetRuntimeState();
+	Wind.RuntimeState->Time = 2.25f;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	Params.bOverrideSteadyForce = true;
+	Params.SteadyForce = 8.0f;
+	Params.bOverrideOscillationPeriod = true;
+	Params.OscillationPeriod = 0.25f;
+
+	{
+		FScopeLock Lock(&Wind.RuntimeState->Mutex);
+		Wind.RuntimeState->PendingParams = Params;
+		Wind.RuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{
+			6.0f,
+			0.1f,
+			0.5f
+		};
+	}
+
+	Wind.ConsumePendingRequests();
+
+	TestSampleNear(*this, TEXT("Pending SteadyForce applied"), Wind.SteadyForce, 8.0f);
+	TestSampleNear(*this, TEXT("Pending OscillationPeriod applied"), Wind.OscillationPeriod, 0.25f);
+	TestSampleNear(*this, TEXT("ActiveGust StartTime"), Wind.RuntimeState->ActiveGust.StartTime, 2.25f);
+	TestSampleNear(*this, TEXT("ActiveGust Strength"), Wind.RuntimeState->ActiveGust.Strength, 6.0f);
+	TestSampleNear(*this, TEXT("ActiveGust RiseTime"), Wind.RuntimeState->ActiveGust.RiseTime, 0.1f);
+	TestSampleNear(*this, TEXT("ActiveGust DecayTime"), Wind.RuntimeState->ActiveGust.DecayTime, 0.5f);
+	TestTrue(TEXT("ActiveGust active"), Wind.RuntimeState->ActiveGust.bIsActive);
+	TestFalse(TEXT("PendingParams reset"), Wind.RuntimeState->PendingParams.IsSet());
+	TestFalse(TEXT("PendingGust reset"), Wind.RuntimeState->PendingGust.IsSet());
+
+	return true;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindFramerateIndependenceTest,
                                  "KawaiiPhysics.ProceduralWind.FramerateIndependence",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -1,0 +1,392 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "KawaiiPhysicsTestHarness.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+
+#include "Animation/AnimInstanceProxy.h"
+#include "Animation/AnimNodeBase.h"
+
+namespace
+{
+constexpr float GProceduralWindTol = KINDA_SMALL_NUMBER;
+
+bool SamplesExactlyEqual(const FKawaiiPhysicsProceduralWindSample& A,
+                         const FKawaiiPhysicsProceduralWindSample& B)
+{
+	return A.Steady == B.Steady &&
+		A.Oscillation == B.Oscillation &&
+		A.Wave == B.Wave &&
+		A.Envelope == B.Envelope &&
+		A.Random == B.Random &&
+		A.Gust == B.Gust &&
+		A.Total == B.Total;
+}
+
+void TestSampleNear(FAutomationTestBase& Test, const TCHAR* Name, const float Actual, const float Expected,
+                    const float Tol = GProceduralWindTol)
+{
+	Test.TestTrue(FString::Printf(TEXT("%s: got %.9f expected %.9f"), Name, Actual, Expected),
+	              FMath::IsNearlyEqual(Actual, Expected, Tol));
+}
+
+int32 FindWavePeakIndex(const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind, const float Time,
+                        const int32 NumSegments)
+{
+	int32 PeakIndex = 0;
+	float PeakValue = -FLT_MAX;
+	for (int32 Index = 0; Index <= NumSegments; ++Index)
+	{
+		const float Rate = static_cast<float>(Index) / static_cast<float>(NumSegments);
+		const float Wave = Wind.ComputeWindSample(Time, Rate).Wave;
+		if (Wave > PeakValue)
+		{
+			PeakValue = Wave;
+			PeakIndex = Index;
+		}
+	}
+	return PeakIndex;
+}
+
+struct FKawaiiPhysicsProceduralWindApplyTestForce : FKawaiiPhysics_ExternalForce_ProceduralWind
+{
+	void SetRandomizedForceScaleForTest(const float InScale)
+	{
+		RandomizedForceScale = InScale;
+	}
+};
+
+void PrimeApplyCache(FKawaiiPhysicsProceduralWindApplyTestForce& Wind, const float Time)
+{
+	Wind.ResetRuntimeState();
+	const FKawaiiPhysicsProceduralWindSample Sample = Wind.ComputeWindSample(Time, 0.0f);
+	Wind.RuntimeState->Time = Time;
+	Wind.RuntimeState->CachedSinesWithoutWave = Sample.Steady + Sample.Oscillation;
+	Wind.RuntimeState->CachedEnvelope = Sample.Envelope;
+	Wind.RuntimeState->CachedRandom = Sample.Random;
+	Wind.RuntimeState->CachedGust = Sample.Gust;
+	Wind.RuntimeState->CachedWindVector = Wind.WindDirection.Vector().GetSafeNormal();
+	Wind.SetRandomizedForceScaleForTest(1.0f);
+}
+
+FVector ApplyProceduralWindDisplacement(const int32 NumSubsteps)
+{
+	const float TotalDt = 1.0f / 30.0f;
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.BuildVerticalChain(2, 10.0f, FVector::ZeroVector, FVector(0.0f, 0.0f, -1.0f));
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.Bone(1).LengthRateFromRoot = 0.75f;
+
+	FKawaiiPhysicsProceduralWindApplyTestForce Wind;
+	Wind.ExternalForceSpace = EExternalForceSpace::ComponentSpace;
+	Wind.WindDirection = FRotator::ZeroRotator;
+	Wind.SteadyForce = 3.0f;
+	Wind.OscillationForce = 2.0f;
+	Wind.OscillationPeriod = 0.5f;
+	Wind.WaveAmplitude = 4.0f;
+	Wind.WavePeriod = 0.75f;
+	Wind.WaveSpatialOffset = 120.0f;
+	Wind.EnvelopeMin = 1.0f;
+	Wind.EnvelopeMax = 1.0f;
+	PrimeApplyCache(Wind, TotalDt);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	const FVector InitialLocation = Accessor.Bone(1).Location;
+	if (NumSubsteps == 1)
+	{
+		Accessor.SetTimeState(TotalDt, TotalDt);
+		Wind.Apply(Accessor.Bone(1), Accessor.Node, PoseContext);
+	}
+	else
+	{
+		const float StepDt = TotalDt / static_cast<float>(NumSubsteps);
+		for (int32 Index = 0; Index < NumSubsteps; ++Index)
+		{
+			Accessor.SetSubstepTimeState(TotalDt, StepDt);
+			Wind.Apply(Accessor.Bone(1), Accessor.Node, PoseContext);
+		}
+	}
+
+	return Accessor.Bone(1).Location - InitialLocation;
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindDeterminismTest,
+                                 "KawaiiPhysics.ProceduralWind.Determinism",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindDeterminismTest::RunTest(const FString& Parameters)
+{
+	// 同じ入力列では完全一致し、シード変更でランダム成分が変わることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind A;
+	FKawaiiPhysics_ExternalForce_ProceduralWind B;
+	FKawaiiPhysics_ExternalForce_ProceduralWind C;
+	A.RandomForce = 3.0f;
+	B.RandomForce = 3.0f;
+	C.RandomForce = 3.0f;
+	A.RandomPeriod = 0.37f;
+	B.RandomPeriod = 0.37f;
+	C.RandomPeriod = 0.37f;
+	A.RandomSeed = 12345;
+	B.RandomSeed = 12345;
+	C.RandomSeed = 54321;
+
+	bool bDifferentSeedChangedRandom = false;
+	for (int32 Index = 0; Index < 64; ++Index)
+	{
+		const float Time = static_cast<float>(Index) * 0.071f;
+		const FKawaiiPhysicsProceduralWindSample SampleA = A.ComputeWindSample(Time, 0.25f);
+		const FKawaiiPhysicsProceduralWindSample SampleB = B.ComputeWindSample(Time, 0.25f);
+		const FKawaiiPhysicsProceduralWindSample SampleC = C.ComputeWindSample(Time, 0.25f);
+		TestTrue(FString::Printf(TEXT("Same seed sample %d"), Index), SamplesExactlyEqual(SampleA, SampleB));
+		bDifferentSeedChangedRandom |= SampleA.Random != SampleC.Random;
+	}
+
+	TestTrue(TEXT("Different seed changes at least one Random component"), bDifferentSeedChangedRandom);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindSteadyOnlyTest,
+                                 "KawaiiPhysics.ProceduralWind.SteadyOnly",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindSteadyOnlyTest::RunTest(const FString& Parameters)
+{
+	// 定常風だけが有効な場合、時刻に関係なく合計が定常風と一致することを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.SteadyForce = 7.25f;
+
+	for (const float Time : {0.0f, 0.1f, 0.5f, 1.0f, 3.75f})
+	{
+		const FKawaiiPhysicsProceduralWindSample Sample = Wind.ComputeWindSample(Time, 0.5f);
+		TestSampleNear(*this, TEXT("Steady"), Sample.Steady, Wind.SteadyForce);
+		TestSampleNear(*this, TEXT("Total"), Sample.Total, Wind.SteadyForce);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindSinePhaseTest,
+                                 "KawaiiPhysics.ProceduralWind.SinePhase",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindSinePhaseTest::RunTest(const FString& Parameters)
+{
+	// 振動と波の位相、および周期性が実装式どおりになることを確認する。
+	const float Period = 2.0f;
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind OscillationWind;
+	OscillationWind.OscillationForce = 1.0f;
+	OscillationWind.OscillationPeriod = Period;
+	TestSampleNear(*this, TEXT("Oscillation P/4"), OscillationWind.ComputeWindSample(Period * 0.25f).Oscillation,
+	               1.0f);
+
+	const float Time = 0.37f;
+	TestSampleNear(*this, TEXT("Oscillation periodicity"),
+	               OscillationWind.ComputeWindSample(Time).Oscillation,
+	               OscillationWind.ComputeWindSample(Time + Period).Oscillation, 0.000001f);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind WaveWind;
+	WaveWind.WaveAmplitude = 1.0f;
+	WaveWind.WavePeriod = Period;
+	WaveWind.WavePhase = 90.0f;
+	TestSampleNear(*this, TEXT("Wave phase"), WaveWind.ComputeWindSample(0.0f, 0.0f).Wave, 1.0f);
+	TestSampleNear(*this, TEXT("Wave periodicity"),
+	               WaveWind.ComputeWindSample(Time, 0.35f).Wave,
+	               WaveWind.ComputeWindSample(Time + Period, 0.35f).Wave, 0.000001f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindWavePropagationTest,
+                                 "KawaiiPhysics.ProceduralWind.WavePropagation",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindWavePropagationTest::RunTest(const FString& Parameters)
+{
+	// 空間位相差で根元と毛先が逆相になり、時間経過でピークが毛先方向へ移動することを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.WaveAmplitude = 1.0f;
+	Wind.WavePeriod = 2.0f;
+	Wind.WaveSpatialOffset = 180.0f;
+
+	const float FixedTime = Wind.WavePeriod * 0.25f;
+	const float RootWave = Wind.ComputeWindSample(FixedTime, 0.0f).Wave;
+	const float TipWave = Wind.ComputeWindSample(FixedTime, 1.0f).Wave;
+	TestTrue(FString::Printf(TEXT("Opposite sign: root=%.6f tip=%.6f"), RootWave, TipWave),
+	         RootWave * TipWave < 0.0f);
+
+	const int32 Peak0 = FindWavePeakIndex(Wind, Wind.WavePeriod * 0.25f, 1000);
+	const int32 Peak1 = FindWavePeakIndex(Wind, Wind.WavePeriod * 0.50f, 1000);
+	TestTrue(FString::Printf(TEXT("Peak moves root to tip: %d -> %d"), Peak0, Peak1),
+	         Peak1 > Peak0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindEnvelopeBoundsTest,
+                                 "KawaiiPhysics.ProceduralWind.EnvelopeBounds",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindEnvelopeBoundsTest::RunTest(const FString& Parameters)
+{
+	// エンベロープが指定範囲内に収まり、最小最大が同値なら定数へ潰れることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.EnvelopeMin = 0.2f;
+	Wind.EnvelopeMax = 1.5f;
+	Wind.EnvelopeFrequency = 0.73f;
+	Wind.EnvelopePhase = 17.0f;
+
+	for (int32 Index = 0; Index < 1000; ++Index)
+	{
+		const float Time = static_cast<float>(Index) * 0.013f;
+		const float Envelope = Wind.ComputeWindSample(Time, 0.0f).Envelope;
+		TestTrue(FString::Printf(TEXT("Envelope bounds %d: %.9f"), Index, Envelope),
+		         Envelope >= Wind.EnvelopeMin - GProceduralWindTol &&
+		         Envelope <= Wind.EnvelopeMax + GProceduralWindTol);
+	}
+
+	Wind.EnvelopeMin = 0.625f;
+	Wind.EnvelopeMax = 0.625f;
+	for (const float Time : {0.0f, 0.4f, 1.7f, 8.0f})
+	{
+		TestSampleNear(*this, TEXT("Envelope identity"), Wind.ComputeWindSample(Time, 0.0f).Envelope, 0.625f);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindNoisePropertiesTest,
+                                 "KawaiiPhysics.ProceduralWind.NoiseProperties",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindNoisePropertiesTest::RunTest(const FString& Parameters)
+{
+	// ノイズ範囲、格子点一致、連続性、ハッシュのスナップショット値を確認する。
+	using FWind = FKawaiiPhysics_ExternalForce_ProceduralWind;
+
+	TestEqual(TEXT("StableHash(0, 0, 0)"), FWind::StableHash(0, 0, 0), 672839204u);
+	TestEqual(TEXT("StableHash(123, 0, 0)"), FWind::StableHash(123, 0, 0), 961409981u);
+	TestEqual(TEXT("StableHash(123, 1, 0)"), FWind::StableHash(123, 1, 0), 688218621u);
+	TestEqual(TEXT("StableHash(123, -1, 0)"), FWind::StableHash(123, -1, 0), 2476066305u);
+	TestEqual(TEXT("StableHash(-17, 42, 3)"), FWind::StableHash(-17, 42, 3), 1090092324u);
+
+	float Previous = FWind::SampleSmoothNoise(-8.0f, 2468, 0);
+	for (int32 Index = 0; Index <= 2000; ++Index)
+	{
+		const float U = -8.0f + static_cast<float>(Index) * 0.01f;
+		const float Value = FWind::SampleSmoothNoise(U, 2468, 0);
+		TestTrue(FString::Printf(TEXT("Noise range U=%.3f Value=%.9f"), U, Value),
+		         Value >= -1.0f - GProceduralWindTol && Value <= 1.0f + GProceduralWindTol);
+		if (Index > 0)
+		{
+			TestTrue(FString::Printf(TEXT("Noise continuity U=%.3f Prev=%.9f Value=%.9f"), U, Previous, Value),
+			         FMath::Abs(Value - Previous) <= 0.1f);
+		}
+		Previous = Value;
+	}
+
+	for (int32 GridIndex = -8; GridIndex <= 8; ++GridIndex)
+	{
+		const float Smooth = FWind::SampleSmoothNoise(static_cast<float>(GridIndex), 2468, 1);
+		const float Grid = FWind::NoiseValueAt(GridIndex, 2468, 1);
+		TestTrue(FString::Printf(TEXT("Grid match %d: smooth=%.9f grid=%.9f"), GridIndex, Smooth, Grid),
+		         Smooth == Grid);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindNoiseChannelsTest,
+                                 "KawaiiPhysics.ProceduralWind.NoiseChannels",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindNoiseChannelsTest::RunTest(const FString& Parameters)
+{
+	// 同じシードと座標でもチャンネルごとに独立した系列になることを確認する。
+	using FWind = FKawaiiPhysics_ExternalForce_ProceduralWind;
+
+	bool bFoundDifferentChannel = false;
+	for (int32 Index = 0; Index < 128; ++Index)
+	{
+		const float U = -3.0f + static_cast<float>(Index) * 0.071f;
+		const float C0 = FWind::SampleSmoothNoise(U, 1357, 0);
+		const float C1 = FWind::SampleSmoothNoise(U, 1357, 1);
+		const float C2 = FWind::SampleSmoothNoise(U, 1357, 2);
+		bFoundDifferentChannel |= !FMath::IsNearlyEqual(C0, C1, GProceduralWindTol) ||
+			!FMath::IsNearlyEqual(C0, C2, GProceduralWindTol) ||
+			!FMath::IsNearlyEqual(C1, C2, GProceduralWindTol);
+	}
+
+	TestTrue(TEXT("Channels differ for at least one sampled U"), bFoundDifferentChannel);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindGustEnvelopeTest,
+                                 "KawaiiPhysics.ProceduralWind.GustEnvelope",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindGustEnvelopeTest::RunTest(const FString& Parameters)
+{
+	// アクティブなガストが立ち上がりと減衰時間に従って評価されることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.ResetRuntimeState();
+	Wind.RuntimeState->ActiveGust.StartTime = 0.0f;
+	Wind.RuntimeState->ActiveGust.Strength = 5.0f;
+	Wind.RuntimeState->ActiveGust.RiseTime = 1.0f;
+	Wind.RuntimeState->ActiveGust.DecayTime = 2.0f;
+	Wind.RuntimeState->ActiveGust.bIsActive = true;
+
+	TestSampleNear(*this, TEXT("Gust t=0.5"), Wind.ComputeWindSample(0.5f, 0.0f).Gust, 2.5f);
+	TestSampleNear(*this, TEXT("Gust t=1.0"), Wind.ComputeWindSample(1.0f, 0.0f).Gust, 5.0f);
+	TestSampleNear(*this, TEXT("Gust t=2.0"), Wind.ComputeWindSample(2.0f, 0.0f).Gust, 2.5f);
+	TestSampleNear(*this, TEXT("Gust t=3.0"), Wind.ComputeWindSample(3.0f, 0.0f).Gust, 0.0f);
+	TestSampleNear(*this, TEXT("Gust beyond"), Wind.ComputeWindSample(4.0f, 0.0f).Gust, 0.0f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindFramerateIndependenceTest,
+                                 "KawaiiPhysics.ProceduralWind.FramerateIndependence",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindFramerateIndependenceTest::RunTest(const FString& Parameters)
+{
+	// 同一フレーム内でキャッシュ済みの波を一括適用しても分割適用しても変位合計が一致することを確認する。
+	const FVector OneStep = ApplyProceduralWindDisplacement(1);
+	const FVector FourSteps = ApplyProceduralWindDisplacement(4);
+	TestTrue(FString::Printf(TEXT("Apply displacement 1 vs 4: %s vs %s"), *OneStep.ToString(), *FourSteps.ToString()),
+	         OneStep.Equals(FourSteps, 0.000001f));
+	TestTrue(TEXT("Wave-including displacement is non-zero"), !OneStep.IsNearlyZero());
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindResetRuntimeStateTest,
+                                 "KawaiiPhysics.ProceduralWind.ResetRuntimeState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindResetRuntimeStateTest::RunTest(const FString& Parameters)
+{
+	// 時刻とガスト状態を進めたあと、リセットで初期状態へ戻ることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.ResetRuntimeState();
+	Wind.RuntimeState->Time = 2.5f;
+	Wind.RuntimeState->ActiveGust.StartTime = 0.0f;
+	Wind.RuntimeState->ActiveGust.Strength = 4.0f;
+	Wind.RuntimeState->ActiveGust.RiseTime = 0.5f;
+	Wind.RuntimeState->ActiveGust.DecayTime = 3.0f;
+	Wind.RuntimeState->ActiveGust.bIsActive = true;
+	TestTrue(TEXT("Gust is active before reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust > 0.0f);
+
+	Wind.ResetRuntimeState();
+	TestSampleNear(*this, TEXT("Gust after reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust, 0.0f);
+	TestSampleNear(*this, TEXT("Time after reset"), Wind.RuntimeState->Time, 0.0f);
+
+	return true;
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -11,8 +11,10 @@
 
 namespace
 {
+// 本テストは積分の蓄積誤差を持たない解析式（sin等）を直接評価するため、既定許容誤差はfloatの丸め程度で足りる
 constexpr float GProceduralWindTol = KINDA_SMALL_NUMBER;
 
+// Sample の全フィールドが完全一致するかを判定するヘルパー（同一seedのサンプル比較に使用）
 bool SamplesExactlyEqual(const FKawaiiPhysicsProceduralWindSample& A,
                          const FKawaiiPhysicsProceduralWindSample& B)
 {
@@ -25,6 +27,7 @@ bool SamplesExactlyEqual(const FKawaiiPhysicsProceduralWindSample& A,
 		A.Total == B.Total;
 }
 
+// 近似比較用アサーションヘルパー。失敗時に実測値と期待値を併記して原因調査しやすくする
 void TestSampleNear(FAutomationTestBase& Test, const TCHAR* Name, const float Actual, const float Expected,
                     const float Tol = GProceduralWindTol)
 {
@@ -32,6 +35,7 @@ void TestSampleNear(FAutomationTestBase& Test, const TCHAR* Name, const float Ac
 	              FMath::IsNearlyEqual(Actual, Expected, Tol));
 }
 
+// Rate=[0,1]をNumSegments分割で走査し、Waveが最大となる区間インデックスを求める（WavePropagationテストでピーク位置の移動検出に使用）
 int32 FindWavePeakIndex(const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind, const float Time,
                         const int32 NumSegments)
 {
@@ -50,6 +54,8 @@ int32 FindWavePeakIndex(const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind,
 	return PeakIndex;
 }
 
+// RandomizedForceScaleはprotectedかつ既定0.0fで、通常はPreApplyのランダム化処理でのみ設定される。
+// Apply()を直接呼ぶテストではPreApplyを経由しないため、テスト用サブクラスで固定値を注入する
 struct FKawaiiPhysicsProceduralWindApplyTestForce : FKawaiiPhysics_ExternalForce_ProceduralWind
 {
 	void SetRandomizedForceScaleForTest(const float InScale)
@@ -58,6 +64,7 @@ struct FKawaiiPhysicsProceduralWindApplyTestForce : FKawaiiPhysics_ExternalForce
 	}
 };
 
+// PreApplyが行うキャッシュ更新（合成波・envelope・random・gust・風向ベクトル）を、ポーズ評価なしで手動再現するヘルパー
 void PrimeApplyCache(FKawaiiPhysicsProceduralWindApplyTestForce& Wind, const float Time)
 {
 	Wind.ResetRuntimeState();
@@ -71,6 +78,8 @@ void PrimeApplyCache(FKawaiiPhysicsProceduralWindApplyTestForce& Wind, const flo
 	Wind.SetRandomizedForceScaleForTest(1.0f);
 }
 
+// 2ボーンチェーンへ同一フレーム分のWindを1回適用/NumSubsteps回に分割適用し、フレーム末の累積変位を返す
+// （FramerateIndependenceテストでsubstep分割数への非依存性を検証するために使用）
 FVector ApplyProceduralWindDisplacement(const int32 NumSubsteps)
 {
 	const float TotalDt = 1.0f / 30.0f;
@@ -135,6 +144,7 @@ bool FKawaiiPhysicsProceduralWindDeterminismTest::RunTest(const FString& Paramet
 	B.RandomSeed = 12345;
 	C.RandomSeed = 54321;
 
+	// 64点の時刻でサンプルを取り、同一seed(A/B)の完全一致と異seed(C)とのRandom成分の差分有無を集計する
 	bool bDifferentSeedChangedRandom = false;
 	for (int32 Index = 0; Index < 64; ++Index)
 	{
@@ -179,6 +189,7 @@ bool FKawaiiPhysicsProceduralWindSinePhaseTest::RunTest(const FString& Parameter
 	// 振動と波の位相、および周期性が実装式どおりになることを確認する。
 	const float Period = 2.0f;
 
+	// 振動成分: 1/4周期でsin位相がpi/2となり振幅そのものが出力される点、および1周期後の値が一致する周期性を確認
 	FKawaiiPhysics_ExternalForce_ProceduralWind OscillationWind;
 	OscillationWind.OscillationForce = 1.0f;
 	OscillationWind.OscillationPeriod = Period;
@@ -190,6 +201,7 @@ bool FKawaiiPhysicsProceduralWindSinePhaseTest::RunTest(const FString& Parameter
 	               OscillationWind.ComputeWindSample(Time).Oscillation,
 	               OscillationWind.ComputeWindSample(Time + Period).Oscillation, 0.000001f);
 
+	// 波成分: WavePhase=90度によりt=0・Rate=0で位相pi/2（振幅最大）となる設定で、位相と周期性を確認
 	FKawaiiPhysics_ExternalForce_ProceduralWind WaveWind;
 	WaveWind.WaveAmplitude = 1.0f;
 	WaveWind.WavePeriod = Period;
@@ -214,12 +226,14 @@ bool FKawaiiPhysicsProceduralWindWavePropagationTest::RunTest(const FString& Par
 	Wind.WavePeriod = 2.0f;
 	Wind.WaveSpatialOffset = 180.0f;
 
+	// WaveSpatialOffset=180度により根元(Rate=0)と毛先(Rate=1)は空間位相差piとなり、符号が反転するはず
 	const float FixedTime = Wind.WavePeriod * 0.25f;
 	const float RootWave = Wind.ComputeWindSample(FixedTime, 0.0f).Wave;
 	const float TipWave = Wind.ComputeWindSample(FixedTime, 1.0f).Wave;
 	TestTrue(FString::Printf(TEXT("Opposite sign: root=%.6f tip=%.6f"), RootWave, TipWave),
 	         RootWave * TipWave < 0.0f);
 
+	// 時間を1/4周期進めるとピークが根元寄りから毛先寄りへ移動する（進行波としての空間伝播）ことを確認
 	const int32 Peak0 = FindWavePeakIndex(Wind, Wind.WavePeriod * 0.25f, 1000);
 	const int32 Peak1 = FindWavePeakIndex(Wind, Wind.WavePeriod * 0.50f, 1000);
 	TestTrue(FString::Printf(TEXT("Peak moves root to tip: %d -> %d"), Peak0, Peak1),
@@ -241,6 +255,7 @@ bool FKawaiiPhysicsProceduralWindEnvelopeBoundsTest::RunTest(const FString& Para
 	Wind.EnvelopeFrequency = 0.73f;
 	Wind.EnvelopePhase = 17.0f;
 
+	// 1000点サンプリングし、Envelopeが常に[EnvelopeMin, EnvelopeMax]の範囲内に収まることを確認
 	for (int32 Index = 0; Index < 1000; ++Index)
 	{
 		const float Time = static_cast<float>(Index) * 0.013f;
@@ -250,6 +265,7 @@ bool FKawaiiPhysicsProceduralWindEnvelopeBoundsTest::RunTest(const FString& Para
 		         Envelope <= Wind.EnvelopeMax + GProceduralWindTol);
 	}
 
+	// MinとMaxを同値にした場合、Lerpの結果が時刻によらず定数へ潰れることを確認
 	Wind.EnvelopeMin = 0.625f;
 	Wind.EnvelopeMax = 0.625f;
 	for (const float Time : {0.0f, 0.4f, 1.7f, 8.0f})
@@ -269,12 +285,14 @@ bool FKawaiiPhysicsProceduralWindNoisePropertiesTest::RunTest(const FString& Par
 	// ノイズ範囲、格子点一致、連続性、ハッシュのスナップショット値を確認する。
 	using FWind = FKawaiiPhysics_ExternalForce_ProceduralWind;
 
+	// StableHashの実装は仕様式を持たないFNV-1a派生のビット演算のため、期待値は現行実装から採取したスナップショット値（回帰検出用）
 	TestEqual(TEXT("StableHash(0, 0, 0)"), FWind::StableHash(0, 0, 0), 672839204u);
 	TestEqual(TEXT("StableHash(123, 0, 0)"), FWind::StableHash(123, 0, 0), 961409981u);
 	TestEqual(TEXT("StableHash(123, 1, 0)"), FWind::StableHash(123, 1, 0), 688218621u);
 	TestEqual(TEXT("StableHash(123, -1, 0)"), FWind::StableHash(123, -1, 0), 2476066305u);
 	TestEqual(TEXT("StableHash(-17, 42, 3)"), FWind::StableHash(-17, 42, 3), 1090092324u);
 
+	// Uを-8〜12の範囲で0.01刻みに走査し、値域[-1,1]と隣接差分が閾値以下に収まる連続性（滑らかな補間）を確認
 	float Previous = FWind::SampleSmoothNoise(-8.0f, 2468, 0);
 	for (int32 Index = 0; Index <= 2000; ++Index)
 	{
@@ -290,6 +308,7 @@ bool FKawaiiPhysicsProceduralWindNoisePropertiesTest::RunTest(const FString& Par
 		Previous = Value;
 	}
 
+	// 整数座標では滑らか補間の結果が格子点の生値（NoiseValueAt）と一致する（補間の境界条件）ことを確認
 	for (int32 GridIndex = -8; GridIndex <= 8; ++GridIndex)
 	{
 		const float Smooth = FWind::SampleSmoothNoise(static_cast<float>(GridIndex), 2468, 1);
@@ -341,6 +360,7 @@ bool FKawaiiPhysicsProceduralWindGustEnvelopeTest::RunTest(const FString& Parame
 	Wind.RuntimeState->ActiveGust.DecayTime = 2.0f;
 	Wind.RuntimeState->ActiveGust.bIsActive = true;
 
+	// RiseTime=1・DecayTime=2に対し、立ち上がり中間(t=0.5)・ピーク(t=1)・減衰中間(t=2)・終了(t=3)・終了後(t=4)の5点で線形補間の傾きを確認
 	TestSampleNear(*this, TEXT("Gust t=0.5"), Wind.ComputeWindSample(0.5f, 0.0f).Gust, 2.5f);
 	TestSampleNear(*this, TEXT("Gust t=1.0"), Wind.ComputeWindSample(1.0f, 0.0f).Gust, 5.0f);
 	TestSampleNear(*this, TEXT("Gust t=2.0"), Wind.ComputeWindSample(2.0f, 0.0f).Gust, 2.5f);
@@ -367,6 +387,7 @@ bool FKawaiiPhysicsProceduralWindDynamicParamsTest::RunTest(const FString& Param
 	Wind.DirectionNoiseAngle = 5.0f;
 	Wind.TimeScale = 1.0f;
 
+	// bOverride*をtrue/false交互に設定し、上書き対象と非対象の双方を1回のApplyDynamicParams呼び出しで検証する
 	FKawaiiProceduralWindDynamicParams Params;
 	Params.bOverrideWindDirection = false;
 	Params.WindDirection = FRotator(10.0f, 20.0f, 30.0f);
@@ -387,6 +408,7 @@ bool FKawaiiPhysicsProceduralWindDynamicParamsTest::RunTest(const FString& Param
 
 	Wind.ApplyDynamicParams(Params);
 
+	// 上書きされた項目は負値でも下限（0 または 0.01）へ安全化され、上書きされない項目は元値のまま残ることを確認
 	TestTrue(TEXT("WindDirection unchanged"), Wind.WindDirection.Equals(FRotator(1.0f, 2.0f, 3.0f)));
 	TestSampleNear(*this, TEXT("SteadyForce clamped"), Wind.SteadyForce, 0.0f);
 	TestSampleNear(*this, TEXT("OscillationForce unchanged"), Wind.OscillationForce, 3.0f);
@@ -416,6 +438,7 @@ bool FKawaiiPhysicsProceduralWindPendingConsumptionTest::RunTest(const FString& 
 	Params.bOverrideOscillationPeriod = true;
 	Params.OscillationPeriod = 0.25f;
 
+	// Mutex配下でPendingParams/PendingGustを設定し、Apply側スレッドからの非同期リクエストを模擬する
 	{
 		FScopeLock Lock(&Wind.RuntimeState->Mutex);
 		Wind.RuntimeState->PendingParams = Params;
@@ -450,6 +473,7 @@ bool FKawaiiPhysicsProceduralWindFramerateIndependenceTest::RunTest(const FStrin
 	// 同一フレーム内でキャッシュ済みの波を一括適用しても分割適用しても変位合計が一致することを確認する。
 	const FVector OneStep = ApplyProceduralWindDisplacement(1);
 	const FVector FourSteps = ApplyProceduralWindDisplacement(4);
+	// 両者はfloat演算順序の違いによる誤差のみを含むはずなので、既定のGProceduralWindTolより厳しい許容誤差で比較する
 	TestTrue(FString::Printf(TEXT("Apply displacement 1 vs 4: %s vs %s"), *OneStep.ToString(), *FourSteps.ToString()),
 	         OneStep.Equals(FourSteps, 0.000001f));
 	TestTrue(TEXT("Wave-including displacement is non-zero"), !OneStep.IsNearlyZero());
@@ -473,6 +497,7 @@ bool FKawaiiPhysicsProceduralWindResetRuntimeStateTest::RunTest(const FString& P
 	Wind.RuntimeState->ActiveGust.bIsActive = true;
 	TestTrue(TEXT("Gust is active before reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust > 0.0f);
 
+	// ResetRuntimeStateはRuntimeStateを新規SharedPtrで差し替えるため、Gust・Timeともに初期値へ戻るはず
 	Wind.ResetRuntimeState();
 	TestSampleNear(*this, TEXT("Gust after reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust, 0.0f);
 	TestSampleNear(*this, TEXT("Time after reset"), Wind.RuntimeState->Time, 0.0f);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsWindPresetTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsWindPresetTest.cpp
@@ -1,0 +1,457 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "KawaiiPhysicsWindPresetDataAsset.h"
+#include "KawaiiPhysicsWindPresetTags.h"
+#include "NativeGameplayTags.h"
+#include "UObject/Package.h"
+#include "UObject/UObjectGlobals.h"
+
+UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysics_WindPreset_TestUnregistered,
+                              "KawaiiPhysics.WindPreset.TestUnregistered");
+
+namespace
+{
+// 既存の手続き風テストと同じく、浮動小数点の丸め程度を既定許容誤差にする
+constexpr float GWindPresetTol = KINDA_SMALL_NUMBER;
+
+struct FWindPresetParamMapping
+{
+	const TCHAR* Name;
+	bool FKawaiiProceduralWindDynamicParams::* DynamicOverride;
+	float FKawaiiProceduralWindDynamicParams::* DynamicValue;
+	float FKawaiiProceduralWindPreset::* PresetValue;
+	float FKawaiiPhysics_ExternalForce_ProceduralWind::* WindValue;
+};
+
+const FWindPresetParamMapping GWindPresetParamMappings[] = {
+	{
+		TEXT("SteadyForce"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideSteadyForce,
+		&FKawaiiProceduralWindDynamicParams::SteadyForce,
+		&FKawaiiProceduralWindPreset::SteadyForce,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::SteadyForce
+	},
+	{
+		TEXT("OscillationForce"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideOscillationForce,
+		&FKawaiiProceduralWindDynamicParams::OscillationForce,
+		&FKawaiiProceduralWindPreset::OscillationForce,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::OscillationForce
+	},
+	{
+		TEXT("OscillationPeriod"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideOscillationPeriod,
+		&FKawaiiProceduralWindDynamicParams::OscillationPeriod,
+		&FKawaiiProceduralWindPreset::OscillationPeriod,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::OscillationPeriod
+	},
+	{
+		TEXT("WaveAmplitude"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideWaveAmplitude,
+		&FKawaiiProceduralWindDynamicParams::WaveAmplitude,
+		&FKawaiiProceduralWindPreset::WaveAmplitude,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::WaveAmplitude
+	},
+	{
+		TEXT("WavePeriod"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideWavePeriod,
+		&FKawaiiProceduralWindDynamicParams::WavePeriod,
+		&FKawaiiProceduralWindPreset::WavePeriod,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::WavePeriod
+	},
+	{
+		TEXT("WaveSpatialOffset"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideWaveSpatialOffset,
+		&FKawaiiProceduralWindDynamicParams::WaveSpatialOffset,
+		&FKawaiiProceduralWindPreset::WaveSpatialOffset,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::WaveSpatialOffset
+	},
+	{
+		TEXT("EnvelopeMin"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideEnvelopeMin,
+		&FKawaiiProceduralWindDynamicParams::EnvelopeMin,
+		&FKawaiiProceduralWindPreset::EnvelopeMin,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::EnvelopeMin
+	},
+	{
+		TEXT("EnvelopeMax"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideEnvelopeMax,
+		&FKawaiiProceduralWindDynamicParams::EnvelopeMax,
+		&FKawaiiProceduralWindPreset::EnvelopeMax,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::EnvelopeMax
+	},
+	{
+		TEXT("EnvelopeFrequency"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideEnvelopeFrequency,
+		&FKawaiiProceduralWindDynamicParams::EnvelopeFrequency,
+		&FKawaiiProceduralWindPreset::EnvelopeFrequency,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::EnvelopeFrequency
+	},
+	{
+		TEXT("RandomForce"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideRandomForce,
+		&FKawaiiProceduralWindDynamicParams::RandomForce,
+		&FKawaiiProceduralWindPreset::RandomForce,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::RandomForce
+	},
+	{
+		TEXT("RandomPeriod"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideRandomPeriod,
+		&FKawaiiProceduralWindDynamicParams::RandomPeriod,
+		&FKawaiiProceduralWindPreset::RandomPeriod,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::RandomPeriod
+	},
+	{
+		TEXT("DirectionNoiseAngle"),
+		&FKawaiiProceduralWindDynamicParams::bOverrideDirectionNoiseAngle,
+		&FKawaiiProceduralWindDynamicParams::DirectionNoiseAngle,
+		&FKawaiiProceduralWindPreset::DirectionNoiseAngle,
+		&FKawaiiPhysics_ExternalForce_ProceduralWind::DirectionNoiseAngle
+	}
+};
+
+bool TestFloatNear(FAutomationTestBase& Test, const FString& Name, const float Actual, const float Expected,
+                   const float Tol = GWindPresetTol)
+{
+	return Test.TestTrue(FString::Printf(TEXT("%s: got %.9f expected %.9f"), *Name, Actual, Expected),
+	                     FMath::IsNearlyEqual(Actual, Expected, Tol));
+}
+
+FKawaiiProceduralWindPreset MakeExpectedPreset(
+	const FGameplayTag& PresetTag,
+	const float SteadyForce,
+	const float OscillationForce,
+	const float OscillationPeriod,
+	const float WaveAmplitude,
+	const float WavePeriod,
+	const float WaveSpatialOffset,
+	const float EnvelopeMin,
+	const float EnvelopeMax,
+	const float EnvelopeFrequency,
+	const float RandomForce,
+	const float RandomPeriod,
+	const float DirectionNoiseAngle)
+{
+	FKawaiiProceduralWindPreset Preset;
+	Preset.PresetTag = PresetTag;
+	Preset.SteadyForce = SteadyForce;
+	Preset.OscillationForce = OscillationForce;
+	Preset.OscillationPeriod = OscillationPeriod;
+	Preset.WaveAmplitude = WaveAmplitude;
+	Preset.WavePeriod = WavePeriod;
+	Preset.WaveSpatialOffset = WaveSpatialOffset;
+	Preset.EnvelopeMin = EnvelopeMin;
+	Preset.EnvelopeMax = EnvelopeMax;
+	Preset.EnvelopeFrequency = EnvelopeFrequency;
+	Preset.RandomForce = RandomForce;
+	Preset.RandomPeriod = RandomPeriod;
+	Preset.DirectionNoiseAngle = DirectionNoiseAngle;
+	return Preset;
+}
+
+bool TestDynamicParamsMatchPreset(FAutomationTestBase& Test, const FString& Prefix,
+                                  const FKawaiiProceduralWindDynamicParams& Params,
+                                  const FKawaiiProceduralWindPreset& Preset)
+{
+	bool bOk = true;
+	for (const FWindPresetParamMapping& Mapping : GWindPresetParamMappings)
+	{
+		bOk &= Test.TestTrue(FString::Printf(TEXT("%s %s override"), *Prefix, Mapping.Name),
+		                     Params.*(Mapping.DynamicOverride));
+		bOk &= TestFloatNear(Test,
+		                      FString::Printf(TEXT("%s %s value"), *Prefix, Mapping.Name),
+		                      Params.*(Mapping.DynamicValue),
+		                      Preset.*(Mapping.PresetValue));
+	}
+	return bOk;
+}
+
+bool TestPresetValues(FAutomationTestBase& Test, const FString& Prefix,
+                      const FKawaiiProceduralWindPreset& Actual,
+                      const FKawaiiProceduralWindPreset& Expected)
+{
+	bool bOk = true;
+	bOk &= Test.TestTrue(FString::Printf(TEXT("%s PresetTag"), *Prefix),
+	                     Actual.PresetTag.MatchesTagExact(Expected.PresetTag));
+	for (const FWindPresetParamMapping& Mapping : GWindPresetParamMappings)
+	{
+		bOk &= TestFloatNear(Test,
+		                      FString::Printf(TEXT("%s %s"), *Prefix, Mapping.Name),
+		                      Actual.*(Mapping.PresetValue),
+		                      Expected.*(Mapping.PresetValue));
+	}
+	return bOk;
+}
+
+bool TestWindValuesMatchPreset(FAutomationTestBase& Test, const FString& Prefix,
+                               const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind,
+                               const FKawaiiProceduralWindPreset& Preset)
+{
+	bool bOk = true;
+	for (const FWindPresetParamMapping& Mapping : GWindPresetParamMappings)
+	{
+		bOk &= TestFloatNear(Test,
+		                      FString::Printf(TEXT("%s %s"), *Prefix, Mapping.Name),
+		                      Wind.*(Mapping.WindValue),
+		                      Preset.*(Mapping.PresetValue));
+	}
+	return bOk;
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetToDynamicParamsTest,
+                                 "KawaiiPhysics.WindPreset.ToDynamicParams",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetToDynamicParamsTest::RunTest(const FString& Parameters)
+{
+	FKawaiiProceduralWindPreset Preset;
+	Preset.SteadyForce = 3.25f;
+	Preset.OscillationForce = 2.5f;
+	Preset.OscillationPeriod = 1.75f;
+	Preset.WaveAmplitude = 4.5f;
+	Preset.WavePeriod = 0.65f;
+	Preset.WaveSpatialOffset = 135.0f;
+	Preset.EnvelopeMin = 0.35f;
+	Preset.EnvelopeMax = 1.45f;
+	Preset.EnvelopeFrequency = 0.12f;
+	Preset.RandomForce = 1.25f;
+	Preset.RandomPeriod = 0.42f;
+	Preset.DirectionNoiseAngle = 12.5f;
+
+	const FKawaiiProceduralWindDynamicParams Params = Preset.ToDynamicParams();
+
+	bool bOk = true;
+	bOk &= TestDynamicParamsMatchPreset(*this, TEXT("ToDynamicParams"), Params, Preset);
+	bOk &= TestFalse(TEXT("WindDirection override remains false"), Params.bOverrideWindDirection);
+	bOk &= TestFalse(TEXT("WavePhase override remains false"), Params.bOverrideWavePhase);
+	bOk &= TestFalse(TEXT("EnvelopePhase override remains false"), Params.bOverrideEnvelopePhase);
+	bOk &= TestFalse(TEXT("DirectionNoisePeriod override remains false"), Params.bOverrideDirectionNoisePeriod);
+	bOk &= TestFalse(TEXT("TimeScale override remains false"), Params.bOverrideTimeScale);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetDefaultsTest,
+                                 "KawaiiPhysics.WindPreset.Defaults",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetDefaultsTest::RunTest(const FString& Parameters)
+{
+	const TArray<FKawaiiProceduralWindPreset> Defaults = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+
+	bool bOk = true;
+	bOk &= TestEqual(TEXT("Default preset count"), Defaults.Num(), 3);
+	if (!bOk)
+	{
+		return false;
+	}
+
+	const FKawaiiProceduralWindPreset ExpectedBreeze = MakeExpectedPreset(
+		TAG_KawaiiPhysics_WindPreset_Breeze,
+		2.0f, 1.0f, 2.0f, 1.0f, 1.5f, 90.0f, 0.6f, 1.0f, 0.05f, 0.5f, 0.8f, 5.0f);
+	const FKawaiiProceduralWindPreset ExpectedStrong = MakeExpectedPreset(
+		TAG_KawaiiPhysics_WindPreset_Strong,
+		8.0f, 4.0f, 0.8f, 3.0f, 0.6f, 120.0f, 0.7f, 1.3f, 0.08f, 2.0f, 0.5f, 10.0f);
+	const FKawaiiProceduralWindPreset ExpectedStorm = MakeExpectedPreset(
+		TAG_KawaiiPhysics_WindPreset_Storm,
+		15.0f, 10.0f, 0.4f, 8.0f, 0.35f, 180.0f, 0.5f, 1.6f, 0.15f, 6.0f, 0.3f, 20.0f);
+
+	bOk &= TestPresetValues(*this, TEXT("Breeze"), Defaults[0], ExpectedBreeze);
+	bOk &= TestPresetValues(*this, TEXT("Strong"), Defaults[1], ExpectedStrong);
+	bOk &= TestPresetValues(*this, TEXT("Storm"), Defaults[2], ExpectedStorm);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetApplyRoundTripTest,
+                                 "KawaiiPhysics.WindPreset.ApplyRoundTrip",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetApplyRoundTripTest::RunTest(const FString& Parameters)
+{
+	const TArray<FKawaiiProceduralWindPreset> Defaults = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+	bool bOk = TestEqual(TEXT("Default preset count"), Defaults.Num(), 3);
+	if (!bOk)
+	{
+		return false;
+	}
+
+	const FKawaiiProceduralWindPreset& Preset = Defaults[1];
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	const float BeforeTimeScale = Wind.TimeScale;
+	const FRotator BeforeWindDirection = Wind.WindDirection;
+	const float BeforeWavePhase = Wind.WavePhase;
+	const float BeforeEnvelopePhase = Wind.EnvelopePhase;
+	const float BeforeDirectionNoisePeriod = Wind.DirectionNoisePeriod;
+
+	Wind.ApplyDynamicParams(Preset.ToDynamicParams());
+
+	bOk &= TestWindValuesMatchPreset(*this, TEXT("Strong applied"), Wind, Preset);
+	bOk &= TestFloatNear(*this, TEXT("TimeScale unchanged"), Wind.TimeScale, BeforeTimeScale);
+	bOk &= TestTrue(TEXT("WindDirection unchanged"), Wind.WindDirection.Equals(BeforeWindDirection));
+	bOk &= TestFloatNear(*this, TEXT("WavePhase unchanged"), Wind.WavePhase, BeforeWavePhase);
+	bOk &= TestFloatNear(*this, TEXT("EnvelopePhase unchanged"), Wind.EnvelopePhase, BeforeEnvelopePhase);
+	bOk &= TestFloatNear(*this, TEXT("DirectionNoisePeriod unchanged"),
+	                     Wind.DirectionNoisePeriod,
+	                     BeforeDirectionNoisePeriod);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetFindPresetByTagTest,
+                                 "KawaiiPhysics.WindPreset.FindPresetByTag",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetFindPresetByTagTest::RunTest(const FString& Parameters)
+{
+	UKawaiiPhysicsWindPresetDataAsset* DataAsset =
+		NewObject<UKawaiiPhysicsWindPresetDataAsset>(GetTransientPackage());
+	DataAsset->Presets = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+
+	bool bOk = TestEqual(TEXT("Default preset count"), DataAsset->Presets.Num(), 3);
+	if (!bOk)
+	{
+		return false;
+	}
+
+	const FKawaiiProceduralWindPreset* StrongPreset =
+		DataAsset->FindPresetByTag(TAG_KawaiiPhysics_WindPreset_Strong);
+	bOk &= TestTrue(TEXT("Strong preset is found"), StrongPreset != nullptr);
+	if (StrongPreset)
+	{
+		bOk &= TestTrue(TEXT("Strong preset tag matches"),
+		                StrongPreset->PresetTag.MatchesTagExact(TAG_KawaiiPhysics_WindPreset_Strong));
+		bOk &= TestFloatNear(*this, TEXT("Strong preset value"), StrongPreset->SteadyForce, 8.0f);
+	}
+
+	bOk &= TestTrue(TEXT("Empty tag returns null"), DataAsset->FindPresetByTag(FGameplayTag()) == nullptr);
+	bOk &= TestTrue(TEXT("Unregistered preset tag returns null"),
+	                DataAsset->FindPresetByTag(TAG_KawaiiPhysics_WindPreset_TestUnregistered) == nullptr);
+
+	FKawaiiProceduralWindPreset DuplicateStrong = DataAsset->Presets[1];
+	DuplicateStrong.SteadyForce = 123.0f;
+	DataAsset->Presets.Add(DuplicateStrong);
+
+	const FKawaiiProceduralWindPreset* FirstStrongPreset =
+		DataAsset->FindPresetByTag(TAG_KawaiiPhysics_WindPreset_Strong);
+	bOk &= TestTrue(TEXT("Duplicate tag returns first preset"), FirstStrongPreset == &DataAsset->Presets[1]);
+	if (FirstStrongPreset)
+	{
+		bOk &= TestFloatNear(*this, TEXT("Duplicate tag keeps first value"), FirstStrongPreset->SteadyForce, 8.0f);
+	}
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetResolveFallbackNullAssetStormTest,
+                                 "KawaiiPhysics.WindPreset.ResolveFallback.NullAssetStorm",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetResolveFallbackNullAssetStormTest::RunTest(const FString& Parameters)
+{
+	const TArray<FKawaiiProceduralWindPreset> Defaults = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+	const FKawaiiProceduralWindPreset* StormPreset = Defaults.FindByPredicate([](const FKawaiiProceduralWindPreset& Preset)
+	{
+		return Preset.PresetTag.MatchesTagExact(TAG_KawaiiPhysics_WindPreset_Storm);
+	});
+
+	bool bOk = TestTrue(TEXT("Storm default preset exists"), StormPreset != nullptr);
+	if (!StormPreset)
+	{
+		return false;
+	}
+
+	FKawaiiProceduralWindDynamicParams Params;
+	bOk &= TestTrue(TEXT("Null asset resolves Storm default"),
+	                UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+		                nullptr,
+		                TAG_KawaiiPhysics_WindPreset_Storm,
+		                Params));
+	bOk &= TestDynamicParamsMatchPreset(*this, TEXT("Storm fallback params"), Params, *StormPreset);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetResolveFallbackInvalidTagTest,
+                                 "KawaiiPhysics.WindPreset.ResolveFallback.InvalidTag",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetResolveFallbackInvalidTagTest::RunTest(const FString& Parameters)
+{
+	FKawaiiProceduralWindDynamicParams Params;
+	return TestFalse(TEXT("Null asset with empty tag does not resolve"),
+	                 UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+		                 nullptr,
+		                 FGameplayTag(),
+		                 Params));
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetResolveFallbackNonDefaultTagTest,
+                                 "KawaiiPhysics.WindPreset.ResolveFallback.NonDefaultTag",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetResolveFallbackNonDefaultTagTest::RunTest(const FString& Parameters)
+{
+	FKawaiiProceduralWindDynamicParams Params;
+	return TestFalse(TEXT("Null asset with non-default tag does not resolve"),
+	                 UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+		                 nullptr,
+		                 TAG_KawaiiPhysics_WindPreset_TestUnregistered,
+		                 Params));
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetResolveFallbackEmptyAssetStormTest,
+                                 "KawaiiPhysics.WindPreset.ResolveFallback.EmptyAssetStorm",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetResolveFallbackEmptyAssetStormTest::RunTest(const FString& Parameters)
+{
+	const TArray<FKawaiiProceduralWindPreset> Defaults = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+	const FKawaiiProceduralWindPreset* StormPreset = Defaults.FindByPredicate([](const FKawaiiProceduralWindPreset& Preset)
+	{
+		return Preset.PresetTag.MatchesTagExact(TAG_KawaiiPhysics_WindPreset_Storm);
+	});
+
+	bool bOk = TestTrue(TEXT("Storm default preset exists"), StormPreset != nullptr);
+	if (!StormPreset)
+	{
+		return false;
+	}
+
+	UKawaiiPhysicsWindPresetDataAsset* DataAsset =
+		NewObject<UKawaiiPhysicsWindPresetDataAsset>(GetTransientPackage());
+	DataAsset->Presets.Empty();
+
+	FKawaiiProceduralWindDynamicParams Params;
+	bOk &= TestTrue(TEXT("Empty asset resolves Storm default"),
+	                UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+		                DataAsset,
+		                TAG_KawaiiPhysics_WindPreset_Storm,
+		                Params));
+	bOk &= TestDynamicParamsMatchPreset(*this, TEXT("Empty asset Storm fallback params"), Params, *StormPreset);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetResolveFallbackConfiguredAssetMissTest,
+                                 "KawaiiPhysics.WindPreset.ResolveFallback.ConfiguredAssetMiss",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetResolveFallbackConfiguredAssetMissTest::RunTest(const FString& Parameters)
+{
+	UKawaiiPhysicsWindPresetDataAsset* DataAsset =
+		NewObject<UKawaiiPhysicsWindPresetDataAsset>(GetTransientPackage());
+
+	FKawaiiProceduralWindPreset CustomPreset;
+	CustomPreset.PresetTag = TAG_KawaiiPhysics_WindPreset_TestUnregistered;
+	CustomPreset.SteadyForce = 123.0f;
+	DataAsset->Presets.Add(CustomPreset);
+
+	FKawaiiProceduralWindDynamicParams Params;
+	return TestFalse(TEXT("Configured asset miss does not fall back to defaults"),
+	                 UKawaiiPhysicsWindPresetDataAsset::ResolvePresetParamsByTag(
+		                 DataAsset,
+		                 TAG_KawaiiPhysics_WindPreset_Storm,
+		                 Params));
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
@@ -1,0 +1,48 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "GameplayTagContainer.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+
+#include "AnimNotify_KawaiiPhysicsTriggerGust.generated.h"
+
+/**
+ * 単発の AnimNotify で ProceduralWind の突風をトリガーする（タグでフィルタ可能）。
+ * AnimNotify that triggers ProceduralWind gusts when fired (filterable by tag).
+ */
+UCLASS(Blueprintable, meta = (DisplayName = "KawaiiPhysics: Trigger Gust"))
+class KAWAIIPHYSICS_API UAnimNotify_KawaiiPhysicsTriggerGust : public UAnimNotify
+{
+	GENERATED_BODY()
+
+public:
+	UAnimNotify_KawaiiPhysicsTriggerGust(const FObjectInitializer& ObjectInitializer);
+
+	virtual FString GetNotifyName_Implementation() const override;
+
+	/** トリガー時に ProceduralWind の突風をリクエストする / Requests ProceduralWind gusts when the notify fires. */
+	virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation,
+	                    const FAnimNotifyEventReference& EventReference) override;
+
+public:
+	/** 突風の強さ / Gust strength. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ProceduralWind")
+	float Strength = 0.0f;
+
+	/** 立ち上がり時間（秒） / Rise time, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ProceduralWind", meta=(ClampMin="0.0", UIMin="0.0"))
+	float RiseTime = 0.0f;
+
+	/** 減衰時間（秒） / Decay time, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ProceduralWind", meta=(ClampMin="0.0", UIMin="0.0"))
+	float DecayTime = 0.0f;
+
+	/** 適用するノードを Tag でフィルタ（空なら全ノード対象） / Tags used to filter target nodes; empty targets all nodes. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Filter")
+	FGameplayTagContainer FilterTags;
+
+	/** Tag の完全一致でフィルタするか / Whether to filter tags by exact match. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Filter")
+	bool bFilterExactMatch = false;
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce.h
@@ -159,6 +159,14 @@ public:
 #endif
 
 protected:
+	/**
+	 * 外力ベクトルを現在のシミュレーション空間へ変換
+	 * Converts an external force vector to the current simulation space
+	 */
+	FVector ConvertExternalForceToSimulationSpace(FAnimNode_KawaiiPhysics& Node,
+	                                              FComponentSpacePoseContext& PoseContext,
+	                                              const FVector& InForce) const;
+
 	/** Checks if the external force can be applied to a bone */
 	bool CanApply(const FKawaiiPhysicsModifyBone& Bone) const;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -217,9 +217,9 @@ struct FKawaiiProceduralWindRuntimeState
 ///
 /**
 * パラメトリック合成風。UE の WindDirectionalSource に依存しない。
-* RandomForceScaleRange が (1,1) 以外の場合、毎フレームのランダムスケールにより決定性が失われる。
+* 合成式: Total = (SteadyForce + Oscillation + Wave) × Envelope + Random + Gust（Gust は TriggerProceduralWindGust API から発生）
 * Parametric synthesized wind. This does not depend on UE WindDirectionalSource.
-* If RandomForceScaleRange is not (1,1), the per-frame random scale makes the result non-deterministic.
+* Composition: Total = (SteadyForce + Oscillation + Wave) x Envelope + Random + Gust (Gust is triggered via the TriggerProceduralWindGust API).
 */
 USTRUCT(BlueprintType, DisplayName = "Procedural Wind")
 struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FKawaiiPhysics_ExternalForce
@@ -233,35 +233,35 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	}
 
 	/**
-	* 風方向。BP からは SetExternalForceRotatorProperty("WindDirection") で操作する。
-	* Wind direction. Use SetExternalForceRotatorProperty("WindDirection") to control this from BP.
+	* 風の吹く方向。BP からは SetExternalForceRotatorProperty("WindDirection") で変更可能
+	* Direction the wind blows. Controllable from BP via SetExternalForceRotatorProperty("WindDirection").
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	FRotator WindDirection = FRotator::ZeroRotator;
 
 	/**
-	* 方向揺らぎの円錐半角
-	* Cone half-angle for directional noise
+	* 風向き自体の揺らぎの円錐半角。向きの単調さを消す
+	* Cone half-angle of the wind direction wander. Breaks directional monotony.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, Units="Degrees", ClampMin=0, UIMin=0,
-		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, Units="Degrees", ClampMin=0, UIMin=0,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float DirectionNoiseAngle = 0.0f;
 
 	/**
-	* 方向揺らぎの周期（秒）
-	* Period for directional noise, in seconds
+	* 向きの揺らぎの周期（秒）
+	* Period of the direction wander, in seconds.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0.01, UIMin=0.01,
-		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=5, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float DirectionNoisePeriod = 1.0f;
 
 	/**
-	* 時間スケール
-	* Time scale
+	* この外力内の時間の進み。0で凍結、2で倍速
+	* Time scale of this force. 0 freezes, 2 doubles speed.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=20, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float TimeScale = 1.0f;
 
 	/**
@@ -270,120 +270,120 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	* Corrects the Force Rate applied to each bone.
 	* Multiplies the ForceRate by the curve value for "Length from RootBone to specific bone / Length from RootBone to end bone" (0.0~1.0)
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=5),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	FRuntimeFloatCurve ForceRateByBoneLengthRate;
 
 	/**
-	* 定常風力
-	* Steady wind force
+	* 常に一定で掛かる風の強さ。上げるとボーンが風下へ流されたままになる
+	* Constant wind strength. Higher values keep bones pushed downwind.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float SteadyForce = 0.0f;
 
 	/**
-	* 振動風力
-	* Oscillating wind force
+	* サイン波で周期的に強弱する成分の振幅。上げると規則的な揺れが強くなる
+	* Amplitude of the sine-based oscillation. Higher values strengthen the rhythmic sway.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=7, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float OscillationForce = 0.0f;
 
 	/**
-	* 振動周期（秒）
-	* Oscillation period, in seconds
+	* 振動の周期（秒）。短いほど速く揺れる
+	* Oscillation period in seconds. Shorter values sway faster.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0.01, UIMin=0.01,
-		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=8, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float OscillationPeriod = 1.0f;
 
 	/**
-	* 空間波の振幅
-	* Spatial wave amplitude
+	* ボーン列に沿って伝わる波成分の振幅。WaveSpatialOffset と組で使う
+	* Amplitude of the traveling wave along the bone chain. Use together with WaveSpatialOffset.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=9, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WaveAmplitude = 0.0f;
 
 	/**
-	* 空間波の周期（秒）
-	* Spatial wave period, in seconds
+	* 波の周期（秒）
+	* Wave period in seconds.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=5, ClampMin=0.01, UIMin=0.01,
-		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=10, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WavePeriod = 1.0f;
 
 	/**
-	* 空間波の位相
-	* Spatial wave phase
+	* 開始位相のオフセット。複数キャラや複数外力の揺れタイミングをずらす用途
+	* Initial phase offset. Use to desynchronize multiple characters or forces.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, Units="Degrees", PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=11, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WavePhase = 0.0f;
 
 	/**
-	* 毛先 r=1 での位相遅れ量。正の値で根元から毛先へ波が伝播する。
-	* Phase delay at tip r=1. Positive values make the wave propagate from root to tip.
+	* 毛先（LengthRate=1）での位相遅れ量。正の値で根元から毛先へ波が走って見える。0なら全ボーン同時に揺れる
+	* Phase delay at the tip. Positive values make the wave travel from root to tip; 0 sways all bones together.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=7, Units="Degrees", PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=12, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WaveSpatialOffset = 0.0f;
 
 	/**
-	* エンベロープ最大値
-	* Maximum envelope value
+	* 風全体の強弱のうねり（低周波変調）の上限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効
+	* Upper multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=13, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeMax = 1.0f;
 
 	/**
-	* エンベロープ最小値
-	* Minimum envelope value
+	* 風全体の強弱のうねり（低周波変調）の下限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効
+	* Lower multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=14, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeMin = 1.0f;
 
 	/**
-	* エンベロープ周波数（Hz）
-	* Envelope frequency, in Hz
+	* うねりの速さ（Hz）。低いほどゆったり
+	* Swell speed in Hz. Lower is slower.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=15, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeFrequency = 0.1f;
 
 	/**
-	* エンベロープ位相
-	* Envelope phase
+	* 開始位相のオフセット。複数キャラや複数外力の揺れタイミングをずらす用途
+	* Initial phase offset. Use to desynchronize multiple characters or forces.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, Units="Degrees", PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=16, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopePhase = 0.0f;
 
 	/**
-	* ランダム風力
-	* Random wind force
+	* 不規則な揺らぎ成分の強さ。自然なランダム感を足す
+	* Strength of the irregular fluctuation. Adds natural randomness.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=17, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float RandomForce = 0.0f;
 
 	/**
-	* ランダム風力の周期（秒）
-	* Random wind period, in seconds
+	* 揺らぎが変化する速さ（秒）。短いほど細かく震える
+	* How fast the fluctuation changes, in seconds. Shorter values jitter faster.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0.01, UIMin=0.01,
-		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=18, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float RandomPeriod = 0.5f;
 
 	/**
-	* ランダム風力のシード
-	* Random wind seed
+	* ランダム系列のシード。同じ値なら同じ揺らぎを再現できる。基底の RandomForceScaleRange が (1,1) 以外の場合は再現性が失われる
+	* Seed of the random sequence. Same seed reproduces the same fluctuation. Reproducibility is lost if the base RandomForceScaleRange is not (1,1).
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3),
-		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=19),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	int32 RandomSeed = 0;
 
 	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> RuntimeState;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -44,9 +44,156 @@ struct FKawaiiProceduralWindScopeSample
 	FKawaiiPhysicsProceduralWindSample Sample;
 };
 
+/**
+* ProceduralWind のランタイム更新パラメータ。bOverride が true の項目だけ次回 PreApply で反映される。
+* Runtime update parameters for ProceduralWind. Only entries whose bOverride flag is true are applied on the next PreApply.
+*/
+USTRUCT(BlueprintType)
+struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
+{
+	GENERATED_BODY()
+
+	/** WindDirection を上書きする / Override WindDirection. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideWindDirection = false;
+
+	/** 風方向 / Wind direction. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	FRotator WindDirection = FRotator::ZeroRotator;
+
+	/** SteadyForce を上書きする / Override SteadyForce. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideSteadyForce = false;
+
+	/** 定常風力 / Steady wind force. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float SteadyForce = 0.0f;
+
+	/** OscillationForce を上書きする / Override OscillationForce. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideOscillationForce = false;
+
+	/** 振動風力 / Oscillating wind force. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float OscillationForce = 0.0f;
+
+	/** OscillationPeriod を上書きする / Override OscillationPeriod. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideOscillationPeriod = false;
+
+	/** 振動周期（秒） / Oscillation period, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float OscillationPeriod = 1.0f;
+
+	/** WaveAmplitude を上書きする / Override WaveAmplitude. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideWaveAmplitude = false;
+
+	/** 空間波の振幅 / Spatial wave amplitude. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float WaveAmplitude = 0.0f;
+
+	/** WavePeriod を上書きする / Override WavePeriod. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideWavePeriod = false;
+
+	/** 空間波の周期（秒） / Spatial wave period, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float WavePeriod = 1.0f;
+
+	/** WavePhase を上書きする / Override WavePhase. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideWavePhase = false;
+
+	/** 空間波の位相 / Spatial wave phase. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float WavePhase = 0.0f;
+
+	/** WaveSpatialOffset を上書きする / Override WaveSpatialOffset. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideWaveSpatialOffset = false;
+
+	/** 毛先 r=1 での位相遅れ量 / Phase delay at tip r=1. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float WaveSpatialOffset = 0.0f;
+
+	/** EnvelopeMax を上書きする / Override EnvelopeMax. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideEnvelopeMax = false;
+
+	/** エンベロープ最大値 / Maximum envelope value. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float EnvelopeMax = 1.0f;
+
+	/** EnvelopeMin を上書きする / Override EnvelopeMin. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideEnvelopeMin = false;
+
+	/** エンベロープ最小値 / Minimum envelope value. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float EnvelopeMin = 1.0f;
+
+	/** EnvelopeFrequency を上書きする / Override EnvelopeFrequency. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideEnvelopeFrequency = false;
+
+	/** エンベロープ周波数（Hz） / Envelope frequency, in Hz. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float EnvelopeFrequency = 0.1f;
+
+	/** EnvelopePhase を上書きする / Override EnvelopePhase. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideEnvelopePhase = false;
+
+	/** エンベロープ位相 / Envelope phase. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float EnvelopePhase = 0.0f;
+
+	/** RandomForce を上書きする / Override RandomForce. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideRandomForce = false;
+
+	/** ランダム風力 / Random wind force. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float RandomForce = 0.0f;
+
+	/** RandomPeriod を上書きする / Override RandomPeriod. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideRandomPeriod = false;
+
+	/** ランダム風力の周期（秒） / Random wind period, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float RandomPeriod = 0.5f;
+
+	/** DirectionNoiseAngle を上書きする / Override DirectionNoiseAngle. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideDirectionNoiseAngle = false;
+
+	/** 方向揺らぎの円錐半角 / Cone half-angle for directional noise. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float DirectionNoiseAngle = 0.0f;
+
+	/** DirectionNoisePeriod を上書きする / Override DirectionNoisePeriod. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideDirectionNoisePeriod = false;
+
+	/** 方向揺らぎの周期（秒） / Period for directional noise, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float DirectionNoisePeriod = 1.0f;
+
+	/** TimeScale を上書きする / Override TimeScale. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideTimeScale = false;
+
+	/** 時間スケール / Time scale. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	float TimeScale = 1.0f;
+};
+
 struct FKawaiiProceduralWindRuntimeState
 {
 	FCriticalSection Mutex;
+	TOptional<FKawaiiProceduralWindDynamicParams> PendingParams;
 	TOptional<FKawaiiProceduralWindGustRequest> PendingGust;
 
 	float Time = 0.0f;
@@ -242,6 +389,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> RuntimeState;
 
 	void ResetRuntimeState();
+	void ApplyDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
+	void ConsumePendingRequests();
 
 	FKawaiiPhysicsProceduralWindSample ComputeWindSample(float InTime, float InLengthRate = 0.0f) const;
 	static uint32 StableHash(int32 Seed, int32 GridIndex, int32 Channel);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -1,0 +1,261 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "ExternalForces/KawaiiPhysicsExternalForce.h"
+
+#include "HAL/CriticalSection.h"
+#include "Math/RandomStream.h"
+#include "Misc/Optional.h"
+#include "Templates/SharedPointer.h"
+
+#include "KawaiiPhysicsExternalForce_ProceduralWind.generated.h"
+
+struct FKawaiiProceduralWindGustRequest
+{
+	float Strength = 0.0f;
+	float RiseTime = 0.0f;
+	float DecayTime = 0.0f;
+};
+
+struct FKawaiiProceduralWindActiveGust
+{
+	float StartTime = 0.0f;
+	float Strength = 0.0f;
+	float RiseTime = 0.0f;
+	float DecayTime = 0.0f;
+	bool bIsActive = false;
+};
+
+struct FKawaiiPhysicsProceduralWindSample
+{
+	float Steady = 0.0f;
+	float Oscillation = 0.0f;
+	float Wave = 0.0f;
+	float Envelope = 1.0f;
+	float Random = 0.0f;
+	float Gust = 0.0f;
+	float Total = 0.0f;
+};
+
+struct FKawaiiProceduralWindScopeSample
+{
+	float Time = 0.0f;
+	FKawaiiPhysicsProceduralWindSample Sample;
+};
+
+struct FKawaiiProceduralWindRuntimeState
+{
+	FCriticalSection Mutex;
+	TOptional<FKawaiiProceduralWindGustRequest> PendingGust;
+
+	float Time = 0.0f;
+	FKawaiiProceduralWindActiveGust ActiveGust;
+
+	float CachedSinesWithoutWave = 0.0f;
+	float CachedEnvelope = 1.0f;
+	float CachedRandom = 0.0f;
+	float CachedGust = 0.0f;
+	FVector CachedWindVector = FVector::ZeroVector;
+
+#if WITH_EDITOR
+	TArray<FKawaiiProceduralWindScopeSample> ScopeBuffer;
+	int32 ScopeWriteIndex = 0;
+	uint64 ScopeSampleCount = 0;
+#endif
+};
+
+///
+/// Procedural Wind
+///
+/**
+* パラメトリック合成風。UE の WindDirectionalSource に依存しない。
+* RandomForceScaleRange が (1,1) 以外の場合、毎フレームのランダムスケールにより決定性が失われる。
+* Parametric synthesized wind. This does not depend on UE WindDirectionalSource.
+* If RandomForceScaleRange is not (1,1), the per-frame random scale makes the result non-deterministic.
+*/
+USTRUCT(BlueprintType, DisplayName = "Procedural Wind")
+struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FKawaiiPhysics_ExternalForce
+{
+	GENERATED_BODY()
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind()
+	{
+		bCanSelectForceSpace = true;
+		ExternalForceSpace = EExternalForceSpace::WorldSpace;
+	}
+
+	/**
+	* 風方向。BP からは SetExternalForceRotatorProperty("WindDirection") で操作する。
+	* Wind direction. Use SetExternalForceRotatorProperty("WindDirection") to control this from BP.
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	FRotator WindDirection = FRotator::ZeroRotator;
+
+	/**
+	* 方向揺らぎの円錐半角
+	* Cone half-angle for directional noise
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, Units="Degrees", ClampMin=0, UIMin=0,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	float DirectionNoiseAngle = 0.0f;
+
+	/**
+	* 方向揺らぎの周期（秒）
+	* Period for directional noise, in seconds
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	float DirectionNoisePeriod = 1.0f;
+
+	/**
+	* 時間スケール
+	* Time scale
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	float TimeScale = 1.0f;
+
+	/**
+	* 各ボーンに適用するForce Rateを補正。
+	* 「RootBoneから特定のボーンまでの長さ / RootBoneから末端のボーンまでの長さ」(0.0~1.0)の値におけるカーブの値をForceRateに乗算
+	* Corrects the Force Rate applied to each bone.
+	* Multiplies the ForceRate by the curve value for "Length from RootBone to specific bone / Length from RootBone to end bone" (0.0~1.0)
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=5),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Common")
+	FRuntimeFloatCurve ForceRateByBoneLengthRate;
+
+	/**
+	* 定常風力
+	* Steady wind force
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float SteadyForce = 0.0f;
+
+	/**
+	* 振動風力
+	* Oscillating wind force
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float OscillationForce = 0.0f;
+
+	/**
+	* 振動周期（秒）
+	* Oscillation period, in seconds
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float OscillationPeriod = 1.0f;
+
+	/**
+	* 空間波の振幅
+	* Spatial wave amplitude
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float WaveAmplitude = 0.0f;
+
+	/**
+	* 空間波の周期（秒）
+	* Spatial wave period, in seconds
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=5, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float WavePeriod = 1.0f;
+
+	/**
+	* 空間波の位相
+	* Spatial wave phase
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float WavePhase = 0.0f;
+
+	/**
+	* 毛先 r=1 での位相遅れ量。正の値で根元から毛先へ波が伝播する。
+	* Phase delay at tip r=1. Positive values make the wave propagate from root to tip.
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=7, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Force")
+	float WaveSpatialOffset = 0.0f;
+
+	/**
+	* エンベロープ最大値
+	* Maximum envelope value
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	float EnvelopeMax = 1.0f;
+
+	/**
+	* エンベロープ最小値
+	* Minimum envelope value
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	float EnvelopeMin = 1.0f;
+
+	/**
+	* エンベロープ周波数（Hz）
+	* Envelope frequency, in Hz
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	float EnvelopeFrequency = 0.1f;
+
+	/**
+	* エンベロープ位相
+	* Envelope phase
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Envelope")
+	float EnvelopePhase = 0.0f;
+
+	/**
+	* ランダム風力
+	* Random wind force
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	float RandomForce = 0.0f;
+
+	/**
+	* ランダム風力の周期（秒）
+	* Random wind period, in seconds
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	float RandomPeriod = 0.5f;
+
+	/**
+	* ランダム風力のシード
+	* Random wind seed
+	*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=3),
+		Category="KawaiiPhysics|ExternalForce|ProceduralWind|Random")
+	int32 RandomSeed = 0;
+
+	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> RuntimeState;
+
+	void ResetRuntimeState();
+
+	FKawaiiPhysicsProceduralWindSample ComputeWindSample(float InTime, float InLengthRate = 0.0f) const;
+	static uint32 StableHash(int32 Seed, int32 GridIndex, int32 Channel);
+	static float NoiseValueAt(int32 GridIndex, int32 Seed, int32 Channel);
+	static float SampleSmoothNoise(float U, int32 Seed, int32 Channel = 0);
+
+	virtual void Initialize(const FAnimationInitializeContext& Context) override;
+	virtual void PreApply(FAnimNode_KawaiiPhysics& Node, FComponentSpacePoseContext& PoseContext) override;
+	virtual void Apply(FKawaiiPhysicsModifyBone& Bone, FAnimNode_KawaiiPhysics& Node,
+	                   FComponentSpacePoseContext& PoseContext,
+	                   const FTransform& BoneTM = FTransform::Identity) override;
+
+#if WITH_EDITOR
+	virtual void AnimDrawDebugForEditMode(const FKawaiiPhysicsModifyBone& ModifyBone,
+	                                      const FAnimNode_KawaiiPhysics& Node, FPrimitiveDrawInterface* PDI) override;
+#endif
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
@@ -6,6 +6,8 @@
 #include "Engine/DeveloperSettings.h"
 #include "KawaiiPhysicsDeveloperSettings.generated.h"
 
+class UKawaiiPhysicsWindPresetDataAsset;
+
 /** MCPノードの自動配置方向。Auto は非接続=縦積み、bAutoConnect=横並びの従来挙動 / Automatic placement direction for MCP nodes. Auto keeps legacy behavior: vertical when not connected, horizontal with bAutoConnect. */
 UENUM(BlueprintType)
 enum class EKawaiiPhysicsMcpNodePlacementDirection : uint8
@@ -110,6 +112,13 @@ public:
 	UPROPERTY(EditAnywhere, config, Category = "Performance Warnings",
 		meta = (DisplayName = "Bridge Dummy Warning Threshold", ClampMin = "0", UIMin = "0", UIMax = "1000"))
 	int32 BridgeDummyWarningThreshold = 200;
+
+	/**
+	* Wind Scope で表示する風プリセット DataAsset。未設定または Presets 空なら組み込み3種を表示、設定時は完全置換。
+	* Wind preset DataAsset shown by Wind Scope. Built-in three presets are shown when unset or Presets is empty; a configured asset fully replaces them.
+	*/
+	UPROPERTY(EditAnywhere, config, Category = "Wind Scope", meta = (DisplayName = "Wind Preset Data Asset"))
+	TSoftObjectPtr<UKawaiiPhysicsWindPresetDataAsset> WindScopePresetDataAsset;
 #endif
 
 	//~ UDeveloperSettings interface

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
@@ -16,6 +16,7 @@
 #include "KawaiiPhysicsLibrary.generated.h"
 
 class UMirrorDataTable;
+class UKawaiiPhysicsWindPresetDataAsset;
 
 UENUM()
 enum class EKawaiiPhysicsAccessExternalForceResult : uint8
@@ -513,6 +514,44 @@ public:
 	static int32 SetProceduralWindParametersOnComponent(
 		USkeletalMeshComponent* MeshComp,
 		const FKawaiiProceduralWindDynamicParams& Params,
+		const FGameplayTagContainer& FilterTags,
+		bool bFilterExactMatch = false);
+
+	/**
+	 * DataAsset のプリセットから ProceduralWind の動的パラメータ更新をリクエストする。プリセットの調整可能な12項目のみ上書きし、
+	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, DirectionNoisePeriod は維持する。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * PresetDataAsset が null または Presets 配列が空の場合は、組み込み既定プリセット3件（KawaiiPhysics.WindPreset.Breeze / Strong / Storm）からタグ照合する。
+	 * 呼び出し側で DataAsset を事前ロードし、シミュレーション中に編集または再ロードしないこと。
+	 * Request a ProceduralWind dynamic parameter update from a DataAsset preset. Only the preset's 12 tunable fields are overwritten;
+	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, and DirectionNoisePeriod are left untouched. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * When PresetDataAsset is null or its Presets array is empty, the tag is matched against the 3 built-in default presets (KawaiiPhysics.WindPreset.Breeze / Strong / Storm).
+	 * The DataAsset must be pre-loaded by the caller and must not be edited or reloaded while simulation is running.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
+	static FKawaiiPhysicsReference ApplyProceduralWindPreset(
+		EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+		const FKawaiiPhysicsReference& KawaiiPhysics,
+		int32 ExternalForceIndex,
+		const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset,
+		FGameplayTag PresetTag);
+
+	/**
+	 * DataAsset のプリセットから Component 内の ProceduralWind へ動的パラメータ更新を一括リクエストする。プリセットの調整可能な12項目のみ上書きし、
+	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, DirectionNoisePeriod は維持する。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * PresetDataAsset が null または Presets 配列が空の場合は、組み込み既定プリセット3件（KawaiiPhysics.WindPreset.Breeze / Strong / Storm）からタグ照合する。
+	 * 呼び出し側で DataAsset を事前ロードし、シミュレーション中に編集または再ロードしないこと。
+	 * Request dynamic parameter updates for ProceduralWind entries in a component from a DataAsset preset. Only the preset's 12 tunable fields are overwritten;
+	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, and DirectionNoisePeriod are left untouched. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * When PresetDataAsset is null or its Presets array is empty, the tag is matched against the 3 built-in default presets (KawaiiPhysics.WindPreset.Breeze / Strong / Storm).
+	 * The DataAsset must be pre-loaded by the caller and must not be edited or reloaded while simulation is running.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))
+	static int32 ApplyProceduralWindPresetOnComponent(
+		USkeletalMeshComponent* MeshComp,
+		const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset,
+		FGameplayTag PresetTag,
 		const FGameplayTagContainer& FilterTags,
 		bool bFilterExactMatch = false);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "AnimNode_KawaiiPhysics.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 #include "KawaiiPhysicsPresetDataAsset.h"
 #include "Animation/AnimNodeReference.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
@@ -462,6 +463,58 @@ public:
 	static bool RemoveExternalForcesFromComponent(USkeletalMeshComponent* MeshComp, UObject* Owner,
 	                                              UPARAM(ref) FGameplayTagContainer& FilterTags,
 	                                              bool bFilterExactMatch = false);
+
+	/**
+	 * ProceduralWind の突風をリクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * Request a ProceduralWind gust. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
+	static FKawaiiPhysicsReference TriggerProceduralWindGust(
+		EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+		const FKawaiiPhysicsReference& KawaiiPhysics,
+		int32 ExternalForceIndex,
+		float Strength,
+		float RiseTime,
+		float DecayTime);
+
+	/**
+	 * ProceduralWind の動的パラメータ更新をリクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * Request a ProceduralWind dynamic parameter update. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
+	static FKawaiiPhysicsReference SetProceduralWindParameters(
+		EKawaiiPhysicsAccessExternalForceResult& ExecResult,
+		const FKawaiiPhysicsReference& KawaiiPhysics,
+		int32 ExternalForceIndex,
+		const FKawaiiProceduralWindDynamicParams& Params);
+
+	/**
+	 * Component 内の ProceduralWind へ突風を一括リクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * Request a gust for ProceduralWind entries in a component. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))
+	static int32 TriggerProceduralWindGustOnComponent(
+		USkeletalMeshComponent* MeshComp,
+		float Strength,
+		float RiseTime,
+		float DecayTime,
+		const FGameplayTagContainer& FilterTags,
+		bool bFilterExactMatch = false);
+
+	/**
+	 * Component 内の ProceduralWind へ動的パラメータ更新を一括リクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
+	 * Request dynamic parameter updates for ProceduralWind entries in a component. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
+		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))
+	static int32 SetProceduralWindParametersOnComponent(
+		USkeletalMeshComponent* MeshComp,
+		const FKawaiiProceduralWindDynamicParams& Params,
+		const FGameplayTagContainer& FilterTags,
+		bool bFilterExactMatch = false);
 
 	/**
 	 * Set alpha (input) to all KawaiiPhysics nodes in the component (and linked/post-process instances).

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsWindPresetDataAsset.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsWindPresetDataAsset.h
@@ -1,0 +1,134 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "Engine/DataAsset.h"
+#include "GameplayTagContainer.h"
+#include "Misc/EngineVersionComparison.h"
+#include "KawaiiPhysicsWindPresetDataAsset.generated.h"
+
+#if WITH_EDITOR
+class FDataValidationContext;
+#endif
+
+USTRUCT(BlueprintType)
+struct KAWAIIPHYSICS_API FKawaiiProceduralWindPreset
+{
+	GENERATED_BODY()
+
+	/**
+	 * ランタイム API でプリセットを照合するためのキー
+	 * Key used by runtime APIs to match a wind preset.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Wind Preset")
+	FGameplayTag PresetTag;
+
+	/** 表示名 / Display name. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Wind Preset")
+	FText PresetName;
+
+	/** 常に一定で掛かる風の強さ / Constant wind strength. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float SteadyForce = 2.0f;
+
+	/** サイン波で周期的に強弱する成分の振幅 / Amplitude of the sine-based oscillation. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=7, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float OscillationForce = 1.0f;
+
+	/** 振動の周期（秒） / Oscillation period in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=8, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float OscillationPeriod = 2.0f;
+
+	/** ボーン列に沿って伝わる波成分の振幅 / Amplitude of the traveling wave along the bone chain. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=9, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float WaveAmplitude = 1.0f;
+
+	/** 波の周期（秒） / Wave period in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=10, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float WavePeriod = 1.5f;
+
+	/** 毛先（LengthRate=1）での位相遅れ量 / Phase delay at the tip. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=12, Units="Degrees", PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float WaveSpatialOffset = 90.0f;
+
+	/** 風全体の強弱のうねりの下限倍率 / Lower multiplier of the slow global intensity swell. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=14, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float EnvelopeMin = 0.6f;
+
+	/** 風全体の強弱のうねりの上限倍率 / Upper multiplier of the slow global intensity swell. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=13, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float EnvelopeMax = 1.0f;
+
+	/** うねりの速さ（Hz） / Swell speed in Hz. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=15, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float EnvelopeFrequency = 0.05f;
+
+	/** 不規則な揺らぎ成分の強さ / Strength of the irregular fluctuation. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=17, ClampMin=0, UIMin=0, PinHiddenByDefault),
+		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float RandomForce = 0.5f;
+
+	/** 揺らぎが変化する速さ（秒） / How fast the fluctuation changes, in seconds. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=18, ClampMin=0.01, UIMin=0.01,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float RandomPeriod = 0.8f;
+
+	/** 風向き自体の揺らぎの円錐半角 / Cone half-angle of the wind direction wander. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=4, Units="Degrees", ClampMin=0, UIMin=0,
+		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
+	float DirectionNoiseAngle = 5.0f;
+
+	/** 動的パラメータへ変換する / Convert to dynamic parameters. */
+	FKawaiiProceduralWindDynamicParams ToDynamicParams() const;
+};
+
+/**
+ * Wind Scope の風プリセットを保存する DataAsset。
+ * DataAsset that stores Wind Scope wind presets.
+ */
+UCLASS(Blueprintable)
+class KAWAIIPHYSICS_API UKawaiiPhysicsWindPresetDataAsset : public UDataAsset
+{
+	GENERATED_BODY()
+
+public:
+#if WITH_EDITORONLY_DATA
+	/** 説明 / Description. */
+	UPROPERTY(EditAnywhere, Category = "Description", meta = (MultiLine = true))
+	FText Description;
+#endif
+
+	/** Wind Scope に表示するプリセット一覧 / Presets shown in Wind Scope. */
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Wind Preset", meta=(TitleProperty="PresetName"))
+	TArray<FKawaiiProceduralWindPreset> Presets;
+
+	/** タグ完全一致で先頭のプリセットを探す / Find the first preset by exact tag match. */
+	const FKawaiiProceduralWindPreset* FindPresetByTag(FGameplayTag PresetTag) const;
+
+	/** DataAsset（null可）または組み込み既定からタグ照合して DynamicParams を解決 / Resolve params from the asset (nullable) or built-in defaults. */
+	static bool ResolvePresetParamsByTag(const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset, FGameplayTag PresetTag, FKawaiiProceduralWindDynamicParams& OutParams);
+
+#if WITH_EDITOR
+	// UObject インターフェース開始 / Begin UObject Interface.
+#if UE_VERSION_OLDER_THAN(5, 3, 0)
+	virtual EDataValidationResult IsDataValid(TArray<FText>& ValidationErrors) override;
+#else
+	virtual EDataValidationResult IsDataValid(FDataValidationContext& Context) const override;
+#endif
+	// UObject インターフェース終了 / End UObject Interface.
+#endif
+
+	/** 組み込みの Wind Scope プリセットを返す / Return built-in Wind Scope presets. */
+	static TArray<FKawaiiProceduralWindPreset> GetDefaultPresets();
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsWindPresetTags.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsWindPresetTags.h
@@ -1,0 +1,10 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "NativeGameplayTags.h"
+
+/** Wind Scope の組み込み風プリセットタグ / Built-in Wind Scope wind preset tags. */
+KAWAIIPHYSICS_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_KawaiiPhysics_WindPreset_Breeze);
+KAWAIIPHYSICS_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_KawaiiPhysics_WindPreset_Strong);
+KAWAIIPHYSICS_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_KawaiiPhysics_WindPreset_Storm);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -572,6 +572,7 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 	CustomizeDetailTools(DetailBuilder);
 	CustomizeDetailDebugVisualizations(DetailBuilder);
 
+	// External Forceカテゴリに Wind Scope ボタン（波形プレビューウィンドウを開く）を追加
 	IDetailCategoryBuilder& ExternalForceCategory = DetailBuilder.EditCategory(TEXT("Force|External Force"));
 	FDetailWidgetRow& WindScopeWidgetRow = ExternalForceCategory.AddCustomRow(LOCTEXT("OpenWindScope", "Wind Scope"));
 	WindScopeWidgetRow
@@ -1013,6 +1014,7 @@ void UAnimGraphNode_KawaiiPhysics::CheckPresetDiff()
 
 void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow()
 {
+	// ExternalForcesから最初のProceduralWindを探す
 	int32 ExternalForceIndex = INDEX_NONE;
 	for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
 	{
@@ -1033,6 +1035,7 @@ void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow()
 		return;
 	}
 
+	// ウィンドウへ渡す引数を組み立てて開く
 	const UAnimBlueprint* AnimBlueprint = GetAnimBlueprint();
 	FKawaiiPhysicsWindScopeWindowArgs Args;
 	Args.GraphNode = this;
@@ -1072,6 +1075,7 @@ void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UG
 		FSlateIcon(),
 		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::ApplyPresetDataAsset)));
 
+	// コンテキストメニューにも Wind Scope を追加
 	Section.AddMenuEntry(
 		"KawaiiPhysicsWindScope",
 		LOCTEXT("WindScopeContextMenu", "Wind Scope"),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -18,7 +18,9 @@
 #include "KawaiiPhysicsLimitsDataAsset.h"
 #include "KawaiiPhysicsPresetDataAsset.h"
 #include "KawaiiPhysicsPresetDiffSnapshot.h"
+#include "KawaiiPhysicsEdWindowUtils.h"
 #include "SKawaiiPhysicsPresetDiffWindow.h"
+#include "SKawaiiPhysicsWindScopeWindow.h"
 #include "Widgets/Input/SButton.h"
 #include "Framework/Commands/UIAction.h"
 #include "Framework/Notifications/NotificationManager.h"
@@ -411,6 +413,54 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetailTools(IDetailLayoutBuilder& De
 			[
 				SNew(STextBlock)
 				.Text(FText::FromString(TEXT("Check Preset Diff")))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+		]
+		+ SUniformGridPanel::Slot(2, 1)
+		[
+			SNew(SButton)
+			.HAlign(HAlign_Center)
+			.VAlign(VAlign_Center)
+			.ToolTipText(LOCTEXT("OpenWindScopeToolTip", "Procedural Wind の波形プレビューウィンドウを開く / Opens the waveform preview window for Procedural Wind."))
+			.OnClicked_Lambda([WeakThis = TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics>(this)]()
+			{
+				if (UAnimGraphNode_KawaiiPhysics* Node = WeakThis.Get())
+				{
+					int32 ExternalForceIndex = INDEX_NONE;
+					for (int32 Index = 0; Index < Node->Node.ExternalForces.Num(); ++Index)
+					{
+						if (Node->Node.ExternalForces[Index].IsValid() &&
+							Node->Node.ExternalForces[Index].GetScriptStruct() ==
+							FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
+						{
+							ExternalForceIndex = Index;
+							break;
+						}
+					}
+
+					if (ExternalForceIndex == INDEX_NONE)
+					{
+						KawaiiPhysicsEdWindowUtils::ShowNotification(
+							LOCTEXT("NoProceduralWindExternalForce", "Procedural Wind の外力がありません / No Procedural Wind external force on this node."),
+							SNotificationItem::CS_Fail);
+						return FReply::Handled();
+					}
+
+					const UAnimBlueprint* AnimBlueprint = Node->GetAnimBlueprint();
+					FKawaiiPhysicsWindScopeWindowArgs Args;
+					Args.GraphNode = Node;
+					Args.AnimBlueprintPath = AnimBlueprint ? FSoftObjectPath(AnimBlueprint) : FSoftObjectPath();
+					Args.NodeGuid = Node->NodeGuid;
+					Args.ExternalForceIndex = ExternalForceIndex;
+
+					SKawaiiPhysicsWindScopeWindow::OpenWindow(MoveTemp(Args));
+				}
+				return FReply::Handled();
+			})
+			.Content()
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("OpenWindScope", "Wind Scope"))
 				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
 			]
 		]

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -416,54 +416,6 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetailTools(IDetailLayoutBuilder& De
 				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
 			]
 		]
-		+ SUniformGridPanel::Slot(2, 1)
-		[
-			SNew(SButton)
-			.HAlign(HAlign_Center)
-			.VAlign(VAlign_Center)
-			.ToolTipText(LOCTEXT("OpenWindScopeToolTip", "Procedural Wind の波形プレビューウィンドウを開く / Opens the waveform preview window for Procedural Wind."))
-			.OnClicked_Lambda([WeakThis = TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics>(this)]()
-			{
-				if (UAnimGraphNode_KawaiiPhysics* Node = WeakThis.Get())
-				{
-					int32 ExternalForceIndex = INDEX_NONE;
-					for (int32 Index = 0; Index < Node->Node.ExternalForces.Num(); ++Index)
-					{
-						if (Node->Node.ExternalForces[Index].IsValid() &&
-							Node->Node.ExternalForces[Index].GetScriptStruct() ==
-							FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
-						{
-							ExternalForceIndex = Index;
-							break;
-						}
-					}
-
-					if (ExternalForceIndex == INDEX_NONE)
-					{
-						KawaiiPhysicsEdWindowUtils::ShowNotification(
-							LOCTEXT("NoProceduralWindExternalForce", "Procedural Wind の外力がありません / No Procedural Wind external force on this node."),
-							SNotificationItem::CS_Fail);
-						return FReply::Handled();
-					}
-
-					const UAnimBlueprint* AnimBlueprint = Node->GetAnimBlueprint();
-					FKawaiiPhysicsWindScopeWindowArgs Args;
-					Args.GraphNode = Node;
-					Args.AnimBlueprintPath = AnimBlueprint ? FSoftObjectPath(AnimBlueprint) : FSoftObjectPath();
-					Args.NodeGuid = Node->NodeGuid;
-					Args.ExternalForceIndex = ExternalForceIndex;
-
-					SKawaiiPhysicsWindScopeWindow::OpenWindow(MoveTemp(Args));
-				}
-				return FReply::Handled();
-			})
-			.Content()
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("OpenWindScope", "Wind Scope"))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-		]
 	];
 }
 
@@ -619,6 +571,30 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 
 	CustomizeDetailTools(DetailBuilder);
 	CustomizeDetailDebugVisualizations(DetailBuilder);
+
+	IDetailCategoryBuilder& ExternalForceCategory = DetailBuilder.EditCategory(TEXT("Force|External Force"));
+	FDetailWidgetRow& WindScopeWidgetRow = ExternalForceCategory.AddCustomRow(LOCTEXT("OpenWindScope", "Wind Scope"));
+	WindScopeWidgetRow
+	[
+		SNew(SButton)
+		.HAlign(HAlign_Center)
+		.VAlign(VAlign_Center)
+		.ToolTipText(LOCTEXT("OpenWindScopeToolTip", "Procedural Wind の波形プレビューウィンドウを開く / Opens the waveform preview window for Procedural Wind."))
+		.OnClicked_Lambda([WeakThis = TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics>(this)]()
+		{
+			if (UAnimGraphNode_KawaiiPhysics* Node = WeakThis.Get())
+			{
+				Node->OpenWindScopeWindow();
+			}
+			return FReply::Handled();
+		})
+		.Content()
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("OpenWindScope", "Wind Scope"))
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+		]
+	];
 
 	// Force order of details panel categories - Must set order for all of them as any that are edited automatically move to the top.
 	auto CategorySorter = [](const TMap<FName, IDetailCategoryBuilder*>& Categories)
@@ -1035,6 +1011,38 @@ void UAnimGraphNode_KawaiiPhysics::CheckPresetDiff()
 	SKawaiiPhysicsPresetDiffWindow::OpenWindow(MoveTemp(Args));
 }
 
+void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow()
+{
+	int32 ExternalForceIndex = INDEX_NONE;
+	for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+	{
+		if (Node.ExternalForces[Index].IsValid() &&
+			Node.ExternalForces[Index].GetScriptStruct() ==
+			FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
+		{
+			ExternalForceIndex = Index;
+			break;
+		}
+	}
+
+	if (ExternalForceIndex == INDEX_NONE)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("NoProceduralWindExternalForce", "Procedural Wind の外力がありません / No Procedural Wind external force on this node."),
+			SNotificationItem::CS_Fail);
+		return;
+	}
+
+	const UAnimBlueprint* AnimBlueprint = GetAnimBlueprint();
+	FKawaiiPhysicsWindScopeWindowArgs Args;
+	Args.GraphNode = this;
+	Args.AnimBlueprintPath = AnimBlueprint ? FSoftObjectPath(AnimBlueprint) : FSoftObjectPath();
+	Args.NodeGuid = NodeGuid;
+	Args.ExternalForceIndex = ExternalForceIndex;
+
+	SKawaiiPhysicsWindScopeWindow::OpenWindow(MoveTemp(Args));
+}
+
 void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UGraphNodeContextMenuContext* Context) const
 {
 	if (!Context || Context->bIsDebugging)
@@ -1063,6 +1071,14 @@ void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UG
 		        "プリセットDataAssetをこのノードへ適用します / Applies a preset data asset to this node."),
 		FSlateIcon(),
 		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::ApplyPresetDataAsset)));
+
+	Section.AddMenuEntry(
+		"KawaiiPhysicsWindScope",
+		LOCTEXT("WindScopeContextMenu", "Wind Scope"),
+		LOCTEXT("WindScopeMenuToolTip",
+		        "Procedural Wind の波形プレビューウィンドウを開きます / Opens the waveform preview window for Procedural Wind."),
+		FSlateIcon(),
+		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow)));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
@@ -8,6 +8,7 @@
 #include "PropertyEditorModule.h"
 #include "SKawaiiPhysicsNodeAuditWindow.h"
 #include "SKawaiiPhysicsPresetDiffWindow.h"
+#include "SKawaiiPhysicsWindScopeWindow.h"
 
 #define LOCTEXT_NAMESPACE "FKawaiiPhysicsModuleEd"
 
@@ -29,6 +30,7 @@ void FKawaiiPhysicsEdModule::StartupModule()
 
 void FKawaiiPhysicsEdModule::ShutdownModule()
 {
+	SKawaiiPhysicsWindScopeWindow::CloseAllWindows();
 	SKawaiiPhysicsPresetDiffWindow::CloseAllWindows();
 	SKawaiiPhysicsNodeAuditWindow::CloseAllWindows();
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
@@ -8,11 +8,13 @@
 
 namespace
 {
+	// FVector2D を ini 保存用の "X,Y" 文字列へ変換する
 	FString MakeVectorConfigString(const FVector2D& Value)
 	{
 		return FString::Printf(TEXT("%.0f,%.0f"), Value.X, Value.Y);
 	}
 
+	// MakeVectorConfigString で保存した "X,Y" 文字列を FVector2D へ復元する
 	bool TryParseVectorConfigString(const FString& StringValue, FVector2D& OutValue)
 	{
 		FString Left;
@@ -38,12 +40,14 @@ namespace KawaiiPhysicsEdWindowUtils
 	{
 		FNotificationInfo NotificationInfo(NotificationText);
 		NotificationInfo.ExpireDuration = ExpireDuration;
+		// Hyperlinkが設定されていれば通知に付与する
 		if (Hyperlink.IsBound())
 		{
 			NotificationInfo.Hyperlink = Hyperlink;
 			NotificationInfo.HyperlinkText = HyperlinkText;
 		}
 
+		// 通知を表示し、完了状態を設定する
 		TSharedPtr<SNotificationItem> NotificationItem =
 			FSlateNotificationManager::Get().AddNotification(NotificationInfo);
 		if (NotificationItem.IsValid())
@@ -57,6 +61,7 @@ namespace KawaiiPhysicsEdWindowUtils
 	                            const TCHAR* WindowPosConfigKey,
 	                            const TCHAR* WindowSizeConfigKey)
 	{
+		// commandlet等 GConfig 未初期化の環境では保存をスキップ
 		if (!GConfig)
 		{
 			return;
@@ -74,11 +79,13 @@ namespace KawaiiPhysicsEdWindowUtils
 	                            const TCHAR* WindowPosConfigKey,
 	                            const TCHAR* WindowSizeConfigKey)
 	{
+		// PersistWindowPlacementと同様、GConfig未初期化ならスキップ
 		if (!GConfig)
 		{
 			return;
 		}
 
+		// 位置・サイズは互いに独立して、パースに成功した場合のみ反映する
 		FString StringValue;
 		FVector2D ParsedValue;
 		if (GConfig->GetString(ConfigSectionName, WindowPosConfigKey, StringValue, GEditorPerProjectIni) &&

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
@@ -1,0 +1,96 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsEdWindowUtils.h"
+
+#include "Framework/Notifications/NotificationManager.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Widgets/SWindow.h"
+
+namespace
+{
+	FString MakeVectorConfigString(const FVector2D& Value)
+	{
+		return FString::Printf(TEXT("%.0f,%.0f"), Value.X, Value.Y);
+	}
+
+	bool TryParseVectorConfigString(const FString& StringValue, FVector2D& OutValue)
+	{
+		FString Left;
+		FString Right;
+		if (!StringValue.Split(TEXT(","), &Left, &Right))
+		{
+			return false;
+		}
+
+		OutValue.X = FCString::Atof(*Left);
+		OutValue.Y = FCString::Atof(*Right);
+		return true;
+	}
+}
+
+namespace KawaiiPhysicsEdWindowUtils
+{
+	void ShowNotification(const FText& NotificationText,
+	                      SNotificationItem::ECompletionState CompletionState,
+	                      float ExpireDuration,
+	                      const FSimpleDelegate& Hyperlink,
+	                      const FText& HyperlinkText)
+	{
+		FNotificationInfo NotificationInfo(NotificationText);
+		NotificationInfo.ExpireDuration = ExpireDuration;
+		if (Hyperlink.IsBound())
+		{
+			NotificationInfo.Hyperlink = Hyperlink;
+			NotificationInfo.HyperlinkText = HyperlinkText;
+		}
+
+		TSharedPtr<SNotificationItem> NotificationItem =
+			FSlateNotificationManager::Get().AddNotification(NotificationInfo);
+		if (NotificationItem.IsValid())
+		{
+			NotificationItem->SetCompletionState(CompletionState);
+		}
+	}
+
+	void PersistWindowPlacement(const TSharedRef<SWindow>& Window,
+	                            const TCHAR* ConfigSectionName,
+	                            const TCHAR* WindowPosConfigKey,
+	                            const TCHAR* WindowSizeConfigKey)
+	{
+		if (!GConfig)
+		{
+			return;
+		}
+
+		const FVector2D Position = Window->GetPositionInScreen();
+		const FVector2D Size = Window->GetSizeInScreen();
+		GConfig->SetString(ConfigSectionName, WindowPosConfigKey, *MakeVectorConfigString(Position), GEditorPerProjectIni);
+		GConfig->SetString(ConfigSectionName, WindowSizeConfigKey, *MakeVectorConfigString(Size), GEditorPerProjectIni);
+		GConfig->Flush(false, GEditorPerProjectIni);
+	}
+
+	void RestoreWindowPlacement(const TSharedRef<SWindow>& Window,
+	                            const TCHAR* ConfigSectionName,
+	                            const TCHAR* WindowPosConfigKey,
+	                            const TCHAR* WindowSizeConfigKey)
+	{
+		if (!GConfig)
+		{
+			return;
+		}
+
+		FString StringValue;
+		FVector2D ParsedValue;
+		if (GConfig->GetString(ConfigSectionName, WindowPosConfigKey, StringValue, GEditorPerProjectIni) &&
+			TryParseVectorConfigString(StringValue, ParsedValue))
+		{
+			Window->MoveWindowTo(ParsedValue);
+		}
+
+		if (GConfig->GetString(ConfigSectionName, WindowSizeConfigKey, StringValue, GEditorPerProjectIni) &&
+			TryParseVectorConfigString(StringValue, ParsedValue))
+		{
+			Window->Resize(ParsedValue);
+		}
+	}
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
@@ -7,6 +7,7 @@
 
 class SWindow;
 
+// PresetDiffWindow・WindScopeWindow など複数のエディタウィンドウで共有する通知/ウィンドウ位置ユーティリティ
 namespace KawaiiPhysicsEdWindowUtils
 {
 	/** Slate通知を表示する / Shows a Slate notification. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
@@ -1,0 +1,30 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/Notifications/SNotificationList.h"
+
+class SWindow;
+
+namespace KawaiiPhysicsEdWindowUtils
+{
+	/** Slate通知を表示する / Shows a Slate notification. */
+	void ShowNotification(const FText& NotificationText,
+	                      SNotificationItem::ECompletionState CompletionState,
+	                      float ExpireDuration = 5.0f,
+	                      const FSimpleDelegate& Hyperlink = FSimpleDelegate(),
+	                      const FText& HyperlinkText = FText::GetEmpty());
+
+	/** ウィンドウ位置とサイズを設定ファイルへ保存する / Persists window position and size to config. */
+	void PersistWindowPlacement(const TSharedRef<SWindow>& Window,
+	                            const TCHAR* ConfigSectionName,
+	                            const TCHAR* WindowPosConfigKey,
+	                            const TCHAR* WindowSizeConfigKey);
+
+	/** 設定ファイルからウィンドウ位置とサイズを復元する / Restores window position and size from config. */
+	void RestoreWindowPlacement(const TSharedRef<SWindow>& Window,
+	                            const TCHAR* ConfigSectionName,
+	                            const TCHAR* WindowPosConfigKey,
+	                            const TCHAR* WindowSizeConfigKey);
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
@@ -7,13 +7,12 @@
 #include "DesktopPlatformModule.h"
 #include "Dom/JsonObject.h"
 #include "Framework/Application/SlateApplication.h"
-#include "Framework/Notifications/NotificationManager.h"
 #include "HAL/PlatformProcess.h"
 #include "ISourceControlModule.h"
 #include "KawaiiPhysicsAuditCommandlet.h"
+#include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "KawaiiPhysicsPresetDiffSnapshot.h"
-#include "Misc/ConfigCacheIni.h"
 #include "Misc/FileHelper.h"
 #include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
@@ -46,91 +45,17 @@ namespace
 	TWeakPtr<SWindow> AuditWindowWeak;
 	TWeakPtr<SKawaiiPhysicsNodeAuditWindow> AuditWidgetWeak;
 
-	void ShowAuditNotification(const FText& NotificationText,
-	                            const SNotificationItem::ECompletionState CompletionState)
-	{
-		FNotificationInfo NotificationInfo(NotificationText);
-		NotificationInfo.ExpireDuration = 5.0f;
-
-		TSharedPtr<SNotificationItem> NotificationItem =
-			FSlateNotificationManager::Get().AddNotification(NotificationInfo);
-		if (NotificationItem.IsValid())
-		{
-			NotificationItem->SetCompletionState(CompletionState);
-		}
-	}
-
 	void ShowAuditExportSucceededNotification(const FString& OutputPath)
 	{
-		FNotificationInfo NotificationInfo(LOCTEXT("ExportSucceeded", "Exported Kawaii Physics audit results."));
-		NotificationInfo.ExpireDuration = 5.0f;
-		NotificationInfo.Hyperlink = FSimpleDelegate::CreateLambda([OutputPath]()
-		{
-			FPlatformProcess::ExploreFolder(*FPaths::GetPath(OutputPath));
-		});
-		NotificationInfo.HyperlinkText = LOCTEXT("ExportSucceededHyperlink", "Show in Folder");
-
-		TSharedPtr<SNotificationItem> NotificationItem =
-			FSlateNotificationManager::Get().AddNotification(NotificationInfo);
-		if (NotificationItem.IsValid())
-		{
-			NotificationItem->SetCompletionState(SNotificationItem::CS_Success);
-		}
-	}
-
-	FString MakeVectorConfigString(const FVector2D& Value)
-	{
-		return FString::Printf(TEXT("%.0f,%.0f"), Value.X, Value.Y);
-	}
-
-	bool TryParseVectorConfigString(const FString& StringValue, FVector2D& OutValue)
-	{
-		FString Left;
-		FString Right;
-		if (!StringValue.Split(TEXT(","), &Left, &Right))
-		{
-			return false;
-		}
-
-		OutValue.X = FCString::Atof(*Left);
-		OutValue.Y = FCString::Atof(*Right);
-		return true;
-	}
-
-	void PersistWindowPlacement(const TSharedRef<SWindow>& Window)
-	{
-		if (!GConfig)
-		{
-			return;
-		}
-
-		const FVector2D Position = Window->GetPositionInScreen();
-		const FVector2D Size = Window->GetSizeInScreen();
-		GConfig->SetString(ConfigSectionName, WindowPosConfigKey, *MakeVectorConfigString(Position), GEditorPerProjectIni);
-		GConfig->SetString(ConfigSectionName, WindowSizeConfigKey, *MakeVectorConfigString(Size), GEditorPerProjectIni);
-		GConfig->Flush(false, GEditorPerProjectIni);
-	}
-
-	void RestoreWindowPlacement(const TSharedRef<SWindow>& Window)
-	{
-		if (!GConfig)
-		{
-			return;
-		}
-
-		FString StringValue;
-		FVector2D ParsedValue;
-		if (GConfig->GetString(ConfigSectionName, WindowPosConfigKey, StringValue, GEditorPerProjectIni) &&
-			TryParseVectorConfigString(StringValue, ParsedValue))
-		{
-			Window->MoveWindowTo(ParsedValue);
-		}
-
-		if (GConfig->GetString(ConfigSectionName, WindowSizeConfigKey, StringValue, GEditorPerProjectIni) &&
-			TryParseVectorConfigString(StringValue, ParsedValue))
-		{
-			Window->Resize(ParsedValue);
-		}
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ExportSucceeded", "Exported Kawaii Physics audit results."),
+			SNotificationItem::CS_Success,
+			5.0f,
+			FSimpleDelegate::CreateLambda([OutputPath]()
+			{
+				FPlatformProcess::ExploreFolder(*FPaths::GetPath(OutputPath));
+			}),
+			LOCTEXT("ExportSucceededHyperlink", "Show in Folder"));
 	}
 
 	FText MakeAuditSummaryText(const TArray<TSharedPtr<FKawaiiPhysicsNodeAuditEntry>>& Entries)
@@ -319,7 +244,11 @@ void SKawaiiPhysicsNodeAuditWindow::OpenWindow(FKawaiiPhysicsNodeAuditWindowArgs
 
 	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
 	{
-		PersistWindowPlacement(ClosedWindow);
+		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
+			ClosedWindow,
+			ConfigSectionName,
+			WindowPosConfigKey,
+			WindowSizeConfigKey);
 		AuditWindowWeak.Reset();
 		AuditWidgetWeak.Reset();
 	}));
@@ -327,7 +256,11 @@ void SKawaiiPhysicsNodeAuditWindow::OpenWindow(FKawaiiPhysicsNodeAuditWindowArgs
 	AuditWindowWeak = Window;
 	AuditWidgetWeak = AuditWidget;
 	FSlateApplication::Get().AddWindow(Window);
-	RestoreWindowPlacement(Window);
+	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
+		Window,
+		ConfigSectionName,
+		WindowPosConfigKey,
+		WindowSizeConfigKey);
 }
 
 void SKawaiiPhysicsNodeAuditWindow::CloseAllWindows()
@@ -610,7 +543,7 @@ void SKawaiiPhysicsNodeAuditWindow::OnRowDoubleClicked(FEntryPtr Entry)
 	UAnimBlueprint* AnimBlueprint = Cast<UAnimBlueprint>(AnimBlueprintObject);
 	if (!AnimBlueprint || !GEditor)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("OpenAnimBlueprintFailed", "Failed to open the AnimBlueprint."),
 			SNotificationItem::CS_Fail);
 		return;
@@ -633,7 +566,7 @@ void SKawaiiPhysicsNodeAuditWindow::OnViewDiffClicked(FEntryPtr Entry)
 		UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(Entry->AnimBlueprintPath, Entry->NodeGuid);
 	if (!GraphNode)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ViewDiffResolveFailed", "Failed to resolve the KawaiiPhysics graph node."),
 			SNotificationItem::CS_Fail);
 		return;
@@ -643,7 +576,7 @@ void SKawaiiPhysicsNodeAuditWindow::OnViewDiffClicked(FEntryPtr Entry)
 		Cast<UKawaiiPhysicsPresetDataAsset>(Entry->MatchedPresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ViewDiffPresetLoadFailed", "Failed to load the matched preset."),
 			SNotificationItem::CS_Fail);
 		return;
@@ -715,7 +648,7 @@ FReply SKawaiiPhysicsNodeAuditWindow::OnRefreshClicked()
 	UKawaiiPhysicsPresetDataAsset* Preset = Cast<UKawaiiPhysicsPresetDataAsset>(PresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("RefreshPresetLoadFailed", "Failed to load the preset for Refresh."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -758,7 +691,7 @@ FReply SKawaiiPhysicsNodeAuditWindow::OnApplyToProjectClicked()
 	UKawaiiPhysicsPresetDataAsset* Preset = Cast<UKawaiiPhysicsPresetDataAsset>(PresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplyToProjectPresetLoadFailed", "Failed to load the preset for Apply to Project."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -769,7 +702,7 @@ FReply SKawaiiPhysicsNodeAuditWindow::OnApplyToProjectClicked()
 		UKawaiiPhysicsEditorLibrary::ReapplyPresetToProject(Preset, false, bCheckOutFiles, Report);
 	ReplaceEntriesFromReport(Report);
 
-	ShowAuditNotification(
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		FText::Format(
 			LOCTEXT("ApplyToProjectSucceeded", "Applied preset to {0} node(s)."),
 			FText::AsNumber(AppliedCount)),
@@ -814,7 +747,7 @@ FReply SKawaiiPhysicsNodeAuditWindow::OnExportClicked()
 
 	if (!bWriteOk)
 	{
-		ShowAuditNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ExportFailed", "Failed to export the Kawaii Physics audit results."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
@@ -8,11 +8,10 @@
 #include "Misc/MessageDialog.h"
 #include "EdGraph/EdGraph.h"
 #include "Framework/Application/SlateApplication.h"
-#include "Framework/Notifications/NotificationManager.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
-#include "Misc/ConfigCacheIni.h"
 #include "ScopedTransaction.h"
 #include "Styling/AppStyle.h"
 #include "Subsystems/AssetEditorSubsystem.h"
@@ -47,75 +46,6 @@ namespace
 
 	TWeakPtr<SWindow> DiffWindowWeak;
 	TWeakPtr<SKawaiiPhysicsPresetDiffWindow> DiffWidgetWeak;
-
-	void ShowPresetDiffNotification(const FText& NotificationText,
-	                                const SNotificationItem::ECompletionState CompletionState)
-	{
-		FNotificationInfo NotificationInfo(NotificationText);
-		NotificationInfo.ExpireDuration = 5.0f;
-
-		TSharedPtr<SNotificationItem> NotificationItem =
-			FSlateNotificationManager::Get().AddNotification(NotificationInfo);
-		if (NotificationItem.IsValid())
-		{
-			NotificationItem->SetCompletionState(CompletionState);
-		}
-	}
-
-	FString MakePresetDiffVectorString(const FVector2D& Value)
-	{
-		return FString::Printf(TEXT("%.0f,%.0f"), Value.X, Value.Y);
-	}
-
-	bool TryParsePresetDiffVectorString(const FString& StringValue, FVector2D& OutValue)
-	{
-		FString Left;
-		FString Right;
-		if (!StringValue.Split(TEXT(","), &Left, &Right))
-		{
-			return false;
-		}
-
-		OutValue.X = FCString::Atof(*Left);
-		OutValue.Y = FCString::Atof(*Right);
-		return true;
-	}
-
-	void PersistPresetDiffPlacement(const TSharedRef<SWindow>& Window)
-	{
-		if (!GConfig)
-		{
-			return;
-		}
-
-		const FVector2D Position = Window->GetPositionInScreen();
-		const FVector2D Size = Window->GetSizeInScreen();
-		GConfig->SetString(PresetDiffConfigSection, PresetDiffPositionKey, *MakePresetDiffVectorString(Position), GEditorPerProjectIni);
-		GConfig->SetString(PresetDiffConfigSection, PresetDiffSizeKey, *MakePresetDiffVectorString(Size), GEditorPerProjectIni);
-		GConfig->Flush(false, GEditorPerProjectIni);
-	}
-
-	void RestorePresetDiffPlacement(const TSharedRef<SWindow>& Window)
-	{
-		if (!GConfig)
-		{
-			return;
-		}
-
-		FString StringValue;
-		FVector2D ParsedValue;
-		if (GConfig->GetString(PresetDiffConfigSection, PresetDiffPositionKey, StringValue, GEditorPerProjectIni) &&
-			TryParsePresetDiffVectorString(StringValue, ParsedValue))
-		{
-			Window->MoveWindowTo(ParsedValue);
-		}
-
-		if (GConfig->GetString(PresetDiffConfigSection, PresetDiffSizeKey, StringValue, GEditorPerProjectIni) &&
-			TryParsePresetDiffVectorString(StringValue, ParsedValue))
-		{
-			Window->Resize(ParsedValue);
-		}
-	}
 
 	FKawaiiPhysicsGraphNodeHandle MakePresetDiffHandle(UAnimGraphNode_KawaiiPhysics* GraphNode)
 	{
@@ -587,7 +517,11 @@ void SKawaiiPhysicsPresetDiffWindow::OpenWindow(FKawaiiPhysicsPresetDiffWindowAr
 
 	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
 	{
-		PersistPresetDiffPlacement(ClosedWindow);
+		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
+			ClosedWindow,
+			PresetDiffConfigSection,
+			PresetDiffPositionKey,
+			PresetDiffSizeKey);
 		DiffWindowWeak.Reset();
 		DiffWidgetWeak.Reset();
 	}));
@@ -595,7 +529,11 @@ void SKawaiiPhysicsPresetDiffWindow::OpenWindow(FKawaiiPhysicsPresetDiffWindowAr
 	DiffWindowWeak = Window;
 	DiffWidgetWeak = DiffWidget;
 	FSlateApplication::Get().AddWindow(Window);
-	RestorePresetDiffPlacement(Window);
+	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
+		Window,
+		PresetDiffConfigSection,
+		PresetDiffPositionKey,
+		PresetDiffSizeKey);
 }
 
 void SKawaiiPhysicsPresetDiffWindow::CloseAllWindows()
@@ -663,7 +601,7 @@ void SKawaiiPhysicsPresetDiffWindow::OnRowDoubleClicked(FRowPtr Row)
 	UAnimBlueprint* AnimBlueprint = Cast<UAnimBlueprint>(AnimBlueprintObject);
 	if (!AnimBlueprint || !GEditor)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("OpenAnimBlueprintFailed", "Failed to open the AnimBlueprint."),
 			SNotificationItem::CS_Fail);
 		return;
@@ -745,7 +683,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnOpenPresetClicked()
 	UObject* PresetObject = SelectedSnapshot->PresetPath.TryLoad();
 	if (!PresetObject)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("OpenPresetFailed", "Failed to load the selected preset."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -767,7 +705,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnCopyClicked()
 
 	const FString ClipboardText = KawaiiPhysicsPresetDiff::SnapshotToClipboardText(*SelectedSnapshot, ContextLabel);
 	FPlatformApplicationMisc::ClipboardCopy(*ClipboardText);
-	ShowPresetDiffNotification(
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		LOCTEXT("CopySucceeded", "Copied preset diff to clipboard."),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
@@ -777,7 +715,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnRefreshClicked()
 {
 	if (!RebuildAllSnapshotsKeepingPreset())
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("RefreshResolveFailed", "Failed to resolve the KawaiiPhysics node."),
 			SNotificationItem::CS_Fail);
 	}
@@ -795,7 +733,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplySelectedClicked()
 		UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(AnimBlueprintPath, NodeGuid);
 	if (!GraphNode || !GraphNode->GetGraph() || !GraphNode->GetGraph()->Nodes.Contains(GraphNode))
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplySelectedResolveFailed", "Failed to resolve the KawaiiPhysics graph node."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -805,7 +743,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplySelectedClicked()
 		Cast<UKawaiiPhysicsPresetDataAsset>(SelectedSnapshot->PresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplySelectedPresetLoadFailed", "Failed to load the selected preset."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -817,7 +755,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplySelectedClicked()
 	if (!SnapshotRowsMatch(*SelectedSnapshot, *FreshSnapshot, &SelectedPropertyNames))
 	{
 		ReplaceSelectedSnapshot(FreshSnapshot);
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplySelectedPresetChanged", "The preset or node changed. Review the refreshed diff before applying."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -830,7 +768,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplySelectedClicked()
 	if (!CopyPropertiesByName(Names, true, GraphNode->Node, *Preset, GraphNode))
 	{
 		Transaction.Cancel();
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplySelectedCopyFailed", "Failed to copy one or more selected properties."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -842,7 +780,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplySelectedClicked()
 
 	ReplaceSelectedSnapshot(KawaiiPhysicsPresetDiff::BuildSnapshot(GraphNode->Node, *Preset, Options));
 	SelectedPropertyNames.Reset();
-	ShowPresetDiffNotification(
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		LOCTEXT("ApplySelectedSucceeded", "Applied selected properties to the node."),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
@@ -859,7 +797,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplyPresetToNodeClicked()
 		UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(AnimBlueprintPath, NodeGuid);
 	if (!GraphNode || !GraphNode->GetGraph() || !GraphNode->GetGraph()->Nodes.Contains(GraphNode))
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplyPresetResolveFailed", "Failed to resolve the KawaiiPhysics graph node."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -869,7 +807,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplyPresetToNodeClicked()
 		Cast<UKawaiiPhysicsPresetDataAsset>(SelectedSnapshot->PresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplyPresetLoadFailed", "Failed to load the selected preset."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -881,7 +819,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplyPresetToNodeClicked()
 	if (!SnapshotRowsMatch(*SelectedSnapshot, *FreshSnapshot, nullptr))
 	{
 		ReplaceSelectedSnapshot(FreshSnapshot);
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplyPresetChanged", "The preset or node changed. Review the refreshed diff before applying."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -889,7 +827,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplyPresetToNodeClicked()
 
 	if (!UKawaiiPhysicsEditorLibrary::ApplyPresetToGraphNode(MakePresetDiffHandle(GraphNode), Preset, Options))
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("ApplyPresetFailed", "Failed to apply the preset to the node."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -897,7 +835,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnApplyPresetToNodeClicked()
 
 	ReplaceSelectedSnapshot(KawaiiPhysicsPresetDiff::BuildSnapshot(GraphNode->Node, *Preset, Options));
 	SelectedPropertyNames.Reset();
-	ShowPresetDiffNotification(
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		LOCTEXT("ApplyPresetSucceeded", "Applied the preset to the node."),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
@@ -915,7 +853,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 		                      : GetDifferingPropertyNames(*SelectedSnapshot);
 	if (Names.IsEmpty())
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("NoPresetPropertiesToUpdate", "No differing properties to update."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -936,7 +874,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 		UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(AnimBlueprintPath, NodeGuid);
 	if (!GraphNode)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("UpdatePresetResolveFailed", "Failed to resolve the KawaiiPhysics graph node."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -946,7 +884,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 		Cast<UKawaiiPhysicsPresetDataAsset>(SelectedSnapshot->PresetPath.TryLoad());
 	if (!Preset)
 	{
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("UpdatePresetLoadFailed", "Failed to load the selected preset."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -958,7 +896,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 	if (!CopyPropertiesByName(Names, false, GraphNode->Node, *Preset, Preset))
 	{
 		Transaction.Cancel();
-		ShowPresetDiffNotification(
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("UpdatePresetCopyFailed", "Failed to copy one or more properties to the preset."),
 			SNotificationItem::CS_Fail);
 		return FReply::Handled();
@@ -968,7 +906,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 	const FKawaiiPhysicsPresetApplyOptions Options;
 	ReplaceSelectedSnapshot(KawaiiPhysicsPresetDiff::BuildSnapshot(GraphNode->Node, *Preset, Options));
 	SelectedPropertyNames.Reset();
-	ShowPresetDiffNotification(
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		LOCTEXT("UpdatePresetSucceeded", "Updated the preset from the node."),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -8,6 +8,7 @@
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 #include "Framework/Application/SlateApplication.h"
 #include "HAL/CriticalSection.h"
+#include "KawaiiPhysicsDeveloperSettings.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
@@ -129,6 +130,49 @@ namespace
 			return RequestedIndex;
 		}
 		return FindFirstProceduralWindIndex(Node);
+	}
+
+	TArray<FKawaiiProceduralWindPreset> ResolveWindScopePresets()
+	{
+		if (const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>())
+		{
+			if (const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset =
+				Settings->WindScopePresetDataAsset.LoadSynchronous())
+			{
+				if (PresetDataAsset->Presets.Num() > 0)
+				{
+					return PresetDataAsset->Presets;
+				}
+			}
+		}
+
+		return UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+	}
+
+	FText ResolveWindPresetDisplayName(const FKawaiiProceduralWindPreset& Preset, int32 PresetIndex)
+	{
+		if (!Preset.PresetName.IsEmpty())
+		{
+			return Preset.PresetName;
+		}
+
+		if (Preset.PresetTag.IsValid())
+		{
+			const FString TagString = Preset.PresetTag.GetTagName().ToString();
+			FString ParentName;
+			FString LeafName;
+			if (TagString.Split(TEXT("."), &ParentName, &LeafName, ESearchCase::CaseSensitive, ESearchDir::FromEnd) &&
+				!LeafName.IsEmpty())
+			{
+				return FText::FromString(LeafName);
+			}
+			if (!TagString.IsEmpty())
+			{
+				return FText::FromString(TagString);
+			}
+		}
+
+		return FText::Format(LOCTEXT("WindPresetFallbackNameFormat", "Preset {0}"), FText::AsNumber(PresetIndex));
 	}
 
 	// サンプルが無い時の初期表示値。Envelope=1にして Total=0（無風）を表すサンプルにする
@@ -614,34 +658,34 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.ColorAndOpacity(FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen")))
 			]
 		]
-		// プリセットボタン列（Breeze / Strong / Storm）
+		// プリセットボタン列
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(8.0f, 2.0f)
 		[
 			SNew(SHorizontalBox)
 			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+			.FillWidth(1.0f)
+			.VAlign(VAlign_Center)
 			[
-				SNew(SButton)
-				.Text(LOCTEXT("BreezePresetButton", "Breeze / そよ風"))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnBreezePresetClicked)
+				SAssignNew(PresetButtonBox, SWrapBox)
+				.UseAllottedSize(true)
+				.InnerSlotPadding(FVector2D(4.0f, 2.0f))
 			]
 			+ SHorizontalBox::Slot()
 			.AutoWidth()
-			.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
 			[
 				SNew(SButton)
-				.Text(LOCTEXT("StrongPresetButton", "Strong / 強風"))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnStrongPresetClicked)
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("StormPresetButton", "Storm / 嵐"))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnStormPresetClicked)
+				.Text(LOCTEXT("ReloadPresetsButton", "Reload"))
+				.ContentPadding(FMargin(6.0f, 2.0f))
+				.ToolTipText(LOCTEXT("ReloadPresetsTooltip", "プリセットDataAssetを再読み込みします / Reload the preset DataAsset."))
+				.OnClicked_Lambda([this]()
+				{
+					RebuildPresetButtons();
+					return FReply::Handled();
+				})
 			]
 		]
 		// 凡例（系列ごとの表示切替チェックボックス）
@@ -724,6 +768,8 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 			]
 		]
 	];
+
+	RebuildPresetButtons();
 
 	// 60fps 相当でティックし、Live/Preview のサンプル更新とグラフ再描画を行う
 	RegisterActiveTimer(1.0f / 60.0f, FWidgetActiveTimerDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::TickWindScope));
@@ -895,74 +941,37 @@ void SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged(float NewValue)
 	}
 }
 
-// 以下3つは強さの異なる決め打ちプリセット（そよ風/強風/嵐）を ApplyPreset に渡すだけの薄いラッパー
-FReply SKawaiiPhysicsWindScopeWindow::OnBreezePresetClicked()
+void SKawaiiPhysicsWindScopeWindow::RebuildPresetButtons()
 {
-	return ApplyPreset(
-		2.0f,
-		1.0f,
-		2.0f,
-		1.0f,
-		1.5f,
-		90.0f,
-		0.6f,
-		1.0f,
-		0.05f,
-		0.5f,
-		0.8f,
-		5.0f,
-		LOCTEXT("BreezePresetName", "Breeze"));
+	CachedPresets = ResolveWindScopePresets();
+	if (!PresetButtonBox.IsValid())
+	{
+		return;
+	}
+
+	PresetButtonBox->ClearChildren();
+	for (int32 PresetIndex = 0; PresetIndex < CachedPresets.Num(); ++PresetIndex)
+	{
+		PresetButtonBox->AddSlot()
+		[
+			SNew(SButton)
+			.Text(ResolveWindPresetDisplayName(CachedPresets[PresetIndex], PresetIndex))
+			.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked, PresetIndex)
+		];
+	}
 }
 
-FReply SKawaiiPhysicsWindScopeWindow::OnStrongPresetClicked()
+FReply SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked(int32 PresetIndex)
 {
-	return ApplyPreset(
-		8.0f,
-		4.0f,
-		0.8f,
-		3.0f,
-		0.6f,
-		120.0f,
-		0.7f,
-		1.3f,
-		0.08f,
-		2.0f,
-		0.5f,
-		10.0f,
-		LOCTEXT("StrongPresetName", "Strong"));
+	if (!CachedPresets.IsValidIndex(PresetIndex))
+	{
+		return FReply::Handled();
+	}
+
+	return ApplyPreset(CachedPresets[PresetIndex]);
 }
 
-FReply SKawaiiPhysicsWindScopeWindow::OnStormPresetClicked()
-{
-	return ApplyPreset(
-		15.0f,
-		10.0f,
-		0.4f,
-		8.0f,
-		0.35f,
-		180.0f,
-		0.5f,
-		1.6f,
-		0.15f,
-		6.0f,
-		0.3f,
-		20.0f,
-		LOCTEXT("StormPresetName", "Storm"));
-}
-
-FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
-                                                  float OscillationForce,
-                                                  float OscillationPeriod,
-                                                  float WaveAmplitude,
-                                                  float WavePeriod,
-                                                  float WaveSpatialOffset,
-                                                  float EnvelopeMin,
-                                                  float EnvelopeMax,
-                                                  float EnvelopeFrequency,
-                                                  float RandomForce,
-                                                  float RandomPeriod,
-                                                  float DirectionNoiseAngle,
-                                                  const FText& PresetName)
+FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPreset& Preset)
 {
 	// 対象グラフノードを解決（失敗時は通知して終了）
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
@@ -998,26 +1007,31 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
 	const FScopedTransaction Transaction(LOCTEXT("ApplyWindPresetTransaction", "Apply Kawaii Physics Wind Preset"));
 	GraphNode->Modify();
 	Wind->bIsEnabled = true;
-	Wind->SteadyForce = SteadyForce;
-	Wind->OscillationForce = OscillationForce;
-	Wind->OscillationPeriod = OscillationPeriod;
-	Wind->WaveAmplitude = WaveAmplitude;
-	Wind->WavePeriod = WavePeriod;
-	Wind->WaveSpatialOffset = WaveSpatialOffset;
-	Wind->EnvelopeMin = EnvelopeMin;
-	Wind->EnvelopeMax = EnvelopeMax;
-	Wind->EnvelopeFrequency = EnvelopeFrequency;
-	Wind->RandomForce = RandomForce;
-	Wind->RandomPeriod = RandomPeriod;
-	Wind->DirectionNoiseAngle = DirectionNoiseAngle;
+	Wind->SteadyForce = Preset.SteadyForce;
+	Wind->OscillationForce = Preset.OscillationForce;
+	Wind->OscillationPeriod = Preset.OscillationPeriod;
+	Wind->WaveAmplitude = Preset.WaveAmplitude;
+	Wind->WavePeriod = Preset.WavePeriod;
+	Wind->WaveSpatialOffset = Preset.WaveSpatialOffset;
+	Wind->EnvelopeMin = Preset.EnvelopeMin;
+	Wind->EnvelopeMax = Preset.EnvelopeMax;
+	Wind->EnvelopeFrequency = Preset.EnvelopeFrequency;
+	Wind->RandomForce = Preset.RandomForce;
+	Wind->RandomPeriod = Preset.RandomPeriod;
+	Wind->DirectionNoiseAngle = Preset.DirectionNoiseAngle;
 	Wind->TimeScale = 1.0f;
 	MarkWindScopeGraphNodeModified(GraphNode);
 
 	// 外力一覧を更新し、成功通知を表示
 	Args.ExternalForceIndex = ResolvedIndex;
 	RefreshExternalForceItems();
+	const int32 PresetIndex = CachedPresets.IndexOfByPredicate([&Preset](const FKawaiiProceduralWindPreset& CachedPreset)
+	{
+		return &CachedPreset == &Preset;
+	});
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
-		FText::Format(LOCTEXT("ApplyPresetSucceeded", "Applied {0} wind preset."), PresetName),
+		FText::Format(LOCTEXT("ApplyPresetSucceeded", "Applied {0} wind preset."),
+			ResolveWindPresetDisplayName(Preset, PresetIndex)),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -61,6 +61,7 @@ namespace
 		float MaxValue = 1.0f;
 	};
 
+	// 各波形成分の表示スタイル（色・凡例ラベル・線種）を定義する
 	const TArray<FKawaiiWindScopeComponentStyle>& GetWindScopeComponentStyles()
 	{
 		static const TArray<FKawaiiWindScopeComponentStyle> Styles =
@@ -76,6 +77,7 @@ namespace
 		return Styles;
 	}
 
+	// FKawaiiPhysicsProceduralWindSample から指定成分の値を取り出す
 	float GetWindScopeComponentValue(const FKawaiiPhysicsProceduralWindSample& Sample,
 	                                 EKawaiiPhysicsWindScopeComponent Component)
 	{
@@ -118,6 +120,7 @@ namespace
 		return INDEX_NONE;
 	}
 
+	// 要求indexが無効（削除済み・型変更済み等）なら、先頭の ProceduralWind へフォールバックする
 	int32 ResolveProceduralWindIndex(const FAnimNode_KawaiiPhysics& Node, int32 RequestedIndex)
 	{
 		if (Node.ExternalForces.IsValidIndex(RequestedIndex) &&
@@ -128,6 +131,7 @@ namespace
 		return FindFirstProceduralWindIndex(Node);
 	}
 
+	// サンプルが無い時の初期表示値。Envelope=1にして Total=0（無風）を表すサンプルにする
 	FKawaiiPhysicsProceduralWindSample MakeZeroWindSample()
 	{
 		FKawaiiPhysicsProceduralWindSample Sample;
@@ -148,10 +152,12 @@ namespace
 	                                           const FKawaiiPhysicsWindScopeSeriesVisibility& Visibility)
 	{
 		FKawaiiWindScopeRange Range;
+		// 直近 DisplaySeconds 秒分を表示ウィンドウとする
 		Range.MaxTime = Samples.Num() > 0 ? Samples.Last().Time : 0.0f;
 		Range.MinTime = Range.MaxTime - FMath::Max(DisplaySeconds, 0.1f);
 		bool bHasValue = false;
 
+		// 表示ウィンドウ内かつ可視な系列の値だけを対象に最小/最大を求める
 		for (const FKawaiiProceduralWindScopeSample& Point : Samples)
 		{
 			if (Point.Time < Range.MinTime)
@@ -181,12 +187,14 @@ namespace
 			}
 		}
 
+		// 表示対象が無い場合はデフォルトの [-1,1] 範囲にフォールバック
 		if (!bHasValue)
 		{
 			Range.MinValue = -1.0f;
 			Range.MaxValue = 1.0f;
 		}
 
+		// 上下に少し余白を持たせる
 		const float Span = Range.MaxValue - Range.MinValue;
 		const float Padding = FMath::Max(Span * 0.1f, 0.01f);
 		Range.MinValue -= Padding;
@@ -220,6 +228,7 @@ namespace
 			const float XRate = (SamplePoint.Time - MinTime) / TimeSpan;
 			const float Value = GetWindScopeComponentValue(SamplePoint.Sample, Component);
 			const float YRate = (Value - MinValue) / ValueSpan;
+			// Slate のローカル座標はY下向きのため、値が大きいほどYが小さくなるよう反転する
 			Points.Add(FVector2D(
 				GraphOrigin.X + GraphSize.X * XRate,
 				GraphOrigin.Y + GraphSize.Y * (1.0f - YRate)));
@@ -227,6 +236,7 @@ namespace
 		return Points;
 	}
 
+	// セグメントごとに Dash/Gap を繰り返して破線を描画する
 	void DrawWindScopeDashedLine(FSlateWindowElementList& OutDrawElements,
 	                             int32 LayerId,
 	                             const FGeometry& AllottedGeometry,
@@ -267,6 +277,7 @@ namespace
 		}
 	}
 
+	// 凡例1項目（色スウォッチ＋表示切替チェックボックス＋ラベル）を生成する
 	TSharedRef<SWidget> MakeWindScopeLegendItem(SKawaiiPhysicsWindScopeWindow* Owner,
 	                                            const FKawaiiWindScopeComponentStyle& Style)
 	{
@@ -296,6 +307,7 @@ namespace
 			];
 	}
 
+	// 所属 AnimBlueprint を変更済みとしてマークする（プリセット適用の Undo/Redo・保存ダーティ化用）
 	void MarkWindScopeGraphNodeModified(UAnimGraphNode_KawaiiPhysics* GraphNode)
 	{
 		if (!GraphNode)
@@ -401,6 +413,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	(void)InWidgetStyle;
 	(void)bParentEnabled;
 
+	// 背景を塗る
 	const FVector2D LocalSize = AllottedGeometry.GetLocalSize();
 	const FSlateBrush* WhiteBrush = FCoreStyle::Get().GetBrush(TEXT("WhiteBrush"));
 	FSlateDrawElement::MakeBox(
@@ -411,6 +424,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		ESlateDrawEffect::None,
 		FLinearColor(0.015f, 0.018f, 0.022f, 1.0f));
 
+	// 描画領域（余白を除いたグラフ内側の矩形）と値レンジを計算
 	const FVector2D GraphOrigin(WindScopeGraphPaddingLeft, WindScopeGraphPaddingTop);
 	const FVector2D GraphSize(
 		FMath::Max(LocalSize.X - WindScopeGraphPaddingLeft - WindScopeGraphPaddingRight, 1.0f),
@@ -420,6 +434,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	const FLinearColor AxisColor(0.52f, 0.56f, 0.62f, 0.9f);
 	const FSlateFontInfo AxisFont(FCoreStyle::GetDefaultFont(), 9);
 
+	// グリッド線（縦横4分割）を描画
 	for (int32 GridIndex = 0; GridIndex <= 4; ++GridIndex)
 	{
 		const float X = GraphOrigin.X + GraphSize.X * (static_cast<float>(GridIndex) / 4.0f);
@@ -451,6 +466,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			1.0f);
 	}
 
+	// 0ライン（値レンジが0を跨ぐ場合のみ）を強調表示
 	if (Range.MinValue <= 0.0f && Range.MaxValue >= 0.0f)
 	{
 		const float ZeroY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((0.0f - Range.MinValue) / (Range.MaxValue - Range.MinValue)));
@@ -468,6 +484,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			1.0f);
 	}
 
+	// 各波形成分のポリラインを描画（Envelope等 bDashed 指定の系列は破線）
 	for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 	{
 		if (!Visibility.IsVisible(Style.Component))
@@ -507,6 +524,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		}
 	}
 
+	// 軸ラベル（最大値・0・最小値・時間軸）を描画
 	const auto DrawAxisText = [&](const FString& Text, const FVector2D& Position)
 	{
 		FSlateDrawElement::MakeText(
@@ -549,6 +567,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 	ChildSlot
 	[
 		SNew(SVerticalBox)
+		// 上段: 対象ノード名・外力選択コンボ・現在モード表示
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(8.0f, 8.0f, 8.0f, 4.0f)
@@ -595,6 +614,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.ColorAndOpacity(FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen")))
 			]
 		]
+		// プリセットボタン列（Breeze / Strong / Storm）
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(8.0f, 2.0f)
@@ -624,6 +644,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnStormPresetClicked)
 			]
 		]
+		// 凡例（系列ごとの表示切替チェックボックス）
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(8.0f, 2.0f)
@@ -639,6 +660,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[5])]
 			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[6])]
 		]
+		// 波形グラフ本体
 		+ SVerticalBox::Slot()
 		.FillHeight(1.0f)
 		.Padding(8.0f, 4.0f)
@@ -651,6 +673,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		[
 			SNew(SSeparator)
 		]
+		// 下段: 現在値テキスト・表示秒数スピンボックス・一時停止チェックボックス
 		+ SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(8.0f, 2.0f, 8.0f, 8.0f)
@@ -702,11 +725,13 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		]
 	];
 
+	// 60fps 相当でティックし、Live/Preview のサンプル更新とグラフ再描画を行う
 	RegisterActiveTimer(1.0f / 60.0f, FWidgetActiveTimerDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::TickWindScope));
 }
 
 void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args)
 {
+	// 既存ウィンドウがあれば引数を差し替えて前面に出すだけ（ウィンドウは常に1つに集約する）
 	if (TSharedPtr<SWindow> ExistingWindow = KawaiiWindScopeWindowWeak.Pin())
 	{
 		if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> ExistingWidget = KawaiiWindScopeWidgetWeak.Pin())
@@ -717,6 +742,7 @@ void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs
 		return;
 	}
 
+	// 新規ウィンドウを生成
 	TSharedRef<SKawaiiPhysicsWindScopeWindow> ScopeWidget =
 		SNew(SKawaiiPhysicsWindScopeWindow, MoveTemp(Args));
 
@@ -730,6 +756,7 @@ void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs
 			ScopeWidget
 		];
 
+	// 閉じたら配置を保存し弱参照をクリアする（次回 OpenWindow 時は上のブロックで新規生成される）
 	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
 	{
 		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
@@ -761,6 +788,7 @@ void SKawaiiPhysicsWindScopeWindow::CloseAllWindows()
 
 void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs InArgs)
 {
+	// 対象引数を差し替え、表示状態をリセットして外力一覧を再構築する
 	Args = MoveTemp(InArgs);
 	DisplaySamples.Reset();
 	PreviewTime = 0.0f;
@@ -784,6 +812,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	(void)SelectInfo;
 	SelectedExternalForceItem = Item;
 	Args.ExternalForceIndex = Item.IsValid() ? *Item : INDEX_NONE;
+	// 選択切替時は別の外力の波形を混在させないよう表示状態を丸ごとリセットする
 	DisplaySamples.Reset();
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
@@ -866,6 +895,7 @@ void SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged(float NewValue)
 	}
 }
 
+// 以下3つは強さの異なる決め打ちプリセット（そよ風/強風/嵐）を ApplyPreset に渡すだけの薄いラッパー
 FReply SKawaiiPhysicsWindScopeWindow::OnBreezePresetClicked()
 {
 	return ApplyPreset(
@@ -934,6 +964,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
                                                   float DirectionNoiseAngle,
                                                   const FText& PresetName)
 {
+	// 対象グラフノードを解決（失敗時は通知して終了）
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	if (!GraphNode)
 	{
@@ -943,6 +974,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
 		return FReply::Handled();
 	}
 
+	// ProceduralWind 外力を解決・型チェック
 	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
 	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
 	{
@@ -962,6 +994,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
 		return FReply::Handled();
 	}
 
+	// Undo/Redo 対応のトランザクションでパラメータを書き込む
 	const FScopedTransaction Transaction(LOCTEXT("ApplyWindPresetTransaction", "Apply Kawaii Physics Wind Preset"));
 	GraphNode->Modify();
 	Wind->bIsEnabled = true;
@@ -980,6 +1013,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
 	Wind->TimeScale = 1.0f;
 	MarkWindScopeGraphNodeModified(GraphNode);
 
+	// 外力一覧を更新し、成功通知を表示
 	Args.ExternalForceIndex = ResolvedIndex;
 	RefreshExternalForceItems();
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
@@ -996,6 +1030,7 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 		return EActiveTimerReturnType::Continue;
 	}
 
+	// Live 取得に失敗したら（PIE/デバッグ対象なし等）Preview 波形を計算する
 	if (!TryUpdateFromLiveRuntime())
 	{
 		RebuildPreviewSamples(InDeltaTime);
@@ -1006,6 +1041,7 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 		CurrentModeText = LOCTEXT("LiveModeTick", "Live");
 	}
 
+	// グラフウィジェットへ最新サンプル・表示設定を反映
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetDisplaySeconds(DisplaySeconds);
@@ -1019,6 +1055,7 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 
 void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
 {
+	// ノードが持つ ProceduralWind 外力のインデックス一覧を再収集
 	ExternalForceItems.Reset();
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	if (GraphNode)
@@ -1032,6 +1069,7 @@ void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
 		}
 	}
 
+	// 直前の選択Indexを維持できなければ先頭を選択
 	SelectedExternalForceItem.Reset();
 	for (const FExternalForceIndexPtr& Item : ExternalForceItems)
 	{
@@ -1047,6 +1085,7 @@ void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
 		Args.ExternalForceIndex = *SelectedExternalForceItem;
 	}
 
+	// コンボボックスへ反映
 	if (ExternalForceComboBox.IsValid())
 	{
 		ExternalForceComboBox->RefreshOptions();
@@ -1056,6 +1095,7 @@ void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
 
 void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
 {
+	// 対象の ProceduralWind 設定を取得できなければ（未選択・ノード未解決等）表示をクリア
 	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
 	if (!TryGetPreviewForceCopy(Wind))
 	{
@@ -1063,6 +1103,7 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
 		return;
 	}
 
+	// エディタ経過時間を積算し、直近 DisplaySeconds 秒分を等間隔サンプリングする
 	PreviewTime += FMath::Max(InDeltaTime, 0.0f);
 	DisplaySamples.Reset();
 	DisplaySamples.Reserve(WindScopePreviewSampleCount);
@@ -1075,6 +1116,8 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
 		const float SampleTime = FMath::Lerp(StartTime, EndTime, Alpha);
 		FKawaiiProceduralWindScopeSample ScopeSample;
 		ScopeSample.Time = SampleTime;
+		// LengthRate=0（ルート相当）で評価。PreApply が ScopeBuffer に書き込む Live サンプルも同じ LengthRate=0
+		// で計算されるため、両者は同一基準で比較できる（実ボーンの LengthRateFromRoot による Wave 位相ずれは含まない）
 		ScopeSample.Sample = Wind.ComputeWindSample(SampleTime, 0.0f);
 		DisplaySamples.Add(ScopeSample);
 	}
@@ -1088,6 +1131,7 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 		return false;
 	}
 
+	// PIE等でデバッグ対象になっているノードを取得（デバッグ対象でなければ Live 扱いにしない）
 	UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
 	UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
 	if (!Cast<UAnimInstance>(ObjectBeingDebugged))
@@ -1095,6 +1139,7 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 		return false;
 	}
 
+	// 実行中の FAnimNode_KawaiiPhysics から対象 ProceduralWind の RuntimeState を解決
 	FAnimNode_KawaiiPhysics* RuntimeNode = GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
 	if (!RuntimeNode)
 	{
@@ -1114,6 +1159,8 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 		return false;
 	}
 
+	// ScopeBuffer は PreApply（アニメーションワーカースレッド）が Mutex 下で書き込むリングバッファなので、
+	// ロック区間はコピーのみに留め、Game Thread 側にスナップショットを持ち出してから解放する
 	TArray<FKawaiiProceduralWindScopeSample> Snapshot;
 	uint64 ScopeSampleCount = 0;
 	{
@@ -1124,6 +1171,7 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 			return false;
 		}
 
+		// ScopeWriteIndex は次に書き込むスロットを指すため、そこから CopyCount 分遡った位置が最古のサンプルになる
 		const int32 BufferNum = Wind->RuntimeState->ScopeBuffer.Num();
 		const int32 CopyCount = FMath::Min<int32>(BufferNum, static_cast<int32>(FMath::Min<uint64>(ScopeSampleCount, MAX_int32)));
 		Snapshot.Reserve(CopyCount);
@@ -1134,6 +1182,7 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 		}
 	}
 
+	// 新規サンプル分だけ取り込めたので Display 側へ反映
 	LastLiveSampleCount = ScopeSampleCount;
 	Args.ExternalForceIndex = ResolvedIndex;
 	DisplaySamples = MoveTemp(Snapshot);
@@ -1162,12 +1211,15 @@ bool SKawaiiPhysicsWindScopeWindow::TryGetPreviewForceCopy(
 		return false;
 	}
 
+	// 値をコピーして返す。Preview計算のためだけに複製し、編集中のグラフノード本体には触れない
 	OutForce = *Wind;
 	return true;
 }
 
 UAnimGraphNode_KawaiiPhysics* SKawaiiPhysicsWindScopeWindow::ResolveGraphNode() const
 {
+	// まず弱参照を優先し、失効していれば AnimBlueprintPath+NodeGuid から再解決する
+	// （BP再コンパイル等でノードインスタンスが差し替わっても追従できる）
 	if (Args.GraphNode.IsValid())
 	{
 		return Args.GraphNode.Get();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -1,0 +1,1184 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "SKawaiiPhysicsWindScopeWindow.h"
+
+#include "AnimGraphNode_KawaiiPhysics.h"
+#include "Animation/AnimBlueprint.h"
+#include "Animation/AnimInstance.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "Framework/Application/SlateApplication.h"
+#include "HAL/CriticalSection.h"
+#include "KawaiiPhysicsEdWindowUtils.h"
+#include "KawaiiPhysicsEditorLibrary.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/ScopeLock.h"
+#include "Rendering/DrawElements.h"
+#include "ScopedTransaction.h"
+#include "Styling/AppStyle.h"
+#include "Styling/CoreStyle.h"
+#include "Widgets/Colors/SColorBlock.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SComboBox.h"
+#include "Widgets/Input/SSpinBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SWrapBox.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "KawaiiPhysicsWindScopeWindow"
+
+namespace
+{
+	const TCHAR* WindScopeConfigSectionName = TEXT("KawaiiPhysicsEd");
+	const TCHAR* WindScopeWindowPosConfigKey = TEXT("WindScopeWindowPos");
+	const TCHAR* WindScopeWindowSizeConfigKey = TEXT("WindScopeWindowSize");
+	constexpr int32 WindScopePreviewSampleCount = 240;
+	constexpr float WindScopeGraphPaddingLeft = 42.0f;
+	constexpr float WindScopeGraphPaddingTop = 12.0f;
+	constexpr float WindScopeGraphPaddingRight = 12.0f;
+	constexpr float WindScopeGraphPaddingBottom = 24.0f;
+
+	TWeakPtr<SWindow> KawaiiWindScopeWindowWeak;
+	TWeakPtr<SKawaiiPhysicsWindScopeWindow> KawaiiWindScopeWidgetWeak;
+
+	struct FKawaiiWindScopeComponentStyle
+	{
+		EKawaiiPhysicsWindScopeComponent Component;
+		FText Label;
+		FLinearColor Color;
+		float Thickness = 1.0f;
+		bool bDashed = false;
+	};
+
+	struct FKawaiiWindScopeRange
+	{
+		float MinTime = 0.0f;
+		float MaxTime = 1.0f;
+		float MinValue = -1.0f;
+		float MaxValue = 1.0f;
+	};
+
+	const TArray<FKawaiiWindScopeComponentStyle>& GetWindScopeComponentStyles()
+	{
+		static const TArray<FKawaiiWindScopeComponentStyle> Styles =
+		{
+			{EKawaiiPhysicsWindScopeComponent::Total, LOCTEXT("TotalLabel", "Total"), FLinearColor::White, 2.0f, false},
+			{EKawaiiPhysicsWindScopeComponent::Steady, LOCTEXT("SteadyLabel", "Steady"), FLinearColor(1.0f, 0.48f, 0.08f), 1.0f, false},
+			{EKawaiiPhysicsWindScopeComponent::Oscillation, LOCTEXT("OscillationLabel", "Oscillation"), FLinearColor(1.0f, 0.86f, 0.05f), 1.0f, false},
+			{EKawaiiPhysicsWindScopeComponent::Wave, LOCTEXT("WaveLabel", "Wave"), FLinearColor(0.0f, 0.85f, 1.0f), 1.0f, false},
+			{EKawaiiPhysicsWindScopeComponent::Envelope, LOCTEXT("EnvelopeLabel", "Envelope"), FLinearColor(0.2f, 0.42f, 1.0f), 1.0f, true},
+			{EKawaiiPhysicsWindScopeComponent::Random, LOCTEXT("RandomLabel", "Random"), FLinearColor(1.0f, 0.25f, 0.78f), 1.0f, false},
+			{EKawaiiPhysicsWindScopeComponent::Gust, LOCTEXT("GustLabel", "Gust"), FLinearColor(1.0f, 0.12f, 0.08f), 1.0f, false},
+		};
+		return Styles;
+	}
+
+	float GetWindScopeComponentValue(const FKawaiiPhysicsProceduralWindSample& Sample,
+	                                 EKawaiiPhysicsWindScopeComponent Component)
+	{
+		switch (Component)
+		{
+		case EKawaiiPhysicsWindScopeComponent::Total:
+			return Sample.Total;
+		case EKawaiiPhysicsWindScopeComponent::Steady:
+			return Sample.Steady;
+		case EKawaiiPhysicsWindScopeComponent::Oscillation:
+			return Sample.Oscillation;
+		case EKawaiiPhysicsWindScopeComponent::Wave:
+			return Sample.Wave;
+		case EKawaiiPhysicsWindScopeComponent::Envelope:
+			return Sample.Envelope;
+		case EKawaiiPhysicsWindScopeComponent::Random:
+			return Sample.Random;
+		case EKawaiiPhysicsWindScopeComponent::Gust:
+			return Sample.Gust;
+		default:
+			return 0.0f;
+		}
+	}
+
+	bool IsProceduralWindStruct(const FInstancedStruct& InstancedStruct)
+	{
+		return InstancedStruct.IsValid() &&
+			InstancedStruct.GetScriptStruct() == FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
+	}
+
+	int32 FindFirstProceduralWindIndex(const FAnimNode_KawaiiPhysics& Node)
+	{
+		for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+		{
+			if (IsProceduralWindStruct(Node.ExternalForces[Index]))
+			{
+				return Index;
+			}
+		}
+		return INDEX_NONE;
+	}
+
+	int32 ResolveProceduralWindIndex(const FAnimNode_KawaiiPhysics& Node, int32 RequestedIndex)
+	{
+		if (Node.ExternalForces.IsValidIndex(RequestedIndex) &&
+			IsProceduralWindStruct(Node.ExternalForces[RequestedIndex]))
+		{
+			return RequestedIndex;
+		}
+		return FindFirstProceduralWindIndex(Node);
+	}
+
+	FKawaiiPhysicsProceduralWindSample MakeZeroWindSample()
+	{
+		FKawaiiPhysicsProceduralWindSample Sample;
+		Sample.Envelope = 1.0f;
+		return Sample;
+	}
+
+	FText FormatFloat2(float Value)
+	{
+		FNumberFormattingOptions Options;
+		Options.MinimumFractionalDigits = 2;
+		Options.MaximumFractionalDigits = 2;
+		return FText::AsNumber(Value, &Options);
+	}
+
+	FKawaiiWindScopeRange ComputeWindScopeRange(const TArray<FKawaiiProceduralWindScopeSample>& Samples,
+	                                           float DisplaySeconds,
+	                                           const FKawaiiPhysicsWindScopeSeriesVisibility& Visibility)
+	{
+		FKawaiiWindScopeRange Range;
+		Range.MaxTime = Samples.Num() > 0 ? Samples.Last().Time : 0.0f;
+		Range.MinTime = Range.MaxTime - FMath::Max(DisplaySeconds, 0.1f);
+		bool bHasValue = false;
+
+		for (const FKawaiiProceduralWindScopeSample& Point : Samples)
+		{
+			if (Point.Time < Range.MinTime)
+			{
+				continue;
+			}
+
+			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+			{
+				if (!Visibility.IsVisible(Style.Component))
+				{
+					continue;
+				}
+
+				const float Value = GetWindScopeComponentValue(Point.Sample, Style.Component);
+				if (!bHasValue)
+				{
+					Range.MinValue = Value;
+					Range.MaxValue = Value;
+					bHasValue = true;
+				}
+				else
+				{
+					Range.MinValue = FMath::Min(Range.MinValue, Value);
+					Range.MaxValue = FMath::Max(Range.MaxValue, Value);
+				}
+			}
+		}
+
+		if (!bHasValue)
+		{
+			Range.MinValue = -1.0f;
+			Range.MaxValue = 1.0f;
+		}
+
+		const float Span = Range.MaxValue - Range.MinValue;
+		const float Padding = FMath::Max(Span * 0.1f, 0.01f);
+		Range.MinValue -= Padding;
+		Range.MaxValue += Padding;
+		return Range;
+	}
+
+	// 契約: Slate 型に依存せず、時刻順サンプル列をグラフローカル座標のポリラインへ変換する。
+	// 入力の時刻・値範囲は呼び出し側が確定し、範囲外の時刻サンプルはここで捨てる。
+	static TArray<FVector2D> BuildWindScopePolylinePoints(
+		const TArray<FKawaiiProceduralWindScopeSample>& Samples,
+		EKawaiiPhysicsWindScopeComponent Component,
+		float MinTime,
+		float MaxTime,
+		float MinValue,
+		float MaxValue,
+		const FVector2D& GraphOrigin,
+		const FVector2D& GraphSize)
+	{
+		TArray<FVector2D> Points;
+		const float TimeSpan = FMath::Max(MaxTime - MinTime, KINDA_SMALL_NUMBER);
+		const float ValueSpan = FMath::Max(MaxValue - MinValue, KINDA_SMALL_NUMBER);
+
+		for (const FKawaiiProceduralWindScopeSample& SamplePoint : Samples)
+		{
+			if (SamplePoint.Time < MinTime || SamplePoint.Time > MaxTime)
+			{
+				continue;
+			}
+
+			const float XRate = (SamplePoint.Time - MinTime) / TimeSpan;
+			const float Value = GetWindScopeComponentValue(SamplePoint.Sample, Component);
+			const float YRate = (Value - MinValue) / ValueSpan;
+			Points.Add(FVector2D(
+				GraphOrigin.X + GraphSize.X * XRate,
+				GraphOrigin.Y + GraphSize.Y * (1.0f - YRate)));
+		}
+		return Points;
+	}
+
+	void DrawWindScopeDashedLine(FSlateWindowElementList& OutDrawElements,
+	                             int32 LayerId,
+	                             const FGeometry& AllottedGeometry,
+	                             const TArray<FVector2D>& Points,
+	                             const FLinearColor& Color,
+	                             float Thickness)
+	{
+		constexpr float DashLength = 6.0f;
+		constexpr float GapLength = 4.0f;
+		for (int32 PointIndex = 1; PointIndex < Points.Num(); ++PointIndex)
+		{
+			const FVector2D Start = Points[PointIndex - 1];
+			const FVector2D End = Points[PointIndex];
+			const FVector2D Segment = End - Start;
+			const float SegmentLength = Segment.Size();
+			if (SegmentLength <= KINDA_SMALL_NUMBER)
+			{
+				continue;
+			}
+
+			const FVector2D Direction = Segment / SegmentLength;
+			for (float Offset = 0.0f; Offset < SegmentLength; Offset += DashLength + GapLength)
+			{
+				const float DashEndOffset = FMath::Min(Offset + DashLength, SegmentLength);
+				TArray<FVector2D> DashPoints;
+				DashPoints.Add(Start + Direction * Offset);
+				DashPoints.Add(Start + Direction * DashEndOffset);
+				FSlateDrawElement::MakeLines(
+					OutDrawElements,
+					LayerId,
+					AllottedGeometry.ToPaintGeometry(),
+					DashPoints,
+					ESlateDrawEffect::None,
+					Color,
+					true,
+					Thickness);
+			}
+		}
+	}
+
+	TSharedRef<SWidget> MakeWindScopeLegendItem(SKawaiiPhysicsWindScopeWindow* Owner,
+	                                            const FKawaiiWindScopeComponentStyle& Style)
+	{
+		return SNew(SCheckBox)
+			.IsChecked(Owner, &SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState, Style.Component)
+			.OnCheckStateChanged(Owner, &SKawaiiPhysicsWindScopeWindow::OnSeriesCheckStateChanged, Style.Component)
+			.ToolTipText(Style.Label)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+				[
+					SNew(SColorBlock)
+					.Color(Style.Color)
+					.Size(FVector2D(12.0f, 8.0f))
+				]
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text(Style.Label)
+					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+				]
+			];
+	}
+
+	void MarkWindScopeGraphNodeModified(UAnimGraphNode_KawaiiPhysics* GraphNode)
+	{
+		if (!GraphNode)
+		{
+			return;
+		}
+
+		if (UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint())
+		{
+			FBlueprintEditorUtils::MarkBlueprintAsModified(AnimBlueprint);
+		}
+	}
+}
+
+bool FKawaiiPhysicsWindScopeSeriesVisibility::IsVisible(EKawaiiPhysicsWindScopeComponent Component) const
+{
+	switch (Component)
+	{
+	case EKawaiiPhysicsWindScopeComponent::Total:
+		return bTotal;
+	case EKawaiiPhysicsWindScopeComponent::Steady:
+		return bSteady;
+	case EKawaiiPhysicsWindScopeComponent::Oscillation:
+		return bOscillation;
+	case EKawaiiPhysicsWindScopeComponent::Wave:
+		return bWave;
+	case EKawaiiPhysicsWindScopeComponent::Envelope:
+		return bEnvelope;
+	case EKawaiiPhysicsWindScopeComponent::Random:
+		return bRandom;
+	case EKawaiiPhysicsWindScopeComponent::Gust:
+		return bGust;
+	default:
+		return false;
+	}
+}
+
+void FKawaiiPhysicsWindScopeSeriesVisibility::SetVisible(
+	EKawaiiPhysicsWindScopeComponent Component,
+	bool bVisible)
+{
+	switch (Component)
+	{
+	case EKawaiiPhysicsWindScopeComponent::Total:
+		bTotal = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Steady:
+		bSteady = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Oscillation:
+		bOscillation = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Wave:
+		bWave = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Envelope:
+		bEnvelope = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Random:
+		bRandom = bVisible;
+		break;
+	case EKawaiiPhysicsWindScopeComponent::Gust:
+		bGust = bVisible;
+		break;
+	default:
+		break;
+	}
+}
+
+void SKawaiiPhysicsWindScopeGraph::Construct(const FArguments& InArgs)
+{
+	(void)InArgs;
+}
+
+void SKawaiiPhysicsWindScopeGraph::SetSamples(TArray<FKawaiiProceduralWindScopeSample> InSamples)
+{
+	Samples = MoveTemp(InSamples);
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+void SKawaiiPhysicsWindScopeGraph::SetDisplaySeconds(float InDisplaySeconds)
+{
+	DisplaySeconds = FMath::Clamp(InDisplaySeconds, 2.0f, 30.0f);
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+void SKawaiiPhysicsWindScopeGraph::SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility)
+{
+	Visibility = InVisibility;
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
+                                            const FGeometry& AllottedGeometry,
+                                            const FSlateRect& MyCullingRect,
+                                            FSlateWindowElementList& OutDrawElements,
+                                            int32 LayerId,
+                                            const FWidgetStyle& InWidgetStyle,
+                                            bool bParentEnabled) const
+{
+	(void)Args;
+	(void)MyCullingRect;
+	(void)InWidgetStyle;
+	(void)bParentEnabled;
+
+	const FVector2D LocalSize = AllottedGeometry.GetLocalSize();
+	const FSlateBrush* WhiteBrush = FCoreStyle::Get().GetBrush(TEXT("WhiteBrush"));
+	FSlateDrawElement::MakeBox(
+		OutDrawElements,
+		LayerId,
+		AllottedGeometry.ToPaintGeometry(),
+		WhiteBrush,
+		ESlateDrawEffect::None,
+		FLinearColor(0.015f, 0.018f, 0.022f, 1.0f));
+
+	const FVector2D GraphOrigin(WindScopeGraphPaddingLeft, WindScopeGraphPaddingTop);
+	const FVector2D GraphSize(
+		FMath::Max(LocalSize.X - WindScopeGraphPaddingLeft - WindScopeGraphPaddingRight, 1.0f),
+		FMath::Max(LocalSize.Y - WindScopeGraphPaddingTop - WindScopeGraphPaddingBottom, 1.0f));
+	const FKawaiiWindScopeRange Range = ComputeWindScopeRange(Samples, DisplaySeconds, Visibility);
+	const FLinearColor GridColor(0.22f, 0.24f, 0.28f, 0.55f);
+	const FLinearColor AxisColor(0.52f, 0.56f, 0.62f, 0.9f);
+	const FSlateFontInfo AxisFont(FCoreStyle::GetDefaultFont(), 9);
+
+	for (int32 GridIndex = 0; GridIndex <= 4; ++GridIndex)
+	{
+		const float X = GraphOrigin.X + GraphSize.X * (static_cast<float>(GridIndex) / 4.0f);
+		TArray<FVector2D> VerticalLine;
+		VerticalLine.Add(FVector2D(X, GraphOrigin.Y));
+		VerticalLine.Add(FVector2D(X, GraphOrigin.Y + GraphSize.Y));
+		FSlateDrawElement::MakeLines(
+			OutDrawElements,
+			LayerId + 1,
+			AllottedGeometry.ToPaintGeometry(),
+			VerticalLine,
+			ESlateDrawEffect::None,
+			GridColor,
+			true,
+			1.0f);
+
+		const float Y = GraphOrigin.Y + GraphSize.Y * (static_cast<float>(GridIndex) / 4.0f);
+		TArray<FVector2D> HorizontalLine;
+		HorizontalLine.Add(FVector2D(GraphOrigin.X, Y));
+		HorizontalLine.Add(FVector2D(GraphOrigin.X + GraphSize.X, Y));
+		FSlateDrawElement::MakeLines(
+			OutDrawElements,
+			LayerId + 1,
+			AllottedGeometry.ToPaintGeometry(),
+			HorizontalLine,
+			ESlateDrawEffect::None,
+			GridColor,
+			true,
+			1.0f);
+	}
+
+	if (Range.MinValue <= 0.0f && Range.MaxValue >= 0.0f)
+	{
+		const float ZeroY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((0.0f - Range.MinValue) / (Range.MaxValue - Range.MinValue)));
+		TArray<FVector2D> ZeroLine;
+		ZeroLine.Add(FVector2D(GraphOrigin.X, ZeroY));
+		ZeroLine.Add(FVector2D(GraphOrigin.X + GraphSize.X, ZeroY));
+		FSlateDrawElement::MakeLines(
+			OutDrawElements,
+			LayerId + 2,
+			AllottedGeometry.ToPaintGeometry(),
+			ZeroLine,
+			ESlateDrawEffect::None,
+			AxisColor,
+			true,
+			1.0f);
+	}
+
+	for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+	{
+		if (!Visibility.IsVisible(Style.Component))
+		{
+			continue;
+		}
+
+		const TArray<FVector2D> Points = BuildWindScopePolylinePoints(
+			Samples,
+			Style.Component,
+			Range.MinTime,
+			Range.MaxTime,
+			Range.MinValue,
+			Range.MaxValue,
+			GraphOrigin,
+			GraphSize);
+		if (Points.Num() < 2)
+		{
+			continue;
+		}
+
+		if (Style.bDashed)
+		{
+			DrawWindScopeDashedLine(OutDrawElements, LayerId + 3, AllottedGeometry, Points, Style.Color, Style.Thickness);
+		}
+		else
+		{
+			FSlateDrawElement::MakeLines(
+				OutDrawElements,
+				LayerId + 3,
+				AllottedGeometry.ToPaintGeometry(),
+				Points,
+				ESlateDrawEffect::None,
+				Style.Color,
+				true,
+				Style.Thickness);
+		}
+	}
+
+	const auto DrawAxisText = [&](const FString& Text, const FVector2D& Position)
+	{
+		FSlateDrawElement::MakeText(
+			OutDrawElements,
+			LayerId + 4,
+			AllottedGeometry.ToPaintGeometry(FVector2D(80.0f, 14.0f), FSlateLayoutTransform(Position)),
+			Text,
+			AxisFont,
+			ESlateDrawEffect::None,
+			AxisColor);
+	};
+
+	DrawAxisText(FString::Printf(TEXT("%.2f"), Range.MaxValue), FVector2D(2.0f, GraphOrigin.Y - 2.0f));
+	if (Range.MinValue <= 0.0f && Range.MaxValue >= 0.0f)
+	{
+		const float ZeroLabelY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((0.0f - Range.MinValue) / (Range.MaxValue - Range.MinValue)));
+		DrawAxisText(TEXT("0.00"), FVector2D(2.0f, ZeroLabelY - 7.0f));
+	}
+	DrawAxisText(FString::Printf(TEXT("%.2f"), Range.MinValue), FVector2D(2.0f, GraphOrigin.Y + GraphSize.Y - 14.0f));
+	DrawAxisText(FString::Printf(TEXT("-%.0fs"), DisplaySeconds), FVector2D(GraphOrigin.X, GraphOrigin.Y + GraphSize.Y + 4.0f));
+	DrawAxisText(TEXT("0s"), FVector2D(GraphOrigin.X + GraphSize.X - 24.0f, GraphOrigin.Y + GraphSize.Y + 4.0f));
+
+	return LayerId + 5;
+}
+
+FVector2D SKawaiiPhysicsWindScopeGraph::ComputeDesiredSize(float LayoutScaleMultiplier) const
+{
+	(void)LayoutScaleMultiplier;
+	return FVector2D(520.0f, 220.0f);
+}
+
+void SKawaiiPhysicsWindScopeWindow::Construct(
+	const FArguments& InArgs,
+	FKawaiiPhysicsWindScopeWindowArgs InitArgs)
+{
+	(void)InArgs;
+	CurrentModeText = LOCTEXT("InitialMode", "Preview");
+	SetArgs(MoveTemp(InitArgs));
+
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(8.0f, 8.0f, 8.0f, 4.0f)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			.VAlign(VAlign_Center)
+			[
+				SNew(STextBlock)
+				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetTargetNodeText)
+				.Clipping(EWidgetClipping::OnDemand)
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(8.0f, 0.0f, 4.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("ExternalForceLabel", "Force"))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SAssignNew(ExternalForceComboBox, SComboBox<FExternalForceIndexPtr>)
+				.OptionsSource(&ExternalForceItems)
+				.InitiallySelectedItem(SelectedExternalForceItem)
+				.OnGenerateWidget(this, &SKawaiiPhysicsWindScopeWindow::GenerateExternalForceComboWidget)
+				.OnSelectionChanged(this, &SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged)
+				[
+					SNew(STextBlock)
+					.Text(this, &SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText)
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(12.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetModeText)
+				.ColorAndOpacity(FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen")))
+			]
+		]
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(8.0f, 2.0f)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("BreezePresetButton", "Breeze / そよ風"))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnBreezePresetClicked)
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("StrongPresetButton", "Strong / 強風"))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnStrongPresetClicked)
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			[
+				SNew(SButton)
+				.Text(LOCTEXT("StormPresetButton", "Storm / 嵐"))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnStormPresetClicked)
+			]
+		]
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(8.0f, 2.0f)
+		[
+			SNew(SWrapBox)
+			.UseAllottedSize(true)
+			.InnerSlotPadding(FVector2D(6.0f, 2.0f))
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[0])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[1])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[2])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[3])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[4])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[5])]
+			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[6])]
+		]
+		+ SVerticalBox::Slot()
+		.FillHeight(1.0f)
+		.Padding(8.0f, 4.0f)
+		[
+			SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+		]
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(8.0f, 0.0f, 8.0f, 4.0f)
+		[
+			SNew(SSeparator)
+		]
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(8.0f, 2.0f, 8.0f, 8.0f)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			.VAlign(VAlign_Center)
+			[
+				SNew(STextBlock)
+				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetCurrentValuesText)
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+				.Clipping(EWidgetClipping::OnDemand)
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(8.0f, 0.0f, 4.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("DisplaySecondsLabel", "Seconds"))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SNew(SSpinBox<float>)
+				.MinValue(2.0f)
+				.MaxValue(30.0f)
+				.MinSliderValue(2.0f)
+				.MaxSliderValue(30.0f)
+				.Value(this, &SKawaiiPhysicsWindScopeWindow::GetDisplaySeconds)
+				.OnValueChanged(this, &SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged)
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(8.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SCheckBox)
+				.IsChecked(this, &SKawaiiPhysicsWindScopeWindow::GetPauseCheckState)
+				.OnCheckStateChanged(this, &SKawaiiPhysicsWindScopeWindow::OnPauseCheckStateChanged)
+				[
+					SNew(STextBlock)
+					.Text(LOCTEXT("PauseLabel", "Pause"))
+				]
+			]
+		]
+	];
+
+	RegisterActiveTimer(1.0f / 60.0f, FWidgetActiveTimerDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::TickWindScope));
+}
+
+void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args)
+{
+	if (TSharedPtr<SWindow> ExistingWindow = KawaiiWindScopeWindowWeak.Pin())
+	{
+		if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> ExistingWidget = KawaiiWindScopeWidgetWeak.Pin())
+		{
+			ExistingWidget->SetArgs(MoveTemp(Args));
+		}
+		ExistingWindow->BringToFront();
+		return;
+	}
+
+	TSharedRef<SKawaiiPhysicsWindScopeWindow> ScopeWidget =
+		SNew(SKawaiiPhysicsWindScopeWindow, MoveTemp(Args));
+
+	TSharedRef<SWindow> Window = SNew(SWindow)
+		.Title(LOCTEXT("WindowTitle", "Kawaii Physics: Wind Scope"))
+		.ClientSize(FVector2D(720.0f, 420.0f))
+		.MinWidth(520.0f)
+		.MinHeight(320.0f)
+		.AutoCenter(EAutoCenter::PreferredWorkArea)
+		[
+			ScopeWidget
+		];
+
+	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
+	{
+		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
+			ClosedWindow,
+			WindScopeConfigSectionName,
+			WindScopeWindowPosConfigKey,
+			WindScopeWindowSizeConfigKey);
+		KawaiiWindScopeWindowWeak.Reset();
+		KawaiiWindScopeWidgetWeak.Reset();
+	}));
+
+	KawaiiWindScopeWindowWeak = Window;
+	KawaiiWindScopeWidgetWeak = ScopeWidget;
+	FSlateApplication::Get().AddWindow(Window);
+	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
+		Window,
+		WindScopeConfigSectionName,
+		WindScopeWindowPosConfigKey,
+		WindScopeWindowSizeConfigKey);
+}
+
+void SKawaiiPhysicsWindScopeWindow::CloseAllWindows()
+{
+	if (TSharedPtr<SWindow> Window = KawaiiWindScopeWindowWeak.Pin())
+	{
+		Window->RequestDestroyWindow();
+	}
+}
+
+void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs InArgs)
+{
+	Args = MoveTemp(InArgs);
+	DisplaySamples.Reset();
+	PreviewTime = 0.0f;
+	LastLiveSampleCount = 0;
+	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
+	RefreshExternalForceItems();
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateExternalForceComboWidget(FExternalForceIndexPtr Item) const
+{
+	return SNew(STextBlock)
+		.Text(Item.IsValid()
+			      ? FText::Format(LOCTEXT("ExternalForceItemFormat", "#{0} ProceduralWind"), FText::AsNumber(*Item))
+			      : LOCTEXT("NoExternalForceItem", "None"));
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
+	FExternalForceIndexPtr Item,
+	ESelectInfo::Type SelectInfo)
+{
+	(void)SelectInfo;
+	SelectedExternalForceItem = Item;
+	Args.ExternalForceIndex = Item.IsValid() ? *Item : INDEX_NONE;
+	DisplaySamples.Reset();
+	LastLiveSampleCount = 0;
+	PreviewTime = 0.0f;
+}
+
+FText SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText() const
+{
+	return SelectedExternalForceItem.IsValid()
+		       ? FText::Format(LOCTEXT("SelectedExternalForceFormat", "#{0} ProceduralWind"), FText::AsNumber(*SelectedExternalForceItem))
+		       : LOCTEXT("NoExternalForceSelected", "No ProceduralWind");
+}
+
+FText SKawaiiPhysicsWindScopeWindow::GetTargetNodeText() const
+{
+	if (const UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode())
+	{
+		return GraphNode->GetNodeTitle(ENodeTitleType::ListView);
+	}
+	return LOCTEXT("UnknownTargetNode", "KawaiiPhysics Node");
+}
+
+FText SKawaiiPhysicsWindScopeWindow::GetModeText() const
+{
+	return CurrentModeText;
+}
+
+FText SKawaiiPhysicsWindScopeWindow::GetCurrentValuesText() const
+{
+	const FKawaiiPhysicsProceduralWindSample Sample =
+		DisplaySamples.Num() > 0 ? DisplaySamples.Last().Sample : MakeZeroWindSample();
+	return FText::Format(
+		LOCTEXT("CurrentValuesFormat", "Total {0}  Steady {1}  Osc {2}  Wave {3}  Env {4}  Rand {5}  Gust {6}"),
+		FormatFloat2(Sample.Total),
+		FormatFloat2(Sample.Steady),
+		FormatFloat2(Sample.Oscillation),
+		FormatFloat2(Sample.Wave),
+		FormatFloat2(Sample.Envelope),
+		FormatFloat2(Sample.Random),
+		FormatFloat2(Sample.Gust));
+}
+
+ECheckBoxState SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState(
+	EKawaiiPhysicsWindScopeComponent Component) const
+{
+	return SeriesVisibility.IsVisible(Component) ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnSeriesCheckStateChanged(
+	ECheckBoxState NewState,
+	EKawaiiPhysicsWindScopeComponent Component)
+{
+	SeriesVisibility.SetVisible(Component, NewState == ECheckBoxState::Checked);
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetSeriesVisibility(SeriesVisibility);
+	}
+}
+
+ECheckBoxState SKawaiiPhysicsWindScopeWindow::GetPauseCheckState() const
+{
+	return bPaused ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnPauseCheckStateChanged(ECheckBoxState NewState)
+{
+	bPaused = NewState == ECheckBoxState::Checked;
+}
+
+float SKawaiiPhysicsWindScopeWindow::GetDisplaySeconds() const
+{
+	return DisplaySeconds;
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged(float NewValue)
+{
+	DisplaySeconds = FMath::Clamp(NewValue, 2.0f, 30.0f);
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetDisplaySeconds(DisplaySeconds);
+	}
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnBreezePresetClicked()
+{
+	return ApplyPreset(
+		2.0f,
+		1.0f,
+		2.0f,
+		1.0f,
+		1.5f,
+		90.0f,
+		0.6f,
+		1.0f,
+		0.05f,
+		0.5f,
+		0.8f,
+		5.0f,
+		LOCTEXT("BreezePresetName", "Breeze"));
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnStrongPresetClicked()
+{
+	return ApplyPreset(
+		8.0f,
+		4.0f,
+		0.8f,
+		3.0f,
+		0.6f,
+		120.0f,
+		0.7f,
+		1.3f,
+		0.08f,
+		2.0f,
+		0.5f,
+		10.0f,
+		LOCTEXT("StrongPresetName", "Strong"));
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnStormPresetClicked()
+{
+	return ApplyPreset(
+		15.0f,
+		10.0f,
+		0.4f,
+		8.0f,
+		0.35f,
+		180.0f,
+		0.5f,
+		1.6f,
+		0.15f,
+		6.0f,
+		0.3f,
+		20.0f,
+		LOCTEXT("StormPresetName", "Storm"));
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(float SteadyForce,
+                                                  float OscillationForce,
+                                                  float OscillationPeriod,
+                                                  float WaveAmplitude,
+                                                  float WavePeriod,
+                                                  float WaveSpatialOffset,
+                                                  float EnvelopeMin,
+                                                  float EnvelopeMax,
+                                                  float EnvelopeFrequency,
+                                                  float RandomForce,
+                                                  float RandomPeriod,
+                                                  float DirectionNoiseAngle,
+                                                  const FText& PresetName)
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetNoNode", "Failed to resolve the KawaiiPhysics graph node."),
+			SNotificationItem::CS_Fail);
+		return FReply::Handled();
+	}
+
+	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
+	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetNoWind", "No ProceduralWind external force was found."),
+			SNotificationItem::CS_Fail);
+		return FReply::Handled();
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		GraphNode->Node.ExternalForces[ResolvedIndex].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	if (!Wind)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetInvalidWind", "The selected external force is not ProceduralWind."),
+			SNotificationItem::CS_Fail);
+		return FReply::Handled();
+	}
+
+	const FScopedTransaction Transaction(LOCTEXT("ApplyWindPresetTransaction", "Apply Kawaii Physics Wind Preset"));
+	GraphNode->Modify();
+	Wind->bIsEnabled = true;
+	Wind->SteadyForce = SteadyForce;
+	Wind->OscillationForce = OscillationForce;
+	Wind->OscillationPeriod = OscillationPeriod;
+	Wind->WaveAmplitude = WaveAmplitude;
+	Wind->WavePeriod = WavePeriod;
+	Wind->WaveSpatialOffset = WaveSpatialOffset;
+	Wind->EnvelopeMin = EnvelopeMin;
+	Wind->EnvelopeMax = EnvelopeMax;
+	Wind->EnvelopeFrequency = EnvelopeFrequency;
+	Wind->RandomForce = RandomForce;
+	Wind->RandomPeriod = RandomPeriod;
+	Wind->DirectionNoiseAngle = DirectionNoiseAngle;
+	Wind->TimeScale = 1.0f;
+	MarkWindScopeGraphNodeModified(GraphNode);
+
+	Args.ExternalForceIndex = ResolvedIndex;
+	RefreshExternalForceItems();
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
+		FText::Format(LOCTEXT("ApplyPresetSucceeded", "Applied {0} wind preset."), PresetName),
+		SNotificationItem::CS_Success);
+	return FReply::Handled();
+}
+
+EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)
+{
+	(void)InCurrentTime;
+	if (bPaused)
+	{
+		return EActiveTimerReturnType::Continue;
+	}
+
+	if (!TryUpdateFromLiveRuntime())
+	{
+		RebuildPreviewSamples(InDeltaTime);
+		CurrentModeText = LOCTEXT("PreviewModeTick", "Preview");
+	}
+	else
+	{
+		CurrentModeText = LOCTEXT("LiveModeTick", "Live");
+	}
+
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetDisplaySeconds(DisplaySeconds);
+		GraphWidget->SetSeriesVisibility(SeriesVisibility);
+		GraphWidget->SetSamples(DisplaySamples);
+	}
+	Invalidate(EInvalidateWidgetReason::Paint);
+
+	return EActiveTimerReturnType::Continue;
+}
+
+void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
+{
+	ExternalForceItems.Reset();
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (GraphNode)
+	{
+		for (int32 Index = 0; Index < GraphNode->Node.ExternalForces.Num(); ++Index)
+		{
+			if (IsProceduralWindStruct(GraphNode->Node.ExternalForces[Index]))
+			{
+				ExternalForceItems.Add(MakeShared<int32>(Index));
+			}
+		}
+	}
+
+	SelectedExternalForceItem.Reset();
+	for (const FExternalForceIndexPtr& Item : ExternalForceItems)
+	{
+		if (Item.IsValid() && *Item == Args.ExternalForceIndex)
+		{
+			SelectedExternalForceItem = Item;
+			break;
+		}
+	}
+	if (!SelectedExternalForceItem.IsValid() && ExternalForceItems.Num() > 0)
+	{
+		SelectedExternalForceItem = ExternalForceItems[0];
+		Args.ExternalForceIndex = *SelectedExternalForceItem;
+	}
+
+	if (ExternalForceComboBox.IsValid())
+	{
+		ExternalForceComboBox->RefreshOptions();
+		ExternalForceComboBox->SetSelectedItem(SelectedExternalForceItem);
+	}
+}
+
+void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
+{
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	if (!TryGetPreviewForceCopy(Wind))
+	{
+		DisplaySamples.Reset();
+		return;
+	}
+
+	PreviewTime += FMath::Max(InDeltaTime, 0.0f);
+	DisplaySamples.Reset();
+	DisplaySamples.Reserve(WindScopePreviewSampleCount);
+	const float EndTime = PreviewTime;
+	const float StartTime = EndTime - DisplaySeconds;
+	const int32 SampleCount = FMath::Max(WindScopePreviewSampleCount, 2);
+	for (int32 SampleIndex = 0; SampleIndex < SampleCount; ++SampleIndex)
+	{
+		const float Alpha = static_cast<float>(SampleIndex) / static_cast<float>(SampleCount - 1);
+		const float SampleTime = FMath::Lerp(StartTime, EndTime, Alpha);
+		FKawaiiProceduralWindScopeSample ScopeSample;
+		ScopeSample.Time = SampleTime;
+		ScopeSample.Sample = Wind.ComputeWindSample(SampleTime, 0.0f);
+		DisplaySamples.Add(ScopeSample);
+	}
+}
+
+bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode)
+	{
+		return false;
+	}
+
+	UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
+	UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
+	if (!Cast<UAnimInstance>(ObjectBeingDebugged))
+	{
+		return false;
+	}
+
+	FAnimNode_KawaiiPhysics* RuntimeNode = GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
+	if (!RuntimeNode)
+	{
+		return false;
+	}
+
+	const int32 ResolvedIndex = ResolveProceduralWindIndex(*RuntimeNode, Args.ExternalForceIndex);
+	if (!RuntimeNode->ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		return false;
+	}
+
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		RuntimeNode->ExternalForces[ResolvedIndex].GetPtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	if (!Wind || !Wind->RuntimeState.IsValid())
+	{
+		return false;
+	}
+
+	TArray<FKawaiiProceduralWindScopeSample> Snapshot;
+	uint64 ScopeSampleCount = 0;
+	{
+		FScopeLock Lock(&Wind->RuntimeState->Mutex);
+		ScopeSampleCount = Wind->RuntimeState->ScopeSampleCount;
+		if (ScopeSampleCount <= LastLiveSampleCount || Wind->RuntimeState->ScopeBuffer.Num() == 0)
+		{
+			return false;
+		}
+
+		const int32 BufferNum = Wind->RuntimeState->ScopeBuffer.Num();
+		const int32 CopyCount = FMath::Min<int32>(BufferNum, static_cast<int32>(FMath::Min<uint64>(ScopeSampleCount, MAX_int32)));
+		Snapshot.Reserve(CopyCount);
+		const int32 StartIndex = (Wind->RuntimeState->ScopeWriteIndex - CopyCount + BufferNum) % BufferNum;
+		for (int32 CopyIndex = 0; CopyIndex < CopyCount; ++CopyIndex)
+		{
+			Snapshot.Add(Wind->RuntimeState->ScopeBuffer[(StartIndex + CopyIndex) % BufferNum]);
+		}
+	}
+
+	LastLiveSampleCount = ScopeSampleCount;
+	Args.ExternalForceIndex = ResolvedIndex;
+	DisplaySamples = MoveTemp(Snapshot);
+	return DisplaySamples.Num() > 0;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::TryGetPreviewForceCopy(
+	FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const
+{
+	const UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode)
+	{
+		return false;
+	}
+
+	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
+	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		return false;
+	}
+
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		GraphNode->Node.ExternalForces[ResolvedIndex].GetPtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	if (!Wind)
+	{
+		return false;
+	}
+
+	OutForce = *Wind;
+	return true;
+}
+
+UAnimGraphNode_KawaiiPhysics* SKawaiiPhysicsWindScopeWindow::ResolveGraphNode() const
+{
+	if (Args.GraphNode.IsValid())
+	{
+		return Args.GraphNode.Get();
+	}
+
+	if (Args.AnimBlueprintPath.IsValid() && Args.NodeGuid.IsValid())
+	{
+		return UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(Args.AnimBlueprintPath, Args.NodeGuid);
+	}
+
+	return nullptr;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "KawaiiPhysicsWindPresetDataAsset.h"
 #include "UObject/SoftObjectPath.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/SLeafWidget.h"
@@ -11,6 +12,7 @@
 #include "Widgets/Input/SComboBox.h"
 
 class SComboBoxBase;
+class SWrapBox;
 class SWindow;
 class UAnimGraphNode_KawaiiPhysics;
 
@@ -126,22 +128,9 @@ private:
 	float GetDisplaySeconds() const;
 	void OnDisplaySecondsChanged(float NewValue);
 
-	FReply OnBreezePresetClicked();
-	FReply OnStrongPresetClicked();
-	FReply OnStormPresetClicked();
-	FReply ApplyPreset(float SteadyForce,
-	                   float OscillationForce,
-	                   float OscillationPeriod,
-	                   float WaveAmplitude,
-	                   float WavePeriod,
-	                   float WaveSpatialOffset,
-	                   float EnvelopeMin,
-	                   float EnvelopeMax,
-	                   float EnvelopeFrequency,
-	                   float RandomForce,
-	                   float RandomPeriod,
-	                   float DirectionNoiseAngle,
-	                   const FText& PresetName);
+	void RebuildPresetButtons();
+	FReply OnPresetButtonClicked(int32 PresetIndex);
+	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
 
 	// 毎フレームの active timer コールバック。Live/Preview いずれかでサンプルを更新し再描画する
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);
@@ -171,4 +160,7 @@ private:
 
 	TSharedPtr<SComboBox<FExternalForceIndexPtr>> ExternalForceComboBox;
 	TSharedPtr<SKawaiiPhysicsWindScopeGraph> GraphWidget;
+	// ボタンindexとの整合を保つプリセットスナップショット
+	TArray<FKawaiiProceduralWindPreset> CachedPresets;
+	TSharedPtr<SWrapBox> PresetButtonBox;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -29,6 +29,7 @@ struct FKawaiiPhysicsWindScopeWindowArgs
 	int32 ExternalForceIndex = INDEX_NONE;
 };
 
+// グラフに表示する波形成分の種別（ランタイム側 FKawaiiPhysicsProceduralWindSample の各フィールドに対応）
 enum class EKawaiiPhysicsWindScopeComponent : uint8
 {
 	Total,
@@ -40,6 +41,7 @@ enum class EKawaiiPhysicsWindScopeComponent : uint8
 	Gust,
 };
 
+// 上記各成分の表示ON/OFFを凡例チェックボックスと連動して保持する
 struct FKawaiiPhysicsWindScopeSeriesVisibility
 {
 	bool bTotal = true;
@@ -54,6 +56,7 @@ struct FKawaiiPhysicsWindScopeSeriesVisibility
 	void SetVisible(EKawaiiPhysicsWindScopeComponent Component, bool bVisible);
 };
 
+// 波形グラフ本体。SLeafWidget を継承し OnPaint でポリラインを直接描画する
 class SKawaiiPhysicsWindScopeGraph : public SLeafWidget
 {
 public:
@@ -68,6 +71,7 @@ public:
 	void SetDisplaySeconds(float InDisplaySeconds);
 	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
 
+	// グラフの描画本体（Slate のペイントコールバック）
 	virtual int32 OnPaint(const FPaintArgs& Args,
 	                      const FGeometry& AllottedGeometry,
 	                      const FSlateRect& MyCullingRect,
@@ -84,6 +88,7 @@ private:
 	float DisplaySeconds = 8.0f;
 };
 
+// Wind Scope ツールウィンドウ本体。ツールバー・凡例・グラフ・プリセットボタンをまとめる SCompoundWidget
 class SKawaiiPhysicsWindScopeWindow : public SCompoundWidget
 {
 public:
@@ -107,6 +112,7 @@ public:
 	void OnSeriesCheckStateChanged(ECheckBoxState NewState, EKawaiiPhysicsWindScopeComponent Component);
 
 private:
+	// ExternalForces 配列のインデックスを保持するコンボボックス項目型（SComboBox は TSharedPtr 項目を要求する）
 	using FExternalForceIndexPtr = TSharedPtr<int32>;
 
 	TSharedRef<SWidget> GenerateExternalForceComboWidget(FExternalForceIndexPtr Item) const;
@@ -137,21 +143,29 @@ private:
 	                   float DirectionNoiseAngle,
 	                   const FText& PresetName);
 
+	// 毎フレームの active timer コールバック。Live/Preview いずれかでサンプルを更新し再描画する
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);
 	void RefreshExternalForceItems();
+	// Live 実行中でない場合の理論波形（Preview）を再計算する
 	void RebuildPreviewSamples(float InDeltaTime);
+	// 実行中の RuntimeState からライブ波形を取得する。取得できなければ false（呼び出し側は Preview へフォールバック）
 	bool TryUpdateFromLiveRuntime();
+	// Preview 計算用に ProceduralWind 設定値のコピーを取得する
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
+	// 弱参照、または AnimBlueprintPath+NodeGuid から対象ノードを再解決する（BP再コンパイル等でポインタが失効しても追従できる）
 	UAnimGraphNode_KawaiiPhysics* ResolveGraphNode() const;
 
 	FKawaiiPhysicsWindScopeWindowArgs Args;
 	TArray<FExternalForceIndexPtr> ExternalForceItems;
 	FExternalForceIndexPtr SelectedExternalForceItem;
 	FKawaiiPhysicsWindScopeSeriesVisibility SeriesVisibility;
+	// 現在グラフに描画中のサンプル列（Live/Preview 共通）
 	TArray<FKawaiiProceduralWindScopeSample> DisplaySamples;
 	FText CurrentModeText;
 	float DisplaySeconds = 8.0f;
+	// Preview モードでの積算経過時間
 	float PreviewTime = 0.0f;
+	// 直前に読み取った RuntimeState->ScopeSampleCount。差分が無ければ新規サンプル無しと判断する
 	uint64 LastLiveSampleCount = 0;
 	bool bPaused = false;
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -1,0 +1,160 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "UObject/SoftObjectPath.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/SLeafWidget.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SComboBox.h"
+
+class SComboBoxBase;
+class SWindow;
+class UAnimGraphNode_KawaiiPhysics;
+
+struct FKawaiiPhysicsWindScopeWindowArgs
+{
+	/** 表示対象のグラフノード / Graph node to inspect. */
+	TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics> GraphNode;
+
+	/** ノードを再解決する AnimBlueprint パス / AnimBlueprint path used to re-resolve the node. */
+	FSoftObjectPath AnimBlueprintPath;
+
+	/** ノードを再解決する NodeGuid / NodeGuid used to re-resolve the node. */
+	FGuid NodeGuid;
+
+	/** 表示対象の ProceduralWind 外力インデックス / ProceduralWind external force index to inspect. */
+	int32 ExternalForceIndex = INDEX_NONE;
+};
+
+enum class EKawaiiPhysicsWindScopeComponent : uint8
+{
+	Total,
+	Steady,
+	Oscillation,
+	Wave,
+	Envelope,
+	Random,
+	Gust,
+};
+
+struct FKawaiiPhysicsWindScopeSeriesVisibility
+{
+	bool bTotal = true;
+	bool bSteady = true;
+	bool bOscillation = true;
+	bool bWave = true;
+	bool bEnvelope = true;
+	bool bRandom = true;
+	bool bGust = true;
+
+	bool IsVisible(EKawaiiPhysicsWindScopeComponent Component) const;
+	void SetVisible(EKawaiiPhysicsWindScopeComponent Component, bool bVisible);
+};
+
+class SKawaiiPhysicsWindScopeGraph : public SLeafWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeGraph)
+		{
+		}
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	void SetSamples(TArray<FKawaiiProceduralWindScopeSample> InSamples);
+	void SetDisplaySeconds(float InDisplaySeconds);
+	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
+
+	virtual int32 OnPaint(const FPaintArgs& Args,
+	                      const FGeometry& AllottedGeometry,
+	                      const FSlateRect& MyCullingRect,
+	                      FSlateWindowElementList& OutDrawElements,
+	                      int32 LayerId,
+	                      const FWidgetStyle& InWidgetStyle,
+	                      bool bParentEnabled) const override;
+
+	virtual FVector2D ComputeDesiredSize(float LayoutScaleMultiplier) const override;
+
+private:
+	TArray<FKawaiiProceduralWindScopeSample> Samples;
+	FKawaiiPhysicsWindScopeSeriesVisibility Visibility;
+	float DisplaySeconds = 8.0f;
+};
+
+class SKawaiiPhysicsWindScopeWindow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeWindow)
+		{
+		}
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs, FKawaiiPhysicsWindScopeWindowArgs InitArgs);
+
+	/** Wind Scope ウィンドウを開くか既存ウィンドウを更新する / Opens the Wind Scope window or updates the existing one. */
+	static void OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args);
+
+	/** 開いている Wind Scope ウィンドウをすべて閉じる / Closes all open Wind Scope windows. */
+	static void CloseAllWindows();
+
+	/** 現在の引数でウィジェット状態を置き換える / Replaces the widget state with the current arguments. */
+	void SetArgs(FKawaiiPhysicsWindScopeWindowArgs Args);
+
+	ECheckBoxState GetSeriesCheckState(EKawaiiPhysicsWindScopeComponent Component) const;
+	void OnSeriesCheckStateChanged(ECheckBoxState NewState, EKawaiiPhysicsWindScopeComponent Component);
+
+private:
+	using FExternalForceIndexPtr = TSharedPtr<int32>;
+
+	TSharedRef<SWidget> GenerateExternalForceComboWidget(FExternalForceIndexPtr Item) const;
+	void OnExternalForceSelectionChanged(FExternalForceIndexPtr Item, ESelectInfo::Type SelectInfo);
+	FText GetSelectedExternalForceText() const;
+	FText GetTargetNodeText() const;
+	FText GetModeText() const;
+	FText GetCurrentValuesText() const;
+	ECheckBoxState GetPauseCheckState() const;
+	void OnPauseCheckStateChanged(ECheckBoxState NewState);
+	float GetDisplaySeconds() const;
+	void OnDisplaySecondsChanged(float NewValue);
+
+	FReply OnBreezePresetClicked();
+	FReply OnStrongPresetClicked();
+	FReply OnStormPresetClicked();
+	FReply ApplyPreset(float SteadyForce,
+	                   float OscillationForce,
+	                   float OscillationPeriod,
+	                   float WaveAmplitude,
+	                   float WavePeriod,
+	                   float WaveSpatialOffset,
+	                   float EnvelopeMin,
+	                   float EnvelopeMax,
+	                   float EnvelopeFrequency,
+	                   float RandomForce,
+	                   float RandomPeriod,
+	                   float DirectionNoiseAngle,
+	                   const FText& PresetName);
+
+	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);
+	void RefreshExternalForceItems();
+	void RebuildPreviewSamples(float InDeltaTime);
+	bool TryUpdateFromLiveRuntime();
+	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
+	UAnimGraphNode_KawaiiPhysics* ResolveGraphNode() const;
+
+	FKawaiiPhysicsWindScopeWindowArgs Args;
+	TArray<FExternalForceIndexPtr> ExternalForceItems;
+	FExternalForceIndexPtr SelectedExternalForceItem;
+	FKawaiiPhysicsWindScopeSeriesVisibility SeriesVisibility;
+	TArray<FKawaiiProceduralWindScopeSample> DisplaySamples;
+	FText CurrentModeText;
+	float DisplaySeconds = 8.0f;
+	float PreviewTime = 0.0f;
+	uint64 LastLiveSampleCount = 0;
+	bool bPaused = false;
+
+	TSharedPtr<SComboBox<FExternalForceIndexPtr>> ExternalForceComboBox;
+	TSharedPtr<SKawaiiPhysicsWindScopeGraph> GraphWidget;
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -80,6 +80,9 @@ private:
 	/** このノードと対象プリセットとの差分を確認します / Checks the diff between this node and its target preset. */
 	void CheckPresetDiff();
 
+	/** Procedural Windの波形プレビューウィンドウを開きます / Opens the waveform preview window for Procedural Wind. */
+	void OpenWindScopeWindow();
+
 public:
 	/** Enables or disables debug drawing for bones. */
 	UPROPERTY()


### PR DESCRIPTION
## 概要

外部力に新種別 **Procedural Wind** を追加します。WindDirectionalSource などのシーン側アクターに依存せず、AnimNode 内で完結するパラメトリックな風（ベース風＋うねり＋乱流＋突風）を合成します。あわせて、波形をリアルタイム確認できるエディタツール **Wind Scope**、GameplayTag 駆動の**風プリセット DataAsset**、ランタイム制御 API を追加します。

## 主な変更

### ランタイム（KawaiiPhysics）
- `FKawaiiPhysics_ExternalForce_ProceduralWind` を追加
  - ベース風・うねり（Swell）・乱流（Turbulence）・突風（Gust）のパラメトリック合成
  - シード付き方向ノイズによる決定論的な揺らぎ（再現性あり）
  - ボーン位置に基づく空間波の伝播（毛先ほど遅れて揺れる）
  - substep 数に依存しない挙動（フレームレート非依存）
- スレッドセーフなランタイム制御 API を追加（突風トリガー / パラメータ一括設定 / `AnimNotify_KawaiiPhysicsTriggerGust`）
- 風プリセットを `UKawaiiPhysicsWindPresetDataAsset` としてデータ駆動化
  - プリセット識別は Native GameplayTag（`KawaiiPhysics.WindPreset.*`）
  - Project Settings からプリセット DataAsset を指定可能
  - DataAsset 未設定時は組み込み既定 3 種（Breeze / Storm / Indoor 相当）へフォールバックする Blueprint API

### エディタ（KawaiiPhysicsEd）
- **Wind Scope** プレビューウィンドウを追加
  - 実測波形／理論波形のライブ表示
  - プリセットボタンは DataAsset から動的生成（リロード対応）
  - 詳細パネルの External Force カテゴリおよびノード右クリックメニューから起動
- Procedural Wind の詳細パネルを整理（カテゴリ統合・効果ベースのツールチップ）

### リファクタリング
- 外部力のシミュレーション空間変換を基底クラスのヘルパーへ集約
- エディタウィンドウの通知・配置永続化ヘルパーを共通化