### PR TITLE
Apply Wind Scope presets to the running simulation in real time

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -3,6 +3,7 @@
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 
 #include "Math/RotationMatrix.h"
+#include "Misc/ScopeLock.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(KawaiiPhysicsExternalForce_ProceduralWind)
 
@@ -111,19 +112,90 @@ float ComputeDebugTotalRate(const FKawaiiPhysics_ExternalForce_ProceduralWind& F
 	const float Reference = FMath::Max(MaxSine * MaxEnvelope + MaxRandom, 1.0f);
 	return FMath::Abs(Total) / Reference;
 }
-}
 
-// RuntimeState を新規に作り直す。Initialize時、または未初期化のままアクセスされた際の遅延生成に使う
-void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
+void InitializeRuntimeStateContents(FKawaiiProceduralWindRuntimeState& State)
 {
-	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
+	State.PendingParams.Reset();
+	State.PendingGust.Reset();
+	State.Time = 0.0f;
+	State.ActiveGust = FKawaiiProceduralWindActiveGust();
+	State.CachedSinesWithoutWave = 0.0f;
+	State.CachedEnvelope = 1.0f;
+	State.CachedRandom = 0.0f;
+	State.CachedGust = 0.0f;
+	State.CachedWindVector = FVector::ZeroVector;
 
 #if WITH_EDITOR
-	// WindScope プレビュー用のリングバッファを確保
-	RuntimeState->ScopeBuffer.SetNum(FMath::Max(ScopeBufferSize, 1));
-	RuntimeState->ScopeWriteIndex = 0;
-	RuntimeState->ScopeSampleCount = 0;
+	State.ScopeBuffer.Empty(FMath::Max(ScopeBufferSize, 1));
+	State.ScopeBuffer.SetNum(FMath::Max(ScopeBufferSize, 1));
+	State.ScopeWriteIndex = 0;
+	State.ScopeSampleCount = 0;
 #endif
+}
+}
+
+FKawaiiPhysics_ExternalForce_ProceduralWind::FKawaiiPhysics_ExternalForce_ProceduralWind()
+{
+	bCanSelectForceSpace = true;
+	ExternalForceSpace = EExternalForceSpace::WorldSpace;
+	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
+	InitializeRuntimeStateContents(*RuntimeState);
+}
+
+FKawaiiPhysics_ExternalForce_ProceduralWind::FKawaiiPhysics_ExternalForce_ProceduralWind(
+	const FKawaiiPhysics_ExternalForce_ProceduralWind& Other)
+	: FKawaiiPhysics_ExternalForce_ProceduralWind()
+{
+	*this = Other;
+}
+
+FKawaiiPhysics_ExternalForce_ProceduralWind& FKawaiiPhysics_ExternalForce_ProceduralWind::operator=(
+	const FKawaiiPhysics_ExternalForce_ProceduralWind& Other)
+{
+	if (this == &Other)
+	{
+		return *this;
+	}
+
+	static_cast<FKawaiiPhysics_ExternalForce&>(*this) = static_cast<const FKawaiiPhysics_ExternalForce&>(Other);
+
+	WindDirection = Other.WindDirection;
+	DirectionNoiseAngle = Other.DirectionNoiseAngle;
+	DirectionNoisePeriod = Other.DirectionNoisePeriod;
+	TimeScale = Other.TimeScale;
+	ForceRateByBoneLengthRate = Other.ForceRateByBoneLengthRate;
+	SteadyForce = Other.SteadyForce;
+	OscillationForce = Other.OscillationForce;
+	OscillationPeriod = Other.OscillationPeriod;
+	WaveAmplitude = Other.WaveAmplitude;
+	WavePeriod = Other.WavePeriod;
+	WavePhase = Other.WavePhase;
+	WaveSpatialOffset = Other.WaveSpatialOffset;
+	EnvelopeMax = Other.EnvelopeMax;
+	EnvelopeMin = Other.EnvelopeMin;
+	EnvelopeFrequency = Other.EnvelopeFrequency;
+	EnvelopePhase = Other.EnvelopePhase;
+	RandomForce = Other.RandomForce;
+	RandomPeriod = Other.RandomPeriod;
+	RandomSeed = Other.RandomSeed;
+
+	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
+	InitializeRuntimeStateContents(*RuntimeState);
+	return *this;
+}
+
+// RuntimeState のポインタは維持し、中身だけを初期状態へ戻す
+void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
+{
+	if (!RuntimeState.IsValid())
+	{
+		RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
+		InitializeRuntimeStateContents(*RuntimeState);
+		return;
+	}
+
+	FScopeLock Lock(&RuntimeState->Mutex);
+	InitializeRuntimeStateContents(*RuntimeState);
 }
 
 // ランタイムAPI（BP/C++）経由で送られた上書きパラメータを反映する。bOverride が立っている項目のみ適用し、
@@ -131,6 +203,10 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 	const FKawaiiProceduralWindDynamicParams& Params)
 {
+	if (Params.bOverrideIsEnabled)
+	{
+		bIsEnabled = Params.bIsEnabled;
+	}
 	if (Params.bOverrideWindDirection)
 	{
 		WindDirection = Params.WindDirection;
@@ -201,33 +277,66 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 	}
 }
 
+// 動的パラメータ更新を PendingParams として積み、次回 PreApply で反映する
+void FKawaiiPhysics_ExternalForce_ProceduralWind::RequestDynamicParams(
+	const FKawaiiProceduralWindDynamicParams& Params)
+{
+	if (!RuntimeState.IsValid())
+	{
+		return;
+	}
+
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = RuntimeState;
+	FScopeLock Lock(&LocalRuntimeState->Mutex);
+	LocalRuntimeState->PendingParams = Params;
+}
+
+// 突風要求を PendingGust として積み、次回 PreApply で反映する
+void FKawaiiPhysics_ExternalForce_ProceduralWind::RequestGust(
+	const float Strength, const float RiseTime, const float DecayTime)
+{
+	if (!RuntimeState.IsValid())
+	{
+		return;
+	}
+
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = RuntimeState;
+	FScopeLock Lock(&LocalRuntimeState->Mutex);
+	LocalRuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{
+		Strength,
+		RiseTime,
+		DecayTime
+	};
+}
+
 // 他スレッド（Game Thread の BP API など）から積まれた Pending 要求を Worker 側の PreApply で取り込む。
 // Mutex で RuntimeState を保護し、書き込み側（Set*/TriggerGust API）とのスレッドセーフ性を確保する
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ConsumePendingRequests()
 {
 	if (!RuntimeState.IsValid())
 	{
-		ResetRuntimeState();
+		return;
 	}
 
-	FScopeLock Lock(&RuntimeState->Mutex);
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = RuntimeState;
+	FScopeLock Lock(&LocalRuntimeState->Mutex);
 	// パラメータ上書き要求を適用
-	if (RuntimeState->PendingParams.IsSet())
+	if (LocalRuntimeState->PendingParams.IsSet())
 	{
-		ApplyDynamicParams(RuntimeState->PendingParams.GetValue());
-		RuntimeState->PendingParams.Reset();
+		ApplyDynamicParams(LocalRuntimeState->PendingParams.GetValue());
+		LocalRuntimeState->PendingParams.Reset();
 	}
 
 	// gust 要求を ActiveGust として起動する（StartTime は現在のシミュレーション内時間を基準にする）
-	if (RuntimeState->PendingGust.IsSet())
+	if (LocalRuntimeState->PendingGust.IsSet())
 	{
-		const FKawaiiProceduralWindGustRequest& PendingGust = RuntimeState->PendingGust.GetValue();
-		RuntimeState->ActiveGust.StartTime = RuntimeState->Time;
-		RuntimeState->ActiveGust.Strength = PendingGust.Strength;
-		RuntimeState->ActiveGust.RiseTime = PendingGust.RiseTime;
-		RuntimeState->ActiveGust.DecayTime = PendingGust.DecayTime;
-		RuntimeState->ActiveGust.bIsActive = true;
-		RuntimeState->PendingGust.Reset();
+		const FKawaiiProceduralWindGustRequest& PendingGust = LocalRuntimeState->PendingGust.GetValue();
+		LocalRuntimeState->ActiveGust.StartTime = LocalRuntimeState->Time;
+		LocalRuntimeState->ActiveGust.Strength = PendingGust.Strength;
+		LocalRuntimeState->ActiveGust.RiseTime = PendingGust.RiseTime;
+		LocalRuntimeState->ActiveGust.DecayTime = PendingGust.DecayTime;
+		LocalRuntimeState->ActiveGust.bIsActive = true;
+		LocalRuntimeState->PendingGust.Reset();
 	}
 }
 
@@ -323,7 +432,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::Initialize(const FAnimationIni
 {
 	Super::Initialize(Context);
 
-	// ノード初期化時に RuntimeState を新規生成し、前回の再生状態（Time/ActiveGust等）を引き継がない
+	// ノード初期化時に RuntimeState の中身を初期化し、前回の再生状態（Time/ActiveGust等）を引き継がない
 	ResetRuntimeState();
 }
 
@@ -332,7 +441,7 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::PreApply(FAnimNode_KawaiiPhysi
 {
 	Super::PreApply(Node, PoseContext);
 
-	// RuntimeState未生成なら遅延生成（Resetや複製直後などInitializeを経ない経路への保険）
+	// RuntimeState未生成なら保険として初期化する
 	if (!RuntimeState.IsValid())
 	{
 		ResetRuntimeState();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -81,18 +81,7 @@ namespace
 	bool QueueProceduralWindGust(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
 	                             const float Strength, const float RiseTime, const float DecayTime)
 	{
-		// RuntimeState未初期化（PreApply未実行）でもリクエストを取りこぼさないよう先に生成しておく
-		if (!ProceduralWind.RuntimeState.IsValid())
-		{
-			ProceduralWind.ResetRuntimeState();
-		}
-
-		FScopeLock Lock(&ProceduralWind.RuntimeState->Mutex);
-		ProceduralWind.RuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{
-			Strength,
-			RiseTime,
-			DecayTime
-		};
+		ProceduralWind.RequestGust(Strength, RiseTime, DecayTime);
 		return true;
 	}
 
@@ -100,13 +89,7 @@ namespace
 	bool QueueProceduralWindParams(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
 	                               const FKawaiiProceduralWindDynamicParams& Params)
 	{
-		if (!ProceduralWind.RuntimeState.IsValid())
-		{
-			ProceduralWind.ResetRuntimeState();
-		}
-
-		FScopeLock Lock(&ProceduralWind.RuntimeState->Mutex);
-		ProceduralWind.RuntimeState->PendingParams = Params;
+		ProceduralWind.RequestDynamicParams(Params);
 		return true;
 	}
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -488,20 +488,81 @@ bool FKawaiiPhysicsProceduralWindResetRuntimeStateTest::RunTest(const FString& P
 {
 	// 時刻とガスト状態を進めたあと、リセットで初期状態へ戻ることを確認する。
 	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
-	Wind.ResetRuntimeState();
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> InitialRuntimeState = Wind.RuntimeState;
+	TestTrue(TEXT("RuntimeState starts valid"), InitialRuntimeState.IsValid());
 	Wind.RuntimeState->Time = 2.5f;
 	Wind.RuntimeState->ActiveGust.StartTime = 0.0f;
 	Wind.RuntimeState->ActiveGust.Strength = 4.0f;
 	Wind.RuntimeState->ActiveGust.RiseTime = 0.5f;
 	Wind.RuntimeState->ActiveGust.DecayTime = 3.0f;
 	Wind.RuntimeState->ActiveGust.bIsActive = true;
+	Wind.RuntimeState->CachedSinesWithoutWave = 1.0f;
+	Wind.RuntimeState->CachedEnvelope = 2.0f;
+	Wind.RuntimeState->CachedRandom = 3.0f;
+	Wind.RuntimeState->CachedGust = 4.0f;
+	Wind.RuntimeState->CachedWindVector = FVector(1.0f, 2.0f, 3.0f);
+	Wind.RuntimeState->PendingParams = FKawaiiProceduralWindDynamicParams();
+	Wind.RuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{1.0f, 0.2f, 0.3f};
+#if WITH_EDITOR
+	Wind.RuntimeState->ScopeWriteIndex = 10;
+	Wind.RuntimeState->ScopeSampleCount = 20;
+#endif
 	TestTrue(TEXT("Gust is active before reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust > 0.0f);
 
-	// ResetRuntimeStateはRuntimeStateを新規SharedPtrで差し替えるため、Gust・Timeともに初期値へ戻るはず
+	// ResetRuntimeStateはRuntimeStateを差し替えず、Mutex配下で中身だけを初期状態へ戻す
 	Wind.ResetRuntimeState();
+	TestTrue(TEXT("RuntimeState pointer is preserved"), Wind.RuntimeState.Get() == InitialRuntimeState.Get());
 	TestSampleNear(*this, TEXT("Gust after reset"), Wind.ComputeWindSample(1.0f, 0.0f).Gust, 0.0f);
 	TestSampleNear(*this, TEXT("Time after reset"), Wind.RuntimeState->Time, 0.0f);
+	TestFalse(TEXT("ActiveGust inactive after reset"), Wind.RuntimeState->ActiveGust.bIsActive);
+	TestFalse(TEXT("PendingParams reset"), Wind.RuntimeState->PendingParams.IsSet());
+	TestFalse(TEXT("PendingGust reset"), Wind.RuntimeState->PendingGust.IsSet());
+	TestSampleNear(*this, TEXT("CachedSinesWithoutWave after reset"), Wind.RuntimeState->CachedSinesWithoutWave, 0.0f);
+	TestSampleNear(*this, TEXT("CachedEnvelope after reset"), Wind.RuntimeState->CachedEnvelope, 1.0f);
+	TestSampleNear(*this, TEXT("CachedRandom after reset"), Wind.RuntimeState->CachedRandom, 0.0f);
+	TestSampleNear(*this, TEXT("CachedGust after reset"), Wind.RuntimeState->CachedGust, 0.0f);
+	TestTrue(TEXT("CachedWindVector after reset"), Wind.RuntimeState->CachedWindVector.IsNearlyZero());
+#if WITH_EDITOR
+	TestTrue(TEXT("ScopeBuffer allocated after reset"), Wind.RuntimeState->ScopeBuffer.Num() > 0);
+	TestEqual(TEXT("ScopeWriteIndex after reset"), Wind.RuntimeState->ScopeWriteIndex, 0);
+	TestEqual(TEXT("ScopeSampleCount after reset"), Wind.RuntimeState->ScopeSampleCount, static_cast<uint64>(0));
+#endif
 
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindCopyRuntimeStateIndependenceTest,
+                                 "KawaiiPhysics.ProceduralWind.CopyRuntimeStateIndependence",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindCopyRuntimeStateIndependenceTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysics_ExternalForce_ProceduralWind Source;
+	Source.SteadyForce = 12.0f;
+	Source.RuntimeState->Time = 1.0f;
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind Copied(Source);
+	TestTrue(TEXT("Copied RuntimeState is valid"), Copied.RuntimeState.IsValid());
+	TestTrue(TEXT("Copy constructor does not share RuntimeState"),
+	         Source.RuntimeState.Get() != Copied.RuntimeState.Get());
+	TestSampleNear(*this, TEXT("Copied SteadyForce"), Copied.SteadyForce, Source.SteadyForce);
+
+	Source.RuntimeState->Time = 2.0f;
+	Copied.RuntimeState->Time = 3.0f;
+	TestSampleNear(*this, TEXT("Source Time independent"), Source.RuntimeState->Time, 2.0f);
+	TestSampleNear(*this, TEXT("Copied Time independent"), Copied.RuntimeState->Time, 3.0f);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind Assigned;
+	Assigned = Source;
+	TestTrue(TEXT("Assigned RuntimeState is valid"), Assigned.RuntimeState.IsValid());
+	TestTrue(TEXT("Copy assignment does not share RuntimeState"),
+	         Source.RuntimeState.Get() != Assigned.RuntimeState.Get());
+	TestSampleNear(*this, TEXT("Assigned SteadyForce"), Assigned.SteadyForce, Source.SteadyForce);
+
+	Source.RuntimeState->Time = 4.0f;
+	Assigned.RuntimeState->Time = 5.0f;
+	TestSampleNear(*this, TEXT("Source Time independent after assign"), Source.RuntimeState->Time, 4.0f);
+	TestSampleNear(*this, TEXT("Assigned Time independent"), Assigned.RuntimeState->Time, 5.0f);
 	return true;
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsWindPresetTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsWindPresetTest.cpp
@@ -231,6 +231,7 @@ bool FKawaiiPhysicsWindPresetToDynamicParamsTest::RunTest(const FString& Paramet
 	bOk &= TestFalse(TEXT("EnvelopePhase override remains false"), Params.bOverrideEnvelopePhase);
 	bOk &= TestFalse(TEXT("DirectionNoisePeriod override remains false"), Params.bOverrideDirectionNoisePeriod);
 	bOk &= TestFalse(TEXT("TimeScale override remains false"), Params.bOverrideTimeScale);
+	bOk &= TestFalse(TEXT("IsEnabled override remains false"), Params.bOverrideIsEnabled);
 	return bOk;
 }
 
@@ -296,6 +297,117 @@ bool FKawaiiPhysicsWindPresetApplyRoundTripTest::RunTest(const FString& Paramete
 	bOk &= TestFloatNear(*this, TEXT("DirectionNoisePeriod unchanged"),
 	                     Wind.DirectionNoisePeriod,
 	                     BeforeDirectionNoisePeriod);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetApplyEnabledOverrideTest,
+                                 "KawaiiPhysics.WindPreset.ApplyEnabledOverride",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetApplyEnabledOverrideTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.bIsEnabled = false;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	Params.bIsEnabled = true;
+	Wind.ApplyDynamicParams(Params);
+
+	bool bOk = true;
+	bOk &= TestFalse(TEXT("bIsEnabled unchanged without override"), Wind.bIsEnabled);
+
+	Params.bOverrideIsEnabled = true;
+	Wind.ApplyDynamicParams(Params);
+	bOk &= TestTrue(TEXT("bIsEnabled changes with override"), Wind.bIsEnabled);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetRequestDynamicParamsStateTest,
+                                 "KawaiiPhysics.WindPreset.RequestDynamicParamsState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetRequestDynamicParamsStateTest::RunTest(const FString& Parameters)
+{
+	const TArray<FKawaiiProceduralWindPreset> Defaults = UKawaiiPhysicsWindPresetDataAsset::GetDefaultPresets();
+	bool bOk = TestEqual(TEXT("Default preset count"), Defaults.Num(), 3);
+	if (!bOk)
+	{
+		return false;
+	}
+
+	const FKawaiiProceduralWindPreset& Preset = Defaults[2];
+	FKawaiiProceduralWindDynamicParams Params = Preset.ToDynamicParams();
+	Params.bOverrideIsEnabled = true;
+	Params.bIsEnabled = true;
+	Params.bOverrideTimeScale = true;
+	Params.TimeScale = 1.0f;
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.bIsEnabled = false;
+	Wind.TimeScale = 2.0f;
+	Wind.ResetRuntimeState();
+	Wind.RuntimeState->Time = 5.0f;
+	Wind.RuntimeState->ActiveGust.StartTime = 4.5f;
+	Wind.RuntimeState->ActiveGust.Strength = 7.0f;
+	Wind.RuntimeState->ActiveGust.RiseTime = 0.2f;
+	Wind.RuntimeState->ActiveGust.DecayTime = 0.7f;
+	Wind.RuntimeState->ActiveGust.bIsActive = true;
+
+	Wind.RequestDynamicParams(Params);
+	bOk &= TestTrue(TEXT("PendingParams queued"), Wind.RuntimeState->PendingParams.IsSet());
+	Wind.ConsumePendingRequests();
+
+	bOk &= TestWindValuesMatchPreset(*this, TEXT("Requested preset applied"), Wind, Preset);
+	bOk &= TestTrue(TEXT("bIsEnabled applied"), Wind.bIsEnabled);
+	bOk &= TestFloatNear(*this, TEXT("TimeScale applied"), Wind.TimeScale, 1.0f);
+	bOk &= TestFloatNear(*this, TEXT("Time preserved"), Wind.RuntimeState->Time, 5.0f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust StartTime preserved"), Wind.RuntimeState->ActiveGust.StartTime, 4.5f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust Strength preserved"), Wind.RuntimeState->ActiveGust.Strength, 7.0f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust RiseTime preserved"), Wind.RuntimeState->ActiveGust.RiseTime, 0.2f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust DecayTime preserved"), Wind.RuntimeState->ActiveGust.DecayTime, 0.7f);
+	bOk &= TestTrue(TEXT("ActiveGust active preserved"), Wind.RuntimeState->ActiveGust.bIsActive);
+	bOk &= TestFalse(TEXT("PendingParams reset"), Wind.RuntimeState->PendingParams.IsSet());
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind LazyWind;
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LazyInitialRuntimeState =
+		LazyWind.RuntimeState;
+	bOk &= TestTrue(TEXT("RuntimeState starts valid"), LazyInitialRuntimeState.IsValid());
+	LazyWind.RequestDynamicParams(Params);
+	bOk &= TestTrue(TEXT("RequestDynamicParams preserves RuntimeState"),
+	                LazyWind.RuntimeState.Get() == LazyInitialRuntimeState.Get());
+	bOk &= TestTrue(TEXT("Lazy PendingParams queued"), LazyWind.RuntimeState->PendingParams.IsSet());
+	LazyWind.ConsumePendingRequests();
+	bOk &= TestWindValuesMatchPreset(*this, TEXT("Lazy requested preset applied"), LazyWind, Preset);
+	bOk &= TestTrue(TEXT("Lazy bIsEnabled applied"), LazyWind.bIsEnabled);
+	bOk &= TestFloatNear(*this, TEXT("Lazy TimeScale applied"), LazyWind.TimeScale, 1.0f);
+	bOk &= TestFalse(TEXT("Lazy PendingParams reset"), LazyWind.RuntimeState->PendingParams.IsSet());
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindPresetRequestGustTest,
+                                 "KawaiiPhysics.WindPreset.RequestGust",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindPresetRequestGustTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.ResetRuntimeState();
+	Wind.RuntimeState->Time = 3.25f;
+
+	Wind.RequestGust(6.0f, 0.1f, 0.5f);
+
+	bool bOk = true;
+	bOk &= TestTrue(TEXT("PendingGust queued"), Wind.RuntimeState->PendingGust.IsSet());
+	bOk &= TestFalse(TEXT("PendingParams unchanged before consume"), Wind.RuntimeState->PendingParams.IsSet());
+	Wind.ConsumePendingRequests();
+	bOk &= TestFloatNear(*this, TEXT("Time unchanged"), Wind.RuntimeState->Time, 3.25f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust StartTime"), Wind.RuntimeState->ActiveGust.StartTime, 3.25f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust Strength"), Wind.RuntimeState->ActiveGust.Strength, 6.0f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust RiseTime"), Wind.RuntimeState->ActiveGust.RiseTime, 0.1f);
+	bOk &= TestFloatNear(*this, TEXT("ActiveGust DecayTime"), Wind.RuntimeState->ActiveGust.DecayTime, 0.5f);
+	bOk &= TestTrue(TEXT("ActiveGust active"), Wind.RuntimeState->ActiveGust.bIsActive);
+	bOk &= TestFalse(TEXT("PendingGust reset"), Wind.RuntimeState->PendingGust.IsSet());
+	bOk &= TestFalse(TEXT("PendingParams unchanged after consume"), Wind.RuntimeState->PendingParams.IsSet());
 	return bOk;
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -53,6 +53,14 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 {
 	GENERATED_BODY()
 
+	/** bIsEnabled を上書きする / Override bIsEnabled. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bOverrideIsEnabled = false;
+
+	/** 外力の有効状態 / External force enabled state. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
+	bool bIsEnabled = true;
+
 	/** WindDirection を上書きする / Override WindDirection. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="KawaiiPhysics|ExternalForce|ProceduralWind|DynamicParams")
 	bool bOverrideWindDirection = false;
@@ -226,11 +234,10 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 {
 	GENERATED_BODY()
 
-	FKawaiiPhysics_ExternalForce_ProceduralWind()
-	{
-		bCanSelectForceSpace = true;
-		ExternalForceSpace = EExternalForceSpace::WorldSpace;
-	}
+	FKawaiiPhysics_ExternalForce_ProceduralWind();
+	// コピーは RuntimeState を共有せず新規生成する（メンバ追加時は operator= のコピー処理にも追加すること）
+	FKawaiiPhysics_ExternalForce_ProceduralWind(const FKawaiiPhysics_ExternalForce_ProceduralWind& Other);
+	FKawaiiPhysics_ExternalForce_ProceduralWind& operator=(const FKawaiiPhysics_ExternalForce_ProceduralWind& Other);
 
 	/**
 	* 風の吹く方向。BP からは SetExternalForceRotatorProperty("WindDirection") で変更可能
@@ -390,6 +397,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 
 	void ResetRuntimeState();
 	void ApplyDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
+	void RequestDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
+	void RequestGust(float Strength, float RiseTime, float DecayTime);
 	void ConsumePendingRequests();
 
 	FKawaiiPhysicsProceduralWindSample ComputeWindSample(float InTime, float InLengthRate = 0.0f) const;
@@ -407,4 +416,13 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	virtual void AnimDrawDebugForEditMode(const FKawaiiPhysicsModifyBone& ModifyBone,
 	                                      const FAnimNode_KawaiiPhysics& Node, FPrimitiveDrawInterface* PDI) override;
 #endif
+};
+
+template<>
+struct TStructOpsTypeTraits<FKawaiiPhysics_ExternalForce_ProceduralWind> : public TStructOpsTypeTraitsBase2<FKawaiiPhysics_ExternalForce_ProceduralWind>
+{
+	enum
+	{
+		WithCopy = true,
+	};
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -41,6 +41,9 @@ namespace
 	constexpr float WindScopeGraphPaddingTop = 12.0f;
 	constexpr float WindScopeGraphPaddingRight = 12.0f;
 	constexpr float WindScopeGraphPaddingBottom = 24.0f;
+	constexpr float WindScopeGustStrength = 6.0f;
+	constexpr float WindScopeGustRiseTime = 0.1f;
+	constexpr float WindScopeGustDecayTime = 0.5f;
 
 	TWeakPtr<SWindow> KawaiiWindScopeWindowWeak;
 	TWeakPtr<SKawaiiPhysicsWindScopeWindow> KawaiiWindScopeWidgetWeak;
@@ -130,6 +133,69 @@ namespace
 			return RequestedIndex;
 		}
 		return FindFirstProceduralWindIndex(Node);
+	}
+
+	const UScriptStruct* GetExternalForceScriptStruct(const FInstancedStruct& InstancedStruct)
+	{
+		return InstancedStruct.IsValid() ? InstancedStruct.GetScriptStruct() : nullptr;
+	}
+
+	bool IsExternalForceShapeMatched(const TArray<FInstancedStruct>& GraphExternalForces,
+	                                 const TArray<FInstancedStruct>& RuntimeExternalForces)
+	{
+		if (GraphExternalForces.Num() != RuntimeExternalForces.Num())
+		{
+			return false;
+		}
+
+		for (int32 Index = 0; Index < GraphExternalForces.Num(); ++Index)
+		{
+			if (GetExternalForceScriptStruct(GraphExternalForces[Index]) !=
+				GetExternalForceScriptStruct(RuntimeExternalForces[Index]))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	FAnimNode_KawaiiPhysics* ResolveLiveKawaiiPhysicsNode(UAnimGraphNode_KawaiiPhysics* GraphNode)
+	{
+		if (!GraphNode)
+		{
+			return nullptr;
+		}
+
+		UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
+		UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
+		if (!Cast<UAnimInstance>(ObjectBeingDebugged))
+		{
+			return nullptr;
+		}
+
+		return GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveLiveProceduralWind(
+		UAnimGraphNode_KawaiiPhysics* GraphNode,
+		FAnimNode_KawaiiPhysics* RuntimeNode,
+		const int32 RequestedIndex)
+	{
+		if (!GraphNode || !RuntimeNode ||
+			!IsExternalForceShapeMatched(GraphNode->Node.ExternalForces, RuntimeNode->ExternalForces))
+		{
+			return nullptr;
+		}
+
+		if (!GraphNode->Node.ExternalForces.IsValidIndex(RequestedIndex) ||
+			!IsProceduralWindStruct(GraphNode->Node.ExternalForces[RequestedIndex]) ||
+			!RuntimeNode->ExternalForces.IsValidIndex(RequestedIndex) ||
+			!IsProceduralWindStruct(RuntimeNode->ExternalForces[RequestedIndex]))
+		{
+			return nullptr;
+		}
+
+		return RuntimeNode->ExternalForces[RequestedIndex].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
 	}
 
 	TArray<FKawaiiProceduralWindPreset> ResolveWindScopePresets()
@@ -678,6 +744,29 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
 			[
 				SNew(SButton)
+				.Text(LOCTEXT("GustButton", "Gust"))
+				.ContentPadding(FMargin(6.0f, 2.0f))
+				.ToolTipText(LOCTEXT("GustButtonTooltip", "実行中のライブ対象へテスト突風を送ります / Sends a test gust to the live target."))
+				.OnClicked_Lambda([this]()
+				{
+					const bool bAppliedLive = PushGustToLiveRuntime(
+						WindScopeGustStrength,
+						WindScopeGustRiseTime,
+						WindScopeGustDecayTime);
+					KawaiiPhysicsEdWindowUtils::ShowNotification(
+						bAppliedLive
+							? LOCTEXT("GustSucceededLive", "Triggered wind gust. (live)")
+							: LOCTEXT("GustNoLiveTarget", "Skipped wind gust. (no live target)"),
+						bAppliedLive ? SNotificationItem::CS_Success : SNotificationItem::CS_Fail);
+					return FReply::Handled();
+				})
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SButton)
 				.Text(LOCTEXT("ReloadPresetsButton", "Reload"))
 				.ContentPadding(FMargin(6.0f, 2.0f))
 				.ToolTipText(LOCTEXT("ReloadPresetsTooltip", "プリセットDataAssetを再読み込みします / Reload the preset DataAsset."))
@@ -1006,34 +1095,67 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 	// Undo/Redo 対応のトランザクションでパラメータを書き込む
 	const FScopedTransaction Transaction(LOCTEXT("ApplyWindPresetTransaction", "Apply Kawaii Physics Wind Preset"));
 	GraphNode->Modify();
-	Wind->bIsEnabled = true;
-	Wind->SteadyForce = Preset.SteadyForce;
-	Wind->OscillationForce = Preset.OscillationForce;
-	Wind->OscillationPeriod = Preset.OscillationPeriod;
-	Wind->WaveAmplitude = Preset.WaveAmplitude;
-	Wind->WavePeriod = Preset.WavePeriod;
-	Wind->WaveSpatialOffset = Preset.WaveSpatialOffset;
-	Wind->EnvelopeMin = Preset.EnvelopeMin;
-	Wind->EnvelopeMax = Preset.EnvelopeMax;
-	Wind->EnvelopeFrequency = Preset.EnvelopeFrequency;
-	Wind->RandomForce = Preset.RandomForce;
-	Wind->RandomPeriod = Preset.RandomPeriod;
-	Wind->DirectionNoiseAngle = Preset.DirectionNoiseAngle;
-	Wind->TimeScale = 1.0f;
+	FKawaiiProceduralWindDynamicParams Params = Preset.ToDynamicParams();
+	Params.bOverrideIsEnabled = true;
+	Params.bIsEnabled = true;
+	Params.bOverrideTimeScale = true;
+	Params.TimeScale = 1.0f;
+	Wind->ApplyDynamicParams(Params);
 	MarkWindScopeGraphNodeModified(GraphNode);
+	Args.ExternalForceIndex = ResolvedIndex;
+	// シミュレーションリセット回避のため PostEditChangeProperty / NotifyGraphNodePropertyChanged は呼ばず、
+	// ライブ側には PendingParams 経由で同じ値を送る
+	const bool bAppliedLive = PushPresetToLiveRuntime(Params);
 
 	// 外力一覧を更新し、成功通知を表示
-	Args.ExternalForceIndex = ResolvedIndex;
 	RefreshExternalForceItems();
 	const int32 PresetIndex = CachedPresets.IndexOfByPredicate([&Preset](const FKawaiiProceduralWindPreset& CachedPreset)
 	{
 		return &CachedPreset == &Preset;
 	});
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
-		FText::Format(LOCTEXT("ApplyPresetSucceeded", "Applied {0} wind preset."),
+		FText::Format(bAppliedLive
+			              ? LOCTEXT("ApplyPresetSucceededLive", "Applied {0} wind preset. (live)")
+			              : LOCTEXT("ApplyPresetSucceededNodeOnly", "Applied {0} wind preset. (node only — no live target)"),
 			ResolveWindPresetDisplayName(Preset, PresetIndex)),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
+}
+
+bool SKawaiiPhysicsWindScopeWindow::PushPresetToLiveRuntime(
+	const FKawaiiProceduralWindDynamicParams& Params)
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	FAnimNode_KawaiiPhysics* RuntimeNode = ResolveLiveKawaiiPhysicsNode(GraphNode);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind = ResolveLiveProceduralWind(
+		GraphNode,
+		RuntimeNode,
+		Args.ExternalForceIndex);
+	if (!RuntimeWind)
+	{
+		return false;
+	}
+
+	RuntimeWind->RequestDynamicParams(Params);
+	return true;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::PushGustToLiveRuntime(
+	const float Strength, const float RiseTime, const float DecayTime)
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	FAnimNode_KawaiiPhysics* RuntimeNode = ResolveLiveKawaiiPhysicsNode(GraphNode);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind = ResolveLiveProceduralWind(
+		GraphNode,
+		RuntimeNode,
+		Args.ExternalForceIndex);
+	if (!RuntimeWind)
+	{
+		return false;
+	}
+
+	RuntimeWind->RequestGust(Strength, RiseTime, DecayTime);
+	return true;
 }
 
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -131,6 +131,8 @@ private:
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
+	bool PushPresetToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
+	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
 
 	// 毎フレームの active timer コールバック。Live/Preview いずれかでサンプルを更新し再描画する
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);


### PR DESCRIPTION
## 概要
Wind Scope ウィンドウの風プリセットボタンを、AnimBP をコンパイルしなくてもプレビュー／PIE 中のシミュレーションへ即時反映されるようにしました。あわせてテスト用の Gust ボタンを追加し、ProceduralWind のランタイム状態管理をスレッドセーフに強化しています。

## 背景・原因
プリセットボタンはエディタ側の `UAnimGraphNode_KawaiiPhysics::Node` に直接書き込むだけで、Details パネル編集時に走るプレビュー伝播経路（`NotifyPostChange` → `CopyNodeDataToPreviewNode`）を経由しないため、コンパイルするまで実行中のシミュレーションに反映されませんでした。

## 変更内容

### ランタイム（98788d8）
- `FKawaiiProceduralWindDynamicParams` に `bOverrideIsEnabled` / `bIsEnabled` を追加（プリセット適用時の有効化をランタイム API 経由で表現可能に）
- `RequestDynamicParams` / `RequestGust` を `FKawaiiPhysics_ExternalForce_ProceduralWind` のメンバ関数へ昇格（`KawaiiPhysicsLibrary` の内部ヘルパは委譲に簡約。エディタモジュールからも利用可能に）
- **RuntimeState のライフタイム強化**: コンストラクタで必ず生成し、以後ポインタを差し替えない設計に変更（`ResetRuntimeState` は Mutex 下で中身のみクリア）。コピーコンストラクタ／コピー代入＋`WithCopy` traits でコピー時は状態を共有せず新規生成。GT からのリクエストと Worker の再初期化が競合しうる既存の穴を構造的に解消

### エディタ（bcf0b75）
- プリセット押下時、グラフノードへの適用（従来どおり Undo/コンパイル永続化対象）に加え、デバッグ対象ノードの `PendingParams` へ push して次フレームから反映（`PostEditChangeProperty` は呼ばないためシミュレーションはリセットされません）
- 誤ターゲット防止ガード: グラフ側／ランタイム側の外力配列の形状一致（要素数＋各 index の型一致）と exact-index を検証し、不一致時は push しない
- 通知の出し分け: ライブ反映時は「(live)」、デバッグ対象なしは「(node only — no live target)」
- Gust テストボタンを追加（ライブ対象へ突風を即時発動、Strength 6.0 / Rise 0.1 / Decay 0.5）

## 既知の制限
- Undo はグラフノード値のみ復元し、ライブ実行中のノードは次のコンパイルまで元に戻りません（仕様として許容）
- Details パネル編集時に風のタイムラインがリセットされるのは従来どおりの挙動です