### PR TITLE
[fix] Resolve native gameplay tag ensure in KawaiiPhysicsEd test

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsPresetDiffSnapshotTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsPresetDiffSnapshotTest.cpp
@@ -2,11 +2,11 @@
 
 #include "../KawaiiPhysicsPresetDiffSnapshot.h"
 
+#include "KawaiiPhysicsWindPresetTags.h"
 #include "Misc/AutomationTest.h"
-#include "NativeGameplayTags.h"
 
-UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysicsPresetDiffSnapshotSource, "KawaiiPhysics.Test.PresetDiffSnapshot.Source");
-UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysicsPresetDiffSnapshotTarget, "KawaiiPhysics.Test.PresetDiffSnapshot.Target");
+// UncookedOnlyモジュールではネイティブタグを定義できない（NativeGameplayTags.cppのensure対象）ため、
+// Runtimeモジュールが登録済みのタグを流用する。テストに必要なのは相異なる有効タグ2つのみ
 
 namespace
 {
@@ -203,8 +203,8 @@ bool FKawaiiPhysicsPresetDiffSnapshotOptionsExcludeTagTest::RunTest(const FStrin
 		return false;
 	}
 
-	Node.KawaiiPhysicsTag = TAG_KawaiiPhysicsPresetDiffSnapshotSource;
-	Preset->Node.KawaiiPhysicsTag = TAG_KawaiiPhysicsPresetDiffSnapshotTarget;
+	Node.KawaiiPhysicsTag = TAG_KawaiiPhysics_WindPreset_Breeze;
+	Preset->Node.KawaiiPhysicsTag = TAG_KawaiiPhysics_WindPreset_Strong;
 
 	const FKawaiiPhysicsPresetApplyOptions Options;
 	const TSharedRef<FKawaiiPhysicsPresetDiffSnapshot> Snapshot =


### PR DESCRIPTION
Reuse runtime-exported wind preset tags (Breeze/Strong) in the editor PresetDiffSnapshot test instead of defining native tags in the UncookedOnly module, which triggered VerifyModuleCanContainGameplayTag ensures at editor startup. 108/108 automation tests pass.