### PR TITLE
Live-apply ProceduralWind preset and Details edits without resetting the simulation

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -384,6 +384,167 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 	}
 }
 
+// プロパティ名から単一項目だけを上書きする DynamicParams を組み立てる
+bool FKawaiiPhysics_ExternalForce_ProceduralWind::BuildDynamicParamsForProperty(
+	const FName PropertyName, FKawaiiProceduralWindDynamicParams& OutParams) const
+{
+	OutParams = FKawaiiProceduralWindDynamicParams();
+
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+	{
+		OutParams.bOverrideIsEnabled = true;
+		OutParams.bIsEnabled = bIsEnabled;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+	{
+		OutParams.bOverrideWindDirection = true;
+		OutParams.WindDirection = WindDirection;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, SteadyForce))
+	{
+		OutParams.bOverrideSteadyForce = true;
+		OutParams.SteadyForce = SteadyForce;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, OscillationForce))
+	{
+		OutParams.bOverrideOscillationForce = true;
+		OutParams.OscillationForce = OscillationForce;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, OscillationPeriod))
+	{
+		OutParams.bOverrideOscillationPeriod = true;
+		OutParams.OscillationPeriod = OscillationPeriod;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WaveAmplitude))
+	{
+		OutParams.bOverrideWaveAmplitude = true;
+		OutParams.WaveAmplitude = WaveAmplitude;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePeriod))
+	{
+		OutParams.bOverrideWavePeriod = true;
+		OutParams.WavePeriod = WavePeriod;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePhase))
+	{
+		OutParams.bOverrideWavePhase = true;
+		OutParams.WavePhase = WavePhase;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WaveSpatialOffset))
+	{
+		OutParams.bOverrideWaveSpatialOffset = true;
+		OutParams.WaveSpatialOffset = WaveSpatialOffset;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMax))
+	{
+		OutParams.bOverrideEnvelopeMax = true;
+		OutParams.EnvelopeMax = EnvelopeMax;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMin))
+	{
+		OutParams.bOverrideEnvelopeMin = true;
+		OutParams.EnvelopeMin = EnvelopeMin;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeFrequency))
+	{
+		OutParams.bOverrideEnvelopeFrequency = true;
+		OutParams.EnvelopeFrequency = EnvelopeFrequency;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopePhase))
+	{
+		OutParams.bOverrideEnvelopePhase = true;
+		OutParams.EnvelopePhase = EnvelopePhase;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomForce))
+	{
+		OutParams.bOverrideRandomForce = true;
+		OutParams.RandomForce = RandomForce;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomPeriod))
+	{
+		OutParams.bOverrideRandomPeriod = true;
+		OutParams.RandomPeriod = RandomPeriod;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, DirectionNoiseAngle))
+	{
+		OutParams.bOverrideDirectionNoiseAngle = true;
+		OutParams.DirectionNoiseAngle = DirectionNoiseAngle;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, DirectionNoisePeriod))
+	{
+		OutParams.bOverrideDirectionNoisePeriod = true;
+		OutParams.DirectionNoisePeriod = DirectionNoisePeriod;
+		return true;
+	}
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, TimeScale))
+	{
+		OutParams.bOverrideTimeScale = true;
+		OutParams.TimeScale = TimeScale;
+		return true;
+	}
+
+	return false;
+}
+
+// 現在値を全項目上書きの DynamicParams として組み立てる
+FKawaiiProceduralWindDynamicParams FKawaiiPhysics_ExternalForce_ProceduralWind::BuildDynamicParamsSnapshot() const
+{
+	FKawaiiProceduralWindDynamicParams Params;
+	Params.bOverrideIsEnabled = true;
+	Params.bIsEnabled = bIsEnabled;
+	Params.bOverrideWindDirection = true;
+	Params.WindDirection = WindDirection;
+	Params.bOverrideSteadyForce = true;
+	Params.SteadyForce = SteadyForce;
+	Params.bOverrideOscillationForce = true;
+	Params.OscillationForce = OscillationForce;
+	Params.bOverrideOscillationPeriod = true;
+	Params.OscillationPeriod = OscillationPeriod;
+	Params.bOverrideWaveAmplitude = true;
+	Params.WaveAmplitude = WaveAmplitude;
+	Params.bOverrideWavePeriod = true;
+	Params.WavePeriod = WavePeriod;
+	Params.bOverrideWavePhase = true;
+	Params.WavePhase = WavePhase;
+	Params.bOverrideWaveSpatialOffset = true;
+	Params.WaveSpatialOffset = WaveSpatialOffset;
+	Params.bOverrideEnvelopeMax = true;
+	Params.EnvelopeMax = EnvelopeMax;
+	Params.bOverrideEnvelopeMin = true;
+	Params.EnvelopeMin = EnvelopeMin;
+	Params.bOverrideEnvelopeFrequency = true;
+	Params.EnvelopeFrequency = EnvelopeFrequency;
+	Params.bOverrideEnvelopePhase = true;
+	Params.EnvelopePhase = EnvelopePhase;
+	Params.bOverrideRandomForce = true;
+	Params.RandomForce = RandomForce;
+	Params.bOverrideRandomPeriod = true;
+	Params.RandomPeriod = RandomPeriod;
+	Params.bOverrideDirectionNoiseAngle = true;
+	Params.DirectionNoiseAngle = DirectionNoiseAngle;
+	Params.bOverrideDirectionNoisePeriod = true;
+	Params.DirectionNoisePeriod = DirectionNoisePeriod;
+	Params.bOverrideTimeScale = true;
+	Params.TimeScale = TimeScale;
+	return Params;
+}
+
 // 動的パラメータ更新を PendingParams として積み、次回 PreApply で反映する
 void FKawaiiPhysics_ExternalForce_ProceduralWind::RequestDynamicParams(
 	const FKawaiiProceduralWindDynamicParams& Params)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -2,6 +2,7 @@
 
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 
+#include "HAL/CriticalSection.h"
 #include "Math/RotationMatrix.h"
 #include "Misc/ScopeLock.h"
 
@@ -132,6 +133,102 @@ void InitializeRuntimeStateContents(FKawaiiProceduralWindRuntimeState& State)
 	State.ScopeSampleCount = 0;
 #endif
 }
+
+void MergePendingDynamicParams(FKawaiiProceduralWindDynamicParams& PendingParams,
+                               const FKawaiiProceduralWindDynamicParams& IncomingParams)
+{
+	// 単一スロットの PendingParams を上書きすると、consume 前に届いた別項目のリクエストが失われるため、項目単位でマージする。同一項目は後勝ち
+	if (IncomingParams.bOverrideIsEnabled)
+	{
+		PendingParams.bOverrideIsEnabled = true;
+		PendingParams.bIsEnabled = IncomingParams.bIsEnabled;
+	}
+	if (IncomingParams.bOverrideWindDirection)
+	{
+		PendingParams.bOverrideWindDirection = true;
+		PendingParams.WindDirection = IncomingParams.WindDirection;
+	}
+	if (IncomingParams.bOverrideSteadyForce)
+	{
+		PendingParams.bOverrideSteadyForce = true;
+		PendingParams.SteadyForce = IncomingParams.SteadyForce;
+	}
+	if (IncomingParams.bOverrideOscillationForce)
+	{
+		PendingParams.bOverrideOscillationForce = true;
+		PendingParams.OscillationForce = IncomingParams.OscillationForce;
+	}
+	if (IncomingParams.bOverrideOscillationPeriod)
+	{
+		PendingParams.bOverrideOscillationPeriod = true;
+		PendingParams.OscillationPeriod = IncomingParams.OscillationPeriod;
+	}
+	if (IncomingParams.bOverrideWaveAmplitude)
+	{
+		PendingParams.bOverrideWaveAmplitude = true;
+		PendingParams.WaveAmplitude = IncomingParams.WaveAmplitude;
+	}
+	if (IncomingParams.bOverrideWavePeriod)
+	{
+		PendingParams.bOverrideWavePeriod = true;
+		PendingParams.WavePeriod = IncomingParams.WavePeriod;
+	}
+	if (IncomingParams.bOverrideWavePhase)
+	{
+		PendingParams.bOverrideWavePhase = true;
+		PendingParams.WavePhase = IncomingParams.WavePhase;
+	}
+	if (IncomingParams.bOverrideWaveSpatialOffset)
+	{
+		PendingParams.bOverrideWaveSpatialOffset = true;
+		PendingParams.WaveSpatialOffset = IncomingParams.WaveSpatialOffset;
+	}
+	if (IncomingParams.bOverrideEnvelopeMax)
+	{
+		PendingParams.bOverrideEnvelopeMax = true;
+		PendingParams.EnvelopeMax = IncomingParams.EnvelopeMax;
+	}
+	if (IncomingParams.bOverrideEnvelopeMin)
+	{
+		PendingParams.bOverrideEnvelopeMin = true;
+		PendingParams.EnvelopeMin = IncomingParams.EnvelopeMin;
+	}
+	if (IncomingParams.bOverrideEnvelopeFrequency)
+	{
+		PendingParams.bOverrideEnvelopeFrequency = true;
+		PendingParams.EnvelopeFrequency = IncomingParams.EnvelopeFrequency;
+	}
+	if (IncomingParams.bOverrideEnvelopePhase)
+	{
+		PendingParams.bOverrideEnvelopePhase = true;
+		PendingParams.EnvelopePhase = IncomingParams.EnvelopePhase;
+	}
+	if (IncomingParams.bOverrideRandomForce)
+	{
+		PendingParams.bOverrideRandomForce = true;
+		PendingParams.RandomForce = IncomingParams.RandomForce;
+	}
+	if (IncomingParams.bOverrideRandomPeriod)
+	{
+		PendingParams.bOverrideRandomPeriod = true;
+		PendingParams.RandomPeriod = IncomingParams.RandomPeriod;
+	}
+	if (IncomingParams.bOverrideDirectionNoiseAngle)
+	{
+		PendingParams.bOverrideDirectionNoiseAngle = true;
+		PendingParams.DirectionNoiseAngle = IncomingParams.DirectionNoiseAngle;
+	}
+	if (IncomingParams.bOverrideDirectionNoisePeriod)
+	{
+		PendingParams.bOverrideDirectionNoisePeriod = true;
+		PendingParams.DirectionNoisePeriod = IncomingParams.DirectionNoisePeriod;
+	}
+	if (IncomingParams.bOverrideTimeScale)
+	{
+		PendingParams.bOverrideTimeScale = true;
+		PendingParams.TimeScale = IncomingParams.TimeScale;
+	}
+}
 }
 
 FKawaiiPhysics_ExternalForce_ProceduralWind::FKawaiiPhysics_ExternalForce_ProceduralWind()
@@ -179,23 +276,33 @@ FKawaiiPhysics_ExternalForce_ProceduralWind& FKawaiiPhysics_ExternalForce_Proced
 	RandomPeriod = Other.RandomPeriod;
 	RandomSeed = Other.RandomSeed;
 
-	RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
-	InitializeRuntimeStateContents(*RuntimeState);
+	// RuntimeState はインスタンス間でコピー・共有しない。代入先が有効な RuntimeState を持つ場合はポインタと中身（Time/ActiveGust/PendingParams）を保持し、
+	// Persona の CopyNodeDataToPreviewNode などのインプレース同期でシミュレーション時刻をリセットしない。無効な代入先だけ新規生成する。
+	EnsureRuntimeState();
 	return *this;
 }
 
 // RuntimeState のポインタは維持し、中身だけを初期状態へ戻す
 void FKawaiiPhysics_ExternalForce_ProceduralWind::ResetRuntimeState()
 {
+	const auto State = EnsureRuntimeState();
+	FScopeLock Lock(&State->Mutex);
+	InitializeRuntimeStateContents(*State);
+}
+
+TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> FKawaiiPhysics_ExternalForce_ProceduralWind::EnsureRuntimeState()
+{
+	// この関数内の RuntimeState 参照はすべてロックで直列化し、invalid→valid 遷移時の未同期な読み書きを避ける。
+	// 他のコードがロックなしで参照できる主保証は、RuntimeState を常に有効に保つ不変条件。
+	static FCriticalSection RuntimeStateCreationMutex;
+	FScopeLock Lock(&RuntimeStateCreationMutex);
 	if (!RuntimeState.IsValid())
 	{
 		RuntimeState = MakeShared<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe>();
 		InitializeRuntimeStateContents(*RuntimeState);
-		return;
 	}
 
-	FScopeLock Lock(&RuntimeState->Mutex);
-	InitializeRuntimeStateContents(*RuntimeState);
+	return RuntimeState;
 }
 
 // ランタイムAPI（BP/C++）経由で送られた上書きパラメータを反映する。bOverride が立っている項目のみ適用し、
@@ -281,26 +388,23 @@ void FKawaiiPhysics_ExternalForce_ProceduralWind::ApplyDynamicParams(
 void FKawaiiPhysics_ExternalForce_ProceduralWind::RequestDynamicParams(
 	const FKawaiiProceduralWindDynamicParams& Params)
 {
-	if (!RuntimeState.IsValid())
-	{
-		return;
-	}
-
-	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = RuntimeState;
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = EnsureRuntimeState();
 	FScopeLock Lock(&LocalRuntimeState->Mutex);
-	LocalRuntimeState->PendingParams = Params;
+	if (LocalRuntimeState->PendingParams.IsSet())
+	{
+		MergePendingDynamicParams(LocalRuntimeState->PendingParams.GetValue(), Params);
+	}
+	else
+	{
+		LocalRuntimeState->PendingParams = Params;
+	}
 }
 
 // 突風要求を PendingGust として積み、次回 PreApply で反映する
 void FKawaiiPhysics_ExternalForce_ProceduralWind::RequestGust(
 	const float Strength, const float RiseTime, const float DecayTime)
 {
-	if (!RuntimeState.IsValid())
-	{
-		return;
-	}
-
-	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = RuntimeState;
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> LocalRuntimeState = EnsureRuntimeState();
 	FScopeLock Lock(&LocalRuntimeState->Mutex);
 	LocalRuntimeState->PendingGust = FKawaiiProceduralWindGustRequest{
 		Strength,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -626,6 +626,36 @@ bool FKawaiiPhysicsProceduralWindAssignmentPreservesDestinationRuntimeStateTest:
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindInPlaceCopyScriptStructPreservesRuntimeStateTest,
+                                 "KawaiiPhysics.ProceduralWind.InPlaceCopyScriptStructPreservesRuntimeState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindInPlaceCopyScriptStructPreservesRuntimeStateTest::RunTest(const FString& Parameters)
+{
+	// エディタの in-place 同期と同じ CopyScriptStruct 経路で、プロパティだけがコピーされ実行中状態が維持されることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Source;
+	Source.WindDirection = FRotator(0.0f, 20.0f, 30.0f);
+	Source.SteadyForce = 5.0f;
+	Source.RuntimeState->Time = 3.0f;
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind Destination;
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> DestinationRuntimeState =
+		Destination.RuntimeState;
+	Destination.RuntimeState->Time = 7.0f;
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct()->CopyScriptStruct(&Destination, &Source);
+
+	TestTrue(TEXT("Destination RuntimeState pointer is preserved"),
+	         Destination.RuntimeState.Get() == DestinationRuntimeState.Get());
+	TestSampleNear(*this, TEXT("Destination Time preserved"), Destination.RuntimeState->Time, 7.0f);
+	TestTrue(TEXT("WindDirection copied"), Destination.WindDirection.Equals(Source.WindDirection));
+	TestSampleNear(*this, TEXT("SteadyForce copied"), Destination.SteadyForce, Source.SteadyForce);
+	TestTrue(TEXT("RuntimeState is not shared with source"),
+	         Destination.RuntimeState.Get() != Source.RuntimeState.Get());
+
+	return true;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindRequestCreatesRuntimeStateTest,
                                  "KawaiiPhysics.ProceduralWind.RequestCreatesRuntimeState",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -36,6 +36,29 @@ void TestSampleNear(FAutomationTestBase& Test, const TCHAR* Name, const float Ac
 }
 
 // DynamicParams の bOverride フラグ数を数え、単一プロパティ/全項目スナップショットの検証に使う
+int32 CountDynamicParamOverrideFlags(const FKawaiiProceduralWindDynamicParams& Params)
+{
+	return
+		(Params.bOverrideIsEnabled ? 1 : 0) +
+		(Params.bOverrideWindDirection ? 1 : 0) +
+		(Params.bOverrideSteadyForce ? 1 : 0) +
+		(Params.bOverrideOscillationForce ? 1 : 0) +
+		(Params.bOverrideOscillationPeriod ? 1 : 0) +
+		(Params.bOverrideWaveAmplitude ? 1 : 0) +
+		(Params.bOverrideWavePeriod ? 1 : 0) +
+		(Params.bOverrideWavePhase ? 1 : 0) +
+		(Params.bOverrideWaveSpatialOffset ? 1 : 0) +
+		(Params.bOverrideEnvelopeMax ? 1 : 0) +
+		(Params.bOverrideEnvelopeMin ? 1 : 0) +
+		(Params.bOverrideEnvelopeFrequency ? 1 : 0) +
+		(Params.bOverrideEnvelopePhase ? 1 : 0) +
+		(Params.bOverrideRandomForce ? 1 : 0) +
+		(Params.bOverrideRandomPeriod ? 1 : 0) +
+		(Params.bOverrideDirectionNoiseAngle ? 1 : 0) +
+		(Params.bOverrideDirectionNoisePeriod ? 1 : 0) +
+		(Params.bOverrideTimeScale ? 1 : 0);
+}
+
 // Rate=[0,1]をNumSegments分割で走査し、Waveが最大となる区間インデックスを求める（WavePropagationテストでピーク位置の移動検出に使用）
 int32 FindWavePeakIndex(const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind, const float Time,
                         const int32 NumSegments)
@@ -689,6 +712,85 @@ bool FKawaiiPhysicsProceduralWindRequestCreatesRuntimeStateTest::RunTest(const F
 	TestSampleNear(*this, TEXT("ActiveGust RiseTime applied"), GustWind.RuntimeState->ActiveGust.RiseTime, 0.2f);
 	TestSampleNear(*this, TEXT("ActiveGust DecayTime applied"), GustWind.RuntimeState->ActiveGust.DecayTime, 0.6f);
 	TestFalse(TEXT("PendingGust reset after consume"), GustWind.RuntimeState->PendingGust.IsSet());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindDynamicParamsForPropertyTest,
+                                 "KawaiiPhysics.ProceduralWind.DynamicParamsForProperty",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindDynamicParamsForPropertyTest::RunTest(const FString& Parameters)
+{
+	// プロパティ名から、その項目だけを上書きする DynamicParams が作られることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.WindDirection = FRotator(0.0f, 20.0f, 30.0f);
+
+	FKawaiiProceduralWindDynamicParams Params;
+	const bool bBuilt = Wind.BuildDynamicParamsForProperty(
+		GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection), Params);
+
+	TestTrue(TEXT("WindDirection params built"), bBuilt);
+	TestTrue(TEXT("Only one override flag is set"), CountDynamicParamOverrideFlags(Params) == 1);
+	TestTrue(TEXT("WindDirection override is set"), Params.bOverrideWindDirection);
+	TestFalse(TEXT("SteadyForce override is not set"), Params.bOverrideSteadyForce);
+	TestFalse(TEXT("TimeScale override is not set"), Params.bOverrideTimeScale);
+	TestFalse(TEXT("IsEnabled override is not set"), Params.bOverrideIsEnabled);
+	TestTrue(TEXT("WindDirection value matches"), Params.WindDirection.Equals(Wind.WindDirection));
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind AppliedWind;
+	AppliedWind.SteadyForce = 2.5f;
+	AppliedWind.TimeScale = 0.75f;
+	AppliedWind.ApplyDynamicParams(Params);
+
+	TestTrue(TEXT("WindDirection applied"), AppliedWind.WindDirection.Equals(Wind.WindDirection));
+	TestSampleNear(*this, TEXT("SteadyForce untouched"), AppliedWind.SteadyForce, 2.5f);
+	TestSampleNear(*this, TEXT("TimeScale untouched"), AppliedWind.TimeScale, 0.75f);
+
+	FKawaiiProceduralWindDynamicParams UnmappedParams;
+	const bool bUnmappedBuilt = Wind.BuildDynamicParamsForProperty(FName(TEXT("RandomSeed")), UnmappedParams);
+	TestFalse(TEXT("RandomSeed is unmapped"), bUnmappedBuilt);
+	TestTrue(TEXT("Unmapped leaves no override flags"), CountDynamicParamOverrideFlags(UnmappedParams) == 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindDynamicParamsSnapshotTest,
+                                 "KawaiiPhysics.ProceduralWind.DynamicParamsSnapshot",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindDynamicParamsSnapshotTest::RunTest(const FString& Parameters)
+{
+	// スナップショットは DynamicParams 対応項目をすべて上書き対象にして現在値を保持する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+	Wind.WindDirection = FRotator(0.0f, 20.0f, 30.0f);
+	Wind.SteadyForce = 5.0f;
+	Wind.OscillationPeriod = 0.25f;
+	Wind.WavePeriod = 0.5f;
+	Wind.RandomPeriod = 0.75f;
+	Wind.DirectionNoisePeriod = 1.25f;
+	Wind.TimeScale = 0.5f;
+	Wind.bIsEnabled = false;
+
+	const FKawaiiProceduralWindDynamicParams Params = Wind.BuildDynamicParamsSnapshot();
+
+	TestTrue(TEXT("All override flags are set"), CountDynamicParamOverrideFlags(Params) == 18);
+	TestTrue(TEXT("IsEnabled override is set"), Params.bOverrideIsEnabled);
+	TestTrue(TEXT("WindDirection override is set"), Params.bOverrideWindDirection);
+	TestTrue(TEXT("SteadyForce override is set"), Params.bOverrideSteadyForce);
+	TestTrue(TEXT("TimeScale override is set"), Params.bOverrideTimeScale);
+	TestFalse(TEXT("Snapshot bIsEnabled matches"), Params.bIsEnabled);
+	TestTrue(TEXT("Snapshot WindDirection matches"), Params.WindDirection.Equals(Wind.WindDirection));
+	TestSampleNear(*this, TEXT("Snapshot SteadyForce matches"), Params.SteadyForce, 5.0f);
+	TestSampleNear(*this, TEXT("Snapshot TimeScale matches"), Params.TimeScale, 0.5f);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind AppliedWind;
+	AppliedWind.ApplyDynamicParams(Params);
+
+	TestTrue(TEXT("Snapshot WindDirection applied"), AppliedWind.WindDirection.Equals(Wind.WindDirection));
+	TestSampleNear(*this, TEXT("Snapshot SteadyForce applied"), AppliedWind.SteadyForce, 5.0f);
+	TestSampleNear(*this, TEXT("Snapshot TimeScale applied"), AppliedWind.TimeScale, 0.5f);
+	TestFalse(TEXT("Snapshot bIsEnabled applied"), AppliedWind.bIsEnabled);
 
 	return true;
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -35,6 +35,7 @@ void TestSampleNear(FAutomationTestBase& Test, const TCHAR* Name, const float Ac
 	              FMath::IsNearlyEqual(Actual, Expected, Tol));
 }
 
+// DynamicParams の bOverride フラグ数を数え、単一プロパティ/全項目スナップショットの検証に使う
 // Rate=[0,1]をNumSegments分割で走査し、Waveが最大となる区間インデックスを求める（WavePropagationテストでピーク位置の移動検出に使用）
 int32 FindWavePeakIndex(const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind, const float Time,
                         const int32 NumSegments)
@@ -464,6 +465,56 @@ bool FKawaiiPhysicsProceduralWindPendingConsumptionTest::RunTest(const FString& 
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindRequestDynamicParamsMergeTest,
+                                 "KawaiiPhysics.ProceduralWind.RequestDynamicParamsMerge",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindRequestDynamicParamsMergeTest::RunTest(const FString& Parameters)
+{
+	// consume 前に複数の動的パラメータ要求が届いても、別項目は保持され、同一項目は後勝ちになることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
+
+	FKawaiiProceduralWindDynamicParams DirectionParams;
+	DirectionParams.bOverrideWindDirection = true;
+	DirectionParams.WindDirection = FRotator(0.0f, 20.0f, 30.0f);
+	Wind.RequestDynamicParams(DirectionParams);
+
+	FKawaiiProceduralWindDynamicParams SteadyParams;
+	SteadyParams.bOverrideSteadyForce = true;
+	SteadyParams.SteadyForce = 9.0f;
+	Wind.RequestDynamicParams(SteadyParams);
+
+	TestTrue(TEXT("PendingParams merged"), Wind.RuntimeState->PendingParams.IsSet());
+	if (!Wind.RuntimeState->PendingParams.IsSet())
+	{
+		return false;
+	}
+
+	const FKawaiiProceduralWindDynamicParams& PendingParams = Wind.RuntimeState->PendingParams.GetValue();
+	TestTrue(TEXT("Pending WindDirection override merged"), PendingParams.bOverrideWindDirection);
+	TestTrue(TEXT("Pending SteadyForce override merged"), PendingParams.bOverrideSteadyForce);
+
+	Wind.ConsumePendingRequests();
+
+	TestTrue(TEXT("Merged WindDirection applied"), Wind.WindDirection.Equals(FRotator(0.0f, 20.0f, 30.0f)));
+	TestSampleNear(*this, TEXT("Merged SteadyForce applied"), Wind.SteadyForce, 9.0f);
+
+	FKawaiiProceduralWindDynamicParams FirstDirectionParams;
+	FirstDirectionParams.bOverrideWindDirection = true;
+	FirstDirectionParams.WindDirection = FRotator(1.0f, 2.0f, 3.0f);
+	Wind.RequestDynamicParams(FirstDirectionParams);
+
+	FKawaiiProceduralWindDynamicParams LastDirectionParams;
+	LastDirectionParams.bOverrideWindDirection = true;
+	LastDirectionParams.WindDirection = FRotator(4.0f, 5.0f, 6.0f);
+	Wind.RequestDynamicParams(LastDirectionParams);
+	Wind.ConsumePendingRequests();
+
+	TestTrue(TEXT("Last WindDirection request wins"), Wind.WindDirection.Equals(FRotator(4.0f, 5.0f, 6.0f)));
+
+	return true;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindFramerateIndependenceTest,
                                  "KawaiiPhysics.ProceduralWind.FramerateIndependence",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -527,6 +578,87 @@ bool FKawaiiPhysicsProceduralWindResetRuntimeStateTest::RunTest(const FString& P
 	TestEqual(TEXT("ScopeWriteIndex after reset"), Wind.RuntimeState->ScopeWriteIndex, 0);
 	TestEqual(TEXT("ScopeSampleCount after reset"), Wind.RuntimeState->ScopeSampleCount, static_cast<uint64>(0));
 #endif
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindAssignmentPreservesDestinationRuntimeStateTest,
+                                 "KawaiiPhysics.ProceduralWind.AssignmentPreservesDestinationRuntimeState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindAssignmentPreservesDestinationRuntimeStateTest::RunTest(const FString& Parameters)
+{
+	// 代入時にプロパティだけをコピーし、代入先の実行中状態（時刻・Pending）とポインタが維持されることを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind Destination;
+	const TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> DestinationRuntimeState =
+		Destination.RuntimeState;
+	Destination.RuntimeState->Time = 7.0f;
+
+	FKawaiiProceduralWindDynamicParams PendingParams;
+	PendingParams.bOverrideSteadyForce = true;
+	PendingParams.SteadyForce = 11.0f;
+	Destination.RequestDynamicParams(PendingParams);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind Source;
+	Source.WindDirection = FRotator(0.0f, 20.0f, 30.0f);
+	Source.SteadyForce = 5.0f;
+	Source.OscillationForce = 6.0f;
+	Source.TimeScale = 0.5f;
+	Source.RuntimeState->Time = 3.0f;
+
+	Destination = Source;
+
+	TestTrue(TEXT("Destination RuntimeState pointer is preserved"),
+	         Destination.RuntimeState.Get() == DestinationRuntimeState.Get());
+	TestSampleNear(*this, TEXT("Destination Time preserved"), Destination.RuntimeState->Time, 7.0f);
+	TestTrue(TEXT("Destination PendingParams preserved"), Destination.RuntimeState->PendingParams.IsSet());
+	TestTrue(TEXT("PendingParams override preserved"),
+	         Destination.RuntimeState->PendingParams.GetValue().bOverrideSteadyForce);
+	TestSampleNear(*this, TEXT("PendingParams value preserved"),
+	               Destination.RuntimeState->PendingParams.GetValue().SteadyForce, 11.0f);
+	TestTrue(TEXT("WindDirection copied"), Destination.WindDirection.Equals(Source.WindDirection));
+	TestSampleNear(*this, TEXT("SteadyForce copied"), Destination.SteadyForce, Source.SteadyForce);
+	TestSampleNear(*this, TEXT("OscillationForce copied"), Destination.OscillationForce, Source.OscillationForce);
+	TestSampleNear(*this, TEXT("TimeScale copied"), Destination.TimeScale, Source.TimeScale);
+	TestTrue(TEXT("RuntimeState is not shared with source"),
+	         Destination.RuntimeState.Get() != Source.RuntimeState.Get());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsProceduralWindRequestCreatesRuntimeStateTest,
+                                 "KawaiiPhysics.ProceduralWind.RequestCreatesRuntimeState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsProceduralWindRequestCreatesRuntimeStateTest::RunTest(const FString& Parameters)
+{
+	// 無効な RuntimeState に対する Request API が状態を遅延生成し、次回消費まで要求を保持することを確認する。
+	FKawaiiPhysics_ExternalForce_ProceduralWind ParamsWind;
+	ParamsWind.RuntimeState.Reset();
+
+	FKawaiiProceduralWindDynamicParams Params;
+	Params.bOverrideSteadyForce = true;
+	Params.SteadyForce = 9.0f;
+	ParamsWind.RequestDynamicParams(Params);
+
+	TestTrue(TEXT("RequestDynamicParams creates RuntimeState"), ParamsWind.RuntimeState.IsValid());
+	TestTrue(TEXT("PendingParams set after request"), ParamsWind.RuntimeState->PendingParams.IsSet());
+	ParamsWind.ConsumePendingRequests();
+	TestSampleNear(*this, TEXT("PendingParams applied"), ParamsWind.SteadyForce, 9.0f);
+	TestFalse(TEXT("PendingParams reset after consume"), ParamsWind.RuntimeState->PendingParams.IsSet());
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind GustWind;
+	GustWind.RuntimeState.Reset();
+	GustWind.RequestGust(4.0f, 0.2f, 0.6f);
+
+	TestTrue(TEXT("RequestGust creates RuntimeState"), GustWind.RuntimeState.IsValid());
+	TestTrue(TEXT("PendingGust set after request"), GustWind.RuntimeState->PendingGust.IsSet());
+	GustWind.ConsumePendingRequests();
+	TestTrue(TEXT("ActiveGust active after consume"), GustWind.RuntimeState->ActiveGust.bIsActive);
+	TestSampleNear(*this, TEXT("ActiveGust Strength applied"), GustWind.RuntimeState->ActiveGust.Strength, 4.0f);
+	TestSampleNear(*this, TEXT("ActiveGust RiseTime applied"), GustWind.RuntimeState->ActiveGust.RiseTime, 0.2f);
+	TestSampleNear(*this, TEXT("ActiveGust DecayTime applied"), GustWind.RuntimeState->ActiveGust.DecayTime, 0.6f);
+	TestFalse(TEXT("PendingGust reset after consume"), GustWind.RuntimeState->PendingGust.IsSet());
 
 	return true;
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -235,7 +235,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	GENERATED_BODY()
 
 	FKawaiiPhysics_ExternalForce_ProceduralWind();
-	// コピーは RuntimeState を共有せず新規生成する（メンバ追加時は operator= のコピー処理にも追加すること）
+	// コピーは RuntimeState を共有しない。代入先の RuntimeState が有効ならポインタと中身を保持する（メンバ追加時は operator= のコピー処理にも追加すること）
 	FKawaiiPhysics_ExternalForce_ProceduralWind(const FKawaiiPhysics_ExternalForce_ProceduralWind& Other);
 	FKawaiiPhysics_ExternalForce_ProceduralWind& operator=(const FKawaiiPhysics_ExternalForce_ProceduralWind& Other);
 
@@ -396,6 +396,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> RuntimeState;
 
 	void ResetRuntimeState();
+	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> EnsureRuntimeState();
 	void ApplyDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
 	void RequestDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
 	void RequestGust(float Strength, float RiseTime, float DecayTime);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -399,6 +399,10 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	TSharedPtr<FKawaiiProceduralWindRuntimeState, ESPMode::ThreadSafe> EnsureRuntimeState();
 	void ApplyDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
 	void RequestDynamicParams(const FKawaiiProceduralWindDynamicParams& Params);
+	// 指定プロパティ名に対応する項目だけ bOverride を立てた DynamicParams を作る（未対応名なら false） / Builds DynamicParams overriding only the named property (false if unmapped)
+	bool BuildDynamicParamsForProperty(FName PropertyName, FKawaiiProceduralWindDynamicParams& OutParams) const;
+	// 全項目の bOverride を立てた現在値スナップショットを作る / Builds a snapshot of current values with every override flag set
+	FKawaiiProceduralWindDynamicParams BuildDynamicParamsSnapshot() const;
 	void RequestGust(float Strength, float RiseTime, float DecayTime);
 	void ConsumePendingRequests();
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -11,6 +11,8 @@
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 #include "IContentBrowserSingleton.h"
 #include "KawaiiPhysics.h"
 #include "KawaiiPhysicsBoneConstraintsDataAsset.h"
@@ -94,6 +96,43 @@ namespace
 			Strings.Add(PropertyName.ToString());
 		}
 		return FString::Join(Strings, TEXT(", "));
+	}
+
+	bool IsProceduralWindExternalForcesEdit(const FPropertyChangedChainEvent& PropertyChangedEvent)
+	{
+		for (FEditPropertyChain::TDoubleLinkedListNode* ChainNode =
+			     PropertyChangedEvent.PropertyChain.GetHead();
+		     ChainNode;
+		     ChainNode = ChainNode->GetNextNode())
+		{
+			const FProperty* ChainProperty = ChainNode->GetValue();
+			if (ChainProperty &&
+				ChainProperty->GetFName() == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, ExternalForces))
+			{
+				return true;
+			}
+		}
+
+		const FProperty* ChangedProperty = PropertyChangedEvent.Property;
+		const UStruct* OwnerStruct = ChangedProperty ? ChangedProperty->GetOwnerStruct() : nullptr;
+		return OwnerStruct &&
+			(OwnerStruct == FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct() ||
+				OwnerStruct->IsChildOf(FKawaiiPhysics_ExternalForce::StaticStruct()));
+	}
+
+	bool IsProceduralWindStructProperty(const FName PropertyName)
+	{
+		return PropertyName != NAME_None &&
+			FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct()->FindPropertyByName(PropertyName) != nullptr;
+	}
+
+	bool IsOtherExternalForceStructProperty(const FProperty* Property)
+	{
+		const UStruct* OwnerStruct = Property ? Property->GetOwnerStruct() : nullptr;
+		return OwnerStruct &&
+			OwnerStruct->IsChildOf(FKawaiiPhysics_ExternalForce::StaticStruct()) &&
+			OwnerStruct != FKawaiiPhysics_ExternalForce::StaticStruct() &&
+			OwnerStruct != FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
 	}
 }
 
@@ -184,6 +223,83 @@ void UAnimGraphNode_KawaiiPhysics::PostEditChangeProperty(struct FPropertyChange
 
 	Node.ModifyBones.Empty();
 	ReconstructNode();
+}
+
+void UAnimGraphNode_KawaiiPhysics::PostEditChangeChainProperty(FPropertyChangedChainEvent& PropertyChangedEvent)
+{
+	// 既定実装が PostEditChangeProperty（ReconstructNode 等）を呼ぶため先に通す
+	Super::PostEditChangeChainProperty(PropertyChangedEvent);
+	PushProceduralWindEditToLiveInstance(PropertyChangedEvent);
+}
+
+void UAnimGraphNode_KawaiiPhysics::PushProceduralWindEditToLiveInstance(
+	const FPropertyChangedChainEvent& PropertyChangedEvent)
+{
+	if (!IsProceduralWindExternalForcesEdit(PropertyChangedEvent))
+	{
+		return;
+	}
+
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(this);
+	if (!RuntimeNode ||
+		!KawaiiPhysicsEdUtils::IsExternalForceShapeMatched(Node.ExternalForces, RuntimeNode->ExternalForces))
+	{
+		return;
+	}
+
+	const FName EditedPropertyName = PropertyChangedEvent.Property
+		                                 ? PropertyChangedEvent.Property->GetFName()
+		                                 : NAME_None;
+
+	const auto PushWindAtIndex = [this, RuntimeNode, EditedPropertyName](const int32 Index)
+	{
+		const FKawaiiPhysics_ExternalForce_ProceduralWind* GraphWind =
+			Node.ExternalForces[Index].GetPtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+		FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind =
+			RuntimeNode->ExternalForces[Index].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+		if (!GraphWind || !RuntimeWind)
+		{
+			return;
+		}
+
+		FKawaiiProceduralWindDynamicParams Params;
+		if (!GraphWind->BuildDynamicParamsForProperty(EditedPropertyName, Params))
+		{
+			if (IsProceduralWindStructProperty(EditedPropertyName))
+			{
+				// 未対応の ProceduralWind メンバは編集値を DynamicParams に載せられないためここでは送らない。
+				// スナップショット送信はその編集値を含まないまま PIE 側の対応済み項目を上書きしてしまう。
+				return;
+			}
+			Params = GraphWind->BuildDynamicParamsSnapshot();
+		}
+		RuntimeWind->RequestDynamicParams(Params);
+	};
+
+	const int32 EditedIndex = PropertyChangedEvent.GetArrayIndex(TEXT("ExternalForces"));
+	if (EditedIndex != INDEX_NONE)
+	{
+		if (!Node.ExternalForces.IsValidIndex(EditedIndex) ||
+			!RuntimeNode->ExternalForces.IsValidIndex(EditedIndex))
+		{
+			return;
+		}
+
+		PushWindAtIndex(EditedIndex);
+		return;
+	}
+
+	if (IsOtherExternalForceStructProperty(PropertyChangedEvent.Property))
+	{
+		return;
+	}
+
+	// 配列インデックスを特定できない単一 ProceduralWind 構成が主用途のため、全 ProceduralWind へのフォールバックは残す。
+	// Persona では CopyNodeDataToPreviewNode の直接同期と二重になるが同値なので無害。PIE では再コンパイル不要で反映される。
+	for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+	{
+		PushWindAtIndex(Index);
+	}
 }
 
 void UAnimGraphNode_KawaiiPhysics::PostLoad()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -18,6 +18,7 @@
 #include "KawaiiPhysicsLimitsDataAsset.h"
 #include "KawaiiPhysicsPresetDataAsset.h"
 #include "KawaiiPhysicsPresetDiffSnapshot.h"
+#include "KawaiiPhysicsEdUtils.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
 #include "SKawaiiPhysicsPresetDiffWindow.h"
 #include "SKawaiiPhysicsWindScopeWindow.h"
@@ -280,7 +281,26 @@ void UAnimGraphNode_KawaiiPhysics::CopyNodeDataToPreviewNode(FAnimNode_Base* Ani
 	KawaiiPhysics->bUseWorldSpaceGravity = Node.bUseWorldSpaceGravity;
 	KawaiiPhysics->SimpleExternalForce = Node.SimpleExternalForce;
 	KawaiiPhysics->bUseWorldSpaceSimpleExternalForce = Node.bUseWorldSpaceSimpleExternalForce;
-	KawaiiPhysics->ExternalForces = Node.ExternalForces;
+	// ExternalForces は丸ごと代入すると FInstancedStruct が破棄→再構築され、ProceduralWind の
+	// RuntimeState（シミュレーション時刻・gust・Pending 要求）が失われる。形状（要素数と型）が
+	// 一致している間は既存メモリへの in-place コピーでプロパティのみ同期し、実行中状態を保持する
+	if (KawaiiPhysicsEdUtils::IsExternalForceShapeMatched(KawaiiPhysics->ExternalForces, Node.ExternalForces))
+	{
+		for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+		{
+			if (const UScriptStruct* ScriptStruct =
+				KawaiiPhysicsEdUtils::GetExternalForceScriptStruct(Node.ExternalForces[Index]))
+			{
+				ScriptStruct->CopyScriptStruct(KawaiiPhysics->ExternalForces[Index].GetMutableMemory(),
+				                               Node.ExternalForces[Index].GetMemory());
+			}
+		}
+	}
+	else
+	{
+		// 外力の追加/削除/並べ替え/型変更時は従来どおり丸ごと代入（フルリセット）
+		KawaiiPhysics->ExternalForces = Node.ExternalForces;
+	}
 	KawaiiPhysics->CustomExternalForces = Node.CustomExternalForces;
 
 	// Wind

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdUtils.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdUtils.h
@@ -1,0 +1,52 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "AnimGraphNode_KawaiiPhysics.h"
+#include "Animation/AnimBlueprint.h"
+#include "Animation/AnimInstance.h"
+
+namespace KawaiiPhysicsEdUtils
+{
+	inline const UScriptStruct* GetExternalForceScriptStruct(const FInstancedStruct& InstancedStruct)
+	{
+		return InstancedStruct.IsValid() ? InstancedStruct.GetScriptStruct() : nullptr;
+	}
+
+	// ExternalForces の要素数と各インデックスの型が一致しているかを判定する。両方無効な要素は同じ形状として扱う
+	inline bool IsExternalForceShapeMatched(const TArray<FInstancedStruct>& A,
+	                                        const TArray<FInstancedStruct>& B)
+	{
+		if (A.Num() != B.Num())
+		{
+			return false;
+		}
+
+		for (int32 Index = 0; Index < A.Num(); ++Index)
+		{
+			if (GetExternalForceScriptStruct(A[Index]) != GetExternalForceScriptStruct(B[Index]))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// デバッグ対象がある場合だけ実行中の KawaiiPhysics ノードを返す
+	inline FAnimNode_KawaiiPhysics* ResolveLiveKawaiiPhysicsNode(UAnimGraphNode_KawaiiPhysics* GraphNode)
+	{
+		if (!GraphNode)
+		{
+			return nullptr;
+		}
+
+		UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
+		UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
+		if (!Cast<UAnimInstance>(ObjectBeingDebugged))
+		{
+			return nullptr;
+		}
+
+		return GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
+	}
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -9,6 +9,7 @@
 #include "Framework/Application/SlateApplication.h"
 #include "HAL/CriticalSection.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
+#include "KawaiiPhysicsEdUtils.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
@@ -135,54 +136,13 @@ namespace
 		return FindFirstProceduralWindIndex(Node);
 	}
 
-	const UScriptStruct* GetExternalForceScriptStruct(const FInstancedStruct& InstancedStruct)
-	{
-		return InstancedStruct.IsValid() ? InstancedStruct.GetScriptStruct() : nullptr;
-	}
-
-	bool IsExternalForceShapeMatched(const TArray<FInstancedStruct>& GraphExternalForces,
-	                                 const TArray<FInstancedStruct>& RuntimeExternalForces)
-	{
-		if (GraphExternalForces.Num() != RuntimeExternalForces.Num())
-		{
-			return false;
-		}
-
-		for (int32 Index = 0; Index < GraphExternalForces.Num(); ++Index)
-		{
-			if (GetExternalForceScriptStruct(GraphExternalForces[Index]) !=
-				GetExternalForceScriptStruct(RuntimeExternalForces[Index]))
-			{
-				return false;
-			}
-		}
-		return true;
-	}
-
-	FAnimNode_KawaiiPhysics* ResolveLiveKawaiiPhysicsNode(UAnimGraphNode_KawaiiPhysics* GraphNode)
-	{
-		if (!GraphNode)
-		{
-			return nullptr;
-		}
-
-		UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
-		UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
-		if (!Cast<UAnimInstance>(ObjectBeingDebugged))
-		{
-			return nullptr;
-		}
-
-		return GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
-	}
-
 	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveLiveProceduralWind(
 		UAnimGraphNode_KawaiiPhysics* GraphNode,
 		FAnimNode_KawaiiPhysics* RuntimeNode,
 		const int32 RequestedIndex)
 	{
 		if (!GraphNode || !RuntimeNode ||
-			!IsExternalForceShapeMatched(GraphNode->Node.ExternalForces, RuntimeNode->ExternalForces))
+			!KawaiiPhysicsEdUtils::IsExternalForceShapeMatched(GraphNode->Node.ExternalForces, RuntimeNode->ExternalForces))
 		{
 			return nullptr;
 		}
@@ -1126,7 +1086,7 @@ bool SKawaiiPhysicsWindScopeWindow::PushPresetToLiveRuntime(
 	const FKawaiiProceduralWindDynamicParams& Params)
 {
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
-	FAnimNode_KawaiiPhysics* RuntimeNode = ResolveLiveKawaiiPhysicsNode(GraphNode);
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind = ResolveLiveProceduralWind(
 		GraphNode,
 		RuntimeNode,
@@ -1144,7 +1104,7 @@ bool SKawaiiPhysicsWindScopeWindow::PushGustToLiveRuntime(
 	const float Strength, const float RiseTime, const float DecayTime)
 {
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
-	FAnimNode_KawaiiPhysics* RuntimeNode = ResolveLiveKawaiiPhysicsNode(GraphNode);
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind = ResolveLiveProceduralWind(
 		GraphNode,
 		RuntimeNode,
@@ -1267,16 +1227,8 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 		return false;
 	}
 
-	// PIE等でデバッグ対象になっているノードを取得（デバッグ対象でなければ Live 扱いにしない）
-	UAnimBlueprint* AnimBlueprint = GraphNode->GetAnimBlueprint();
-	UObject* ObjectBeingDebugged = AnimBlueprint ? AnimBlueprint->GetObjectBeingDebugged() : nullptr;
-	if (!Cast<UAnimInstance>(ObjectBeingDebugged))
-	{
-		return false;
-	}
-
 	// 実行中の FAnimNode_KawaiiPhysics から対象 ProceduralWind の RuntimeState を解決
-	FAnimNode_KawaiiPhysics* RuntimeNode = GraphNode->GetDebuggedAnimNode<FAnimNode_KawaiiPhysics>();
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);
 	if (!RuntimeNode)
 	{
 		return false;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -27,6 +27,7 @@ class UAnimGraphNode_KawaiiPhysics : public UAnimGraphNode_SkeletalControlBase
 
 	// UObject interface
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+	virtual void PostEditChangeChainProperty(struct FPropertyChangedChainEvent& PropertyChangedEvent) override;
 	virtual void PostLoad() override;
 
 protected:
@@ -54,6 +55,9 @@ protected:
 private:
 	/** コリジョン配列のGuidを一意化する（複製/貼り付け/旧データの重複Guidを再発番） */
 	void EnsureUniqueCollisionGuids();
+
+	/** ProceduralWind の Details 編集を実行中ノードへ DynamicParams として送る */
+	void PushProceduralWindEditToLiveInstance(const struct FPropertyChangedChainEvent& PropertyChangedEvent);
 
 	/** Creates the export data asset path. */
 	void CreateExportDataAssetPath(FString& PackageName, const FString& DefaultSuffix) const;


### PR DESCRIPTION
## 概要

ProceduralWind のパラメータをエディタから編集した際、再コンパイルなしで実行中のシミュレーションへ即時反映されるようにします。あわせて「Details パネルで WindDirection を変更しても風向きが変わらない」問題の根本原因（エディタ同期によるシミュレーション状態の破壊）を修正します。

## 背景 / 問題

- AnimGraph ノードの `ExternalForces`（`FInstancedStruct` 配列）は Persona の同期（`CopyNodeDataToPreviewNode`）で丸ごと代入されており、そのたびに FInstancedStruct が破棄→再構築され、ProceduralWind の `RuntimeState`（風の経過時間・gust・Pending リクエスト）が毎回リセットされていた
- `operator=` も代入のたびに `RuntimeState` を作り直していた
- `RequestDynamicParams` / `RequestGust` は初回 `PreApply` 前に呼ぶとリクエストを無言で破棄していた
- PIE 中の Details 編集は再コンパイルまで実行中インスタンスに一切届かなかった

## 変更内容

### Wind Scope プリセットのライブ反映（98788d8, bcf0b75）
- スレッドセーフな `RequestDynamicParams` / `RequestGust` API と enabled 上書きを追加
- Wind Scope のプリセットボタンから PendingParams 経由で実行中シミュレーションへ直接適用（再コンパイル不要）

### Details 編集のライブ反映と状態保全（56c73a6, 5fa1fde, a907f91）
- `operator=` が代入先の有効な `RuntimeState` を保持するように変更（ポインタ・中身とも維持。インスタンス間で共有はしない）
- Request API は `RuntimeState` 未生成時に遅延生成してリクエストを保持（`EnsureRuntimeState`、生成はロックで直列化）
- `PendingParams` を項目単位マージに変更（consume 前に届いた別項目のリクエストが失われない。同一項目は後勝ち）
- `CopyNodeDataToPreviewNode` の `ExternalForces` 同期を、形状（要素数・型）一致時は in-place `CopyScriptStruct` に変更（形状変更時は従来どおり丸ごと代入でフルリセット）
- `PostEditChangeChainProperty` から、編集されたプロパティのみを `RequestDynamicParams` 経由でデバッグ対象の実行中ノードへプッシュ（PIE でも再コンパイル不要で反映）。配列インデックス特定時は当該エントリのみ、非 wind 要素の編集時はスキップ
- Wind Scope と共用のヘルパー（形状一致判定・実行中ノード解決）を `KawaiiPhysicsEdUtils` へ集約

## 既知の制限

- DynamicParams に対応しない項目（`RandomSeed`、`ForceRateByBoneLengthRate`、`ExternalForceSpace`、ボーンフィルタ等）は従来どおりノード再選択の同期または再コンパイルが必要
- 配列インデックスを特定できない編集は、ノード内の全 ProceduralWind へ現在値を冪等にプッシュする（単一 wind 構成が主用途のため）
