### PR TITLE
Convert editor windows (Wind Scope / Preset Diff / Node Audit) to dockable tabs

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
@@ -37,7 +37,9 @@ public class KawaiiPhysicsEd : ModuleRules
 			"ToolMenus",
 			"Json",
 			"JsonUtilities",
-			"DesktopPlatform"
+			"DesktopPlatform",
+			"Projects",
+			"WorkspaceMenuStructure"
 		});
 
 		if (Target.Version.MajorVersion > 5 || (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion >= 5))

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -708,7 +708,7 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 	CustomizeDetailTools(DetailBuilder);
 	CustomizeDetailDebugVisualizations(DetailBuilder);
 
-	// External Forceカテゴリに Wind Scope ボタン（波形プレビューウィンドウを開く）を追加
+	// External Forceカテゴリに Wind Scope ボタン（波形プレビュータブを開く）を追加
 	IDetailCategoryBuilder& ExternalForceCategory = DetailBuilder.EditCategory(TEXT("Force|External Force"));
 	FDetailWidgetRow& WindScopeWidgetRow = ExternalForceCategory.AddCustomRow(LOCTEXT("OpenWindScope", "Wind Scope"));
 	WindScopeWidgetRow
@@ -716,7 +716,7 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 		SNew(SButton)
 		.HAlign(HAlign_Center)
 		.VAlign(VAlign_Center)
-		.ToolTipText(LOCTEXT("OpenWindScopeToolTip", "Procedural Wind の波形プレビューウィンドウを開く / Opens the waveform preview window for Procedural Wind."))
+		.ToolTipText(LOCTEXT("OpenWindScopeToolTip", "Procedural Wind の波形プレビュータブを開く / Opens the waveform preview tab for Procedural Wind."))
 		.OnClicked_Lambda([WeakThis = TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics>(this)]()
 		{
 			if (UAnimGraphNode_KawaiiPhysics* Node = WeakThis.Get())
@@ -1129,7 +1129,7 @@ void UAnimGraphNode_KawaiiPhysics::CheckPresetDiff()
 		       *JoinPropertyNames(DiffProperties));
 	}
 
-	// 差分ウィンドウのコンテキストラベル（ノードタイトル＋AnimBlueprint名＋Tag）を組み立てる。
+	// 差分タブのコンテキストラベル（ノードタイトル＋AnimBlueprint名＋Tag）を組み立てる。
 	const UAnimBlueprint* AnimBlueprint = GetAnimBlueprint();
 	const FText ContextLabel = FText::Format(
 		LOCTEXT("CheckPresetDiffContextLabel", "{0}  |  {1}  |  Tag: {2}"),
@@ -1171,7 +1171,7 @@ void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow()
 		return;
 	}
 
-	// ウィンドウへ渡す引数を組み立てて開く
+	// タブへ渡す引数を組み立てて開く
 	const UAnimBlueprint* AnimBlueprint = GetAnimBlueprint();
 	FKawaiiPhysicsWindScopeWindowArgs Args;
 	Args.GraphNode = this;
@@ -1199,7 +1199,7 @@ void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UG
 		"KawaiiPhysicsCheckPresetDiff",
 		LOCTEXT("CheckPresetDiffMenuLabel", "Check Preset Diff"),
 		LOCTEXT("CheckPresetDiffMenuToolTip",
-		        "このノードとプリセットの差分をウィンドウで確認します / Shows the diff between this node and its presets in a window."),
+		        "このノードとプリセットの差分をタブで確認します / Shows the diff between this node and its presets in a tab."),
 		FSlateIcon(),
 		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::CheckPresetDiff)));
 
@@ -1216,7 +1216,7 @@ void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UG
 		"KawaiiPhysicsWindScope",
 		LOCTEXT("WindScopeContextMenu", "Wind Scope"),
 		LOCTEXT("WindScopeMenuToolTip",
-		        "Procedural Wind の波形プレビューウィンドウを開きます / Opens the waveform preview window for Procedural Wind."),
+		        "Procedural Wind の波形プレビュータブを開きます / Opens the waveform preview tab for Procedural Wind."),
 		FSlateIcon(),
 		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow)));
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
@@ -1,17 +1,40 @@
 // Copyright 2019-2026 pafuhana1213. All Rights Reserved.
 
 #include "KawaiiPhysicsEd.h"
-#include "Modules/ModuleManager.h"
-#include "Textures/SlateIcon.h"
+
+#include "CoreGlobals.h"
+#include "EditorModeRegistry.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Docking/WorkspaceItem.h"
+#include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEditMode.h"
 #include "KawaiiPhysicsPresetDataAssetDetails.h"
+#include "Misc/App.h"
+#include "Misc/CoreDelegates.h"
+#include "Misc/EngineVersionComparison.h"
+#include "Modules/ModuleManager.h"
 #include "PropertyEditorModule.h"
 #include "SKawaiiPhysicsNodeAuditWindow.h"
 #include "SKawaiiPhysicsPresetDiffWindow.h"
 #include "SKawaiiPhysicsWindScopeWindow.h"
+#include "Textures/SlateIcon.h"
+#include "WorkspaceMenuStructure.h"
+#include "WorkspaceMenuStructureModule.h"
 
 #define LOCTEXT_NAMESPACE "FKawaiiPhysicsModuleEd"
 
+namespace
+{
+	FSimpleMulticastDelegate& GetKawaiiPhysicsPostEngineInitDelegate()
+	{
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
+		return FCoreDelegates::OnPostEngineInit;
+#else
+		return FCoreDelegates::GetOnPostEngineInit();
+#endif
+	}
+}
 
 void FKawaiiPhysicsEdModule::StartupModule()
 {
@@ -25,6 +48,20 @@ void FKawaiiPhysicsEdModule::StartupModule()
 		"KawaiiPhysicsPresetDataAsset",
 		FOnGetDetailCustomizationInstance::CreateStatic(&FKawaiiPhysicsPresetDataAssetDetails::MakeInstance));
 	PropertyEditorModule.NotifyCustomizationModuleChanged();
+
+	if (GIsEditor && !IsRunningCommandlet())
+	{
+		if (FSlateApplication::IsInitialized())
+		{
+			RegisterTabSpawners();
+		}
+		else
+		{
+			PostEngineInitHandle = GetKawaiiPhysicsPostEngineInitDelegate().AddRaw(
+				this,
+				&FKawaiiPhysicsEdModule::RegisterTabSpawners);
+		}
+	}
 }
 
 
@@ -34,6 +71,28 @@ void FKawaiiPhysicsEdModule::ShutdownModule()
 	SKawaiiPhysicsPresetDiffWindow::CloseAllWindows();
 	SKawaiiPhysicsNodeAuditWindow::CloseAllWindows();
 
+	if (PostEngineInitHandle.IsValid())
+	{
+		GetKawaiiPhysicsPostEngineInitDelegate().Remove(PostEngineInitHandle);
+		PostEngineInitHandle.Reset();
+	}
+
+	if (bTabSpawnersRegistered)
+	{
+		SKawaiiPhysicsWindScopeWindow::UnregisterTabSpawner();
+		SKawaiiPhysicsPresetDiffWindow::UnregisterTabSpawner();
+		SKawaiiPhysicsNodeAuditWindow::UnregisterTabSpawner();
+
+		if (KawaiiPhysicsMenuGroup.IsValid())
+		{
+			WorkspaceMenu::GetMenuStructure().GetStructureRoot()->RemoveItem(KawaiiPhysicsMenuGroup.ToSharedRef());
+			KawaiiPhysicsMenuGroup.Reset();
+		}
+
+		FKawaiiPhysicsEdStyle::Shutdown();
+		bTabSpawnersRegistered = false;
+	}
+
 	if (FPropertyEditorModule* PropertyEditorModule = FModuleManager::GetModulePtr<FPropertyEditorModule>(
 		"PropertyEditor"))
 	{
@@ -42,6 +101,29 @@ void FKawaiiPhysicsEdModule::ShutdownModule()
 	}
 
 	FEditorModeRegistry::Get().UnregisterMode("AnimGraph.SkeletalControl.KawaiiPhysics");
+}
+
+void FKawaiiPhysicsEdModule::RegisterTabSpawners()
+{
+	if (bTabSpawnersRegistered || !GIsEditor || IsRunningCommandlet() || !FSlateApplication::IsInitialized())
+	{
+		return;
+	}
+
+	FKawaiiPhysicsEdStyle::Initialize();
+
+	const FSlateIcon KawaiiPhysicsIcon(
+		FKawaiiPhysicsEdStyle::GetStyleSetName(),
+		TEXT("KawaiiPhysics.TabIcon"));
+	KawaiiPhysicsMenuGroup = WorkspaceMenu::GetMenuStructure().GetStructureRoot()->AddGroup(
+		LOCTEXT("KawaiiPhysicsMenuGroup", "Kawaii Physics"),
+		KawaiiPhysicsIcon,
+		false);
+
+	SKawaiiPhysicsWindScopeWindow::RegisterTabSpawner(KawaiiPhysicsMenuGroup.ToSharedRef());
+	SKawaiiPhysicsPresetDiffWindow::RegisterTabSpawner(KawaiiPhysicsMenuGroup.ToSharedRef());
+	SKawaiiPhysicsNodeAuditWindow::RegisterTabSpawner(KawaiiPhysicsMenuGroup.ToSharedRef());
+	bTabSpawnersRegistered = true;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdStyle.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdStyle.cpp
@@ -1,0 +1,62 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsEdStyle.h"
+
+#include "Brushes/SlateImageBrush.h"
+#include "Interfaces/IPluginManager.h"
+#include "Math/Vector2D.h"
+#include "Misc/Paths.h"
+#include "Styling/SlateStyle.h"
+#include "Styling/SlateStyleRegistry.h"
+
+TSharedPtr<FSlateStyleSet> FKawaiiPhysicsEdStyle::StyleSet;
+
+void FKawaiiPhysicsEdStyle::Initialize()
+{
+	const FName StyleSetName = GetStyleSetName();
+	if (FSlateStyleRegistry::FindSlateStyle(StyleSetName))
+	{
+		FSlateStyleRegistry::UnRegisterSlateStyle(StyleSetName);
+	}
+
+	if (StyleSet.IsValid())
+	{
+		StyleSet.Reset();
+	}
+
+	const TSharedPtr<IPlugin> KawaiiPhysicsPlugin = IPluginManager::Get().FindPlugin(TEXT("KawaiiPhysics"));
+	if (!KawaiiPhysicsPlugin.IsValid())
+	{
+		return;
+	}
+
+	StyleSet = MakeShared<FSlateStyleSet>(StyleSetName);
+	StyleSet->SetContentRoot(FPaths::Combine(KawaiiPhysicsPlugin->GetBaseDir(), TEXT("Resources")));
+	StyleSet->Set(
+		TEXT("KawaiiPhysics.TabIcon"),
+		new FSlateImageBrush(StyleSet->RootToContentDir(TEXT("Icon128"), TEXT(".png")), FVector2D(16.0f, 16.0f)));
+
+	FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
+}
+
+void FKawaiiPhysicsEdStyle::Shutdown()
+{
+	if (StyleSet.IsValid())
+	{
+		FSlateStyleRegistry::UnRegisterSlateStyle(*StyleSet.Get());
+		ensure(StyleSet.IsUnique());
+		StyleSet.Reset();
+	}
+}
+
+const ISlateStyle& FKawaiiPhysicsEdStyle::Get()
+{
+	check(StyleSet.IsValid());
+	return *StyleSet.Get();
+}
+
+FName FKawaiiPhysicsEdStyle::GetStyleSetName()
+{
+	static const FName StyleSetName(TEXT("KawaiiPhysicsEdStyle"));
+	return StyleSetName;
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdStyle.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdStyle.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "Templates/SharedPointer.h"
+#include "UObject/NameTypes.h"
+
+class FSlateStyleSet;
+class ISlateStyle;
+
+class FKawaiiPhysicsEdStyle
+{
+public:
+	static void Initialize();
+	static void Shutdown();
+	static const ISlateStyle& Get();
+	static FName GetStyleSetName();
+
+private:
+	static TSharedPtr<FSlateStyleSet> StyleSet;
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.cpp
@@ -3,32 +3,6 @@
 #include "KawaiiPhysicsEdWindowUtils.h"
 
 #include "Framework/Notifications/NotificationManager.h"
-#include "Misc/ConfigCacheIni.h"
-#include "Widgets/SWindow.h"
-
-namespace
-{
-	// FVector2D を ini 保存用の "X,Y" 文字列へ変換する
-	FString MakeVectorConfigString(const FVector2D& Value)
-	{
-		return FString::Printf(TEXT("%.0f,%.0f"), Value.X, Value.Y);
-	}
-
-	// MakeVectorConfigString で保存した "X,Y" 文字列を FVector2D へ復元する
-	bool TryParseVectorConfigString(const FString& StringValue, FVector2D& OutValue)
-	{
-		FString Left;
-		FString Right;
-		if (!StringValue.Split(TEXT(","), &Left, &Right))
-		{
-			return false;
-		}
-
-		OutValue.X = FCString::Atof(*Left);
-		OutValue.Y = FCString::Atof(*Right);
-		return true;
-	}
-}
 
 namespace KawaiiPhysicsEdWindowUtils
 {
@@ -53,51 +27,6 @@ namespace KawaiiPhysicsEdWindowUtils
 		if (NotificationItem.IsValid())
 		{
 			NotificationItem->SetCompletionState(CompletionState);
-		}
-	}
-
-	void PersistWindowPlacement(const TSharedRef<SWindow>& Window,
-	                            const TCHAR* ConfigSectionName,
-	                            const TCHAR* WindowPosConfigKey,
-	                            const TCHAR* WindowSizeConfigKey)
-	{
-		// commandlet等 GConfig 未初期化の環境では保存をスキップ
-		if (!GConfig)
-		{
-			return;
-		}
-
-		const FVector2D Position = Window->GetPositionInScreen();
-		const FVector2D Size = Window->GetSizeInScreen();
-		GConfig->SetString(ConfigSectionName, WindowPosConfigKey, *MakeVectorConfigString(Position), GEditorPerProjectIni);
-		GConfig->SetString(ConfigSectionName, WindowSizeConfigKey, *MakeVectorConfigString(Size), GEditorPerProjectIni);
-		GConfig->Flush(false, GEditorPerProjectIni);
-	}
-
-	void RestoreWindowPlacement(const TSharedRef<SWindow>& Window,
-	                            const TCHAR* ConfigSectionName,
-	                            const TCHAR* WindowPosConfigKey,
-	                            const TCHAR* WindowSizeConfigKey)
-	{
-		// PersistWindowPlacementと同様、GConfig未初期化ならスキップ
-		if (!GConfig)
-		{
-			return;
-		}
-
-		// 位置・サイズは互いに独立して、パースに成功した場合のみ反映する
-		FString StringValue;
-		FVector2D ParsedValue;
-		if (GConfig->GetString(ConfigSectionName, WindowPosConfigKey, StringValue, GEditorPerProjectIni) &&
-			TryParseVectorConfigString(StringValue, ParsedValue))
-		{
-			Window->MoveWindowTo(ParsedValue);
-		}
-
-		if (GConfig->GetString(ConfigSectionName, WindowSizeConfigKey, StringValue, GEditorPerProjectIni) &&
-			TryParseVectorConfigString(StringValue, ParsedValue))
-		{
-			Window->Resize(ParsedValue);
 		}
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEdWindowUtils.h
@@ -5,9 +5,7 @@
 #include "CoreMinimal.h"
 #include "Widgets/Notifications/SNotificationList.h"
 
-class SWindow;
-
-// PresetDiffWindow・WindScopeWindow など複数のエディタウィンドウで共有する通知/ウィンドウ位置ユーティリティ
+// 通知ユーティリティ / Notification utilities.
 namespace KawaiiPhysicsEdWindowUtils
 {
 	/** Slate通知を表示する / Shows a Slate notification. */
@@ -16,16 +14,4 @@ namespace KawaiiPhysicsEdWindowUtils
 	                      float ExpireDuration = 5.0f,
 	                      const FSimpleDelegate& Hyperlink = FSimpleDelegate(),
 	                      const FText& HyperlinkText = FText::GetEmpty());
-
-	/** ウィンドウ位置とサイズを設定ファイルへ保存する / Persists window position and size to config. */
-	void PersistWindowPlacement(const TSharedRef<SWindow>& Window,
-	                            const TCHAR* ConfigSectionName,
-	                            const TCHAR* WindowPosConfigKey,
-	                            const TCHAR* WindowSizeConfigKey);
-
-	/** 設定ファイルからウィンドウ位置とサイズを復元する / Restores window position and size from config. */
-	void RestoreWindowPlacement(const TSharedRef<SWindow>& Window,
-	                            const TCHAR* ConfigSectionName,
-	                            const TCHAR* WindowPosConfigKey,
-	                            const TCHAR* WindowSizeConfigKey);
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDataAssetDetails.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDataAssetDetails.cpp
@@ -240,7 +240,7 @@ void FKawaiiPhysicsPresetDataAssetDetails::CustomizeDetails(IDetailLayoutBuilder
 				FindTargetNodes(WeakPreset.Get());
 				return FReply::Handled();
 			})
-			.ToolTipText(LOCTEXT("FindTargetNodesToolTip", "TargetTags に一致する KawaiiPhysics ノードをプロジェクト内の全 AnimBlueprint から検索し、結果をウィンドウで一覧表示します（詳細は Output Log にも出力） / Searches all AnimBlueprints in the project for KawaiiPhysics nodes matching TargetTags and lists the results in a window (details are also logged to the Output Log)."))
+			.ToolTipText(LOCTEXT("FindTargetNodesToolTip", "TargetTags に一致する KawaiiPhysics ノードをプロジェクト内の全 AnimBlueprint から検索し、結果をタブで一覧表示します（詳細は Output Log にも出力） / Searches all AnimBlueprints in the project for KawaiiPhysics nodes matching TargetTags and lists the results in a tab (details are also logged to the Output Log)."))
 			.Content()
 			[
 				SNew(STextBlock)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
@@ -7,9 +7,12 @@
 #include "DesktopPlatformModule.h"
 #include "Dom/JsonObject.h"
 #include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Docking/WorkspaceItem.h"
 #include "HAL/PlatformProcess.h"
 #include "ISourceControlModule.h"
 #include "KawaiiPhysicsAuditCommandlet.h"
+#include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "KawaiiPhysicsPresetDiffSnapshot.h"
@@ -20,9 +23,14 @@
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "Subsystems/AssetEditorSubsystem.h"
+#include "Textures/SlateIcon.h"
+#include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SSeparator.h"
+#include "Widgets/SWindow.h"
+#include "Widgets/SNullWidget.h"
+#include "Widgets/SWidget.h"
 #include "Widgets/Notifications/SNotificationList.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Views/STableRow.h"
@@ -38,11 +46,8 @@ namespace
 	const FName MatchesColumnName(TEXT("Matches"));
 	const FName DiffPropertiesColumnName(TEXT("DiffProperties"));
 	const FName ViewDiffColumnName(TEXT("ViewDiff"));
-	const TCHAR* ConfigSectionName = TEXT("KawaiiPhysicsEd");
-	const TCHAR* WindowPosConfigKey = TEXT("NodeAuditWindowPos");
-	const TCHAR* WindowSizeConfigKey = TEXT("NodeAuditWindowSize");
 
-	TWeakPtr<SWindow> AuditWindowWeak;
+	TWeakPtr<SDockTab> AuditTabWeak;
 	TWeakPtr<SKawaiiPhysicsNodeAuditWindow> AuditWidgetWeak;
 
 	void ShowAuditExportSucceededNotification(const FString& OutputPath)
@@ -210,65 +215,103 @@ namespace
 	};
 }
 
+const FName SKawaiiPhysicsNodeAuditWindow::NodeAuditTabId(TEXT("KawaiiPhysicsNodeAudit"));
+
 void SKawaiiPhysicsNodeAuditWindow::Construct(const FArguments& InArgs, FKawaiiPhysicsNodeAuditWindowArgs InitArgs)
 {
 	(void)InArgs;
 	SetArgs(MoveTemp(InitArgs));
 }
 
-void SKawaiiPhysicsNodeAuditWindow::OpenWindow(FKawaiiPhysicsNodeAuditWindowArgs Args)
+void SKawaiiPhysicsNodeAuditWindow::RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup)
 {
-	const FText WindowTitleCopy = Args.WindowTitle;
+	const FSlateIcon KawaiiPhysicsIcon(
+		FKawaiiPhysicsEdStyle::GetStyleSetName(),
+		TEXT("KawaiiPhysics.TabIcon"));
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
+			NodeAuditTabId,
+			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsNodeAuditWindow::SpawnNodeAuditTab))
+		.SetDisplayName(LOCTEXT("NodeAuditMenuDisplayName", "Kawaii Physics: Node Audit"))
+		.SetTooltipText(LOCTEXT("NodeAuditMenuTooltip", "KawaiiPhysics のノード監査タブを開きます / Opens the KawaiiPhysics node audit tab."))
+		.SetGroup(InMenuGroup)
+		.SetIcon(KawaiiPhysicsIcon);
+}
 
-	if (TSharedPtr<SWindow> ExistingWindow = AuditWindowWeak.Pin())
-	{
-		if (TSharedPtr<SKawaiiPhysicsNodeAuditWindow> ExistingWidget = AuditWidgetWeak.Pin())
+void SKawaiiPhysicsNodeAuditWindow::UnregisterTabSpawner()
+{
+	FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(NodeAuditTabId);
+}
+
+TSharedRef<SDockTab> SKawaiiPhysicsNodeAuditWindow::SpawnNodeAuditTab(const FSpawnTabArgs& SpawnTabArgs)
+{
+	(void)SpawnTabArgs;
+
+	TSharedRef<SKawaiiPhysicsNodeAuditWindow> AuditWidget = SNew(SKawaiiPhysicsNodeAuditWindow);
+	TSharedRef<SDockTab> AuditTab = SNew(SDockTab)
+		.TabRole(ETabRole::NomadTab)
+		.Label(LOCTEXT("NodeAuditTabLabel", "Kawaii Node Audit"))
+		.OnTabClosed_Lambda([](TSharedRef<SDockTab> ClosedTab)
 		{
-			ExistingWidget->SetArgs(MoveTemp(Args));
-		}
-		ExistingWindow->SetTitle(WindowTitleCopy);
-		ExistingWindow->BringToFront();
-		return;
-	}
-
-	TSharedRef<SKawaiiPhysicsNodeAuditWindow> AuditWidget =
-		SNew(SKawaiiPhysicsNodeAuditWindow, MoveTemp(Args));
-
-	TSharedRef<SWindow> Window = SNew(SWindow)
-		.Title(WindowTitleCopy)
-		.ClientSize(FVector2D(980.0f, 560.0f))
-		.AutoCenter(EAutoCenter::PreferredWorkArea)
+			(void)ClosedTab;
+			AuditTabWeak.Reset();
+			AuditWidgetWeak.Reset();
+		})
 		[
 			AuditWidget
 		];
 
-	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
-	{
-		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
-			ClosedWindow,
-			ConfigSectionName,
-			WindowPosConfigKey,
-			WindowSizeConfigKey);
-		AuditWindowWeak.Reset();
-		AuditWidgetWeak.Reset();
-	}));
-
-	AuditWindowWeak = Window;
+	AuditTabWeak = AuditTab;
 	AuditWidgetWeak = AuditWidget;
-	FSlateApplication::Get().AddWindow(Window);
-	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
-		Window,
-		ConfigSectionName,
-		WindowPosConfigKey,
-		WindowSizeConfigKey);
+	return AuditTab;
+}
+
+void SKawaiiPhysicsNodeAuditWindow::OpenWindow(FKawaiiPhysicsNodeAuditWindowArgs Args)
+{
+	const FText TabLabel = Args.WindowTitle;
+
+	// タブを呼び出してから、監査結果の引数を既存コンテンツへ注入する
+	TSharedPtr<SDockTab> InvokedTab = FGlobalTabmanager::Get()->TryInvokeTab(NodeAuditTabId);
+	if (!InvokedTab.IsValid())
+	{
+		return;
+	}
+
+	TSharedPtr<SWidget> TabContent = InvokedTab->GetContent();
+	if (!TabContent.IsValid())
+	{
+		return;
+	}
+
+	if (!TabLabel.IsEmpty())
+	{
+		InvokedTab->SetLabel(TabLabel);
+	}
+
+	if (TSharedPtr<SKawaiiPhysicsNodeAuditWindow> ExistingWidget = AuditWidgetWeak.Pin())
+	{
+		ExistingWidget->SetArgs(MoveTemp(Args));
+		return;
+	}
+
+	// Hot Reload等でファイルスコープの弱参照だけが失効した場合、タブ内容から復旧する
+	if (TabContent->GetType() == FName(TEXT("SKawaiiPhysicsNodeAuditWindow")))
+	{
+		TSharedPtr<SKawaiiPhysicsNodeAuditWindow> RecoveredWidget =
+			StaticCastSharedPtr<SKawaiiPhysicsNodeAuditWindow>(TabContent);
+		AuditTabWeak = InvokedTab;
+		AuditWidgetWeak = RecoveredWidget;
+		RecoveredWidget->SetArgs(MoveTemp(Args));
+	}
 }
 
 void SKawaiiPhysicsNodeAuditWindow::CloseAllWindows()
 {
-	if (TSharedPtr<SWindow> Window = AuditWindowWeak.Pin())
+	if (TSharedPtr<SDockTab> AuditTab = AuditTabWeak.Pin())
 	{
-		Window->RequestDestroyWindow();
+		AuditTab->RequestCloseTab();
 	}
+	AuditTabWeak.Reset();
+	AuditWidgetWeak.Reset();
 }
 
 void SKawaiiPhysicsNodeAuditWindow::SetArgs(FKawaiiPhysicsNodeAuditWindowArgs Args)
@@ -287,7 +330,14 @@ void SKawaiiPhysicsNodeAuditWindow::SetArgs(FKawaiiPhysicsNodeAuditWindowArgs Ar
 		Entries.Add(MakeShared<FKawaiiPhysicsNodeAuditEntry>(Entry));
 	}
 
-	SummaryText = Args.SummaryText.IsEmpty() ? MakeAuditSummaryText(Entries) : Args.SummaryText;
+	if (Entries.IsEmpty() && Args.SummaryText.IsEmpty() && !PresetPath.IsValid())
+	{
+		SummaryText = LOCTEXT("NoAuditResultsGuidance", "監査結果なし: プリセット DataAsset 詳細の [Find Target Nodes] / [Apply To Project (Dry Run)] から開いてください / No audit results: open from the preset DataAsset details.");
+	}
+	else
+	{
+		SummaryText = Args.SummaryText.IsEmpty() ? MakeAuditSummaryText(Entries) : Args.SummaryText;
+	}
 
 	RebuildWidget();
 }
@@ -407,6 +457,10 @@ void SKawaiiPhysicsNodeAuditWindow::RebuildWidget()
 				SNew(SButton)
 				.Text(LOCTEXT("RefreshButton", "Refresh"))
 				.ToolTipText(LOCTEXT("RefreshButtonToolTip", "プリセットを対象ノードへドライラン適用し直し、一覧を再計算します / Re-runs a dry-run apply of the preset against the target nodes and rebuilds the list."))
+				.IsEnabled_Lambda([this]()
+				{
+					return PresetPath.IsValid();
+				})
 				.OnClicked(this, &SKawaiiPhysicsNodeAuditWindow::OnRefreshClicked)
 			]
 			+ SHorizontalBox::Slot()
@@ -425,6 +479,10 @@ void SKawaiiPhysicsNodeAuditWindow::RebuildWidget()
 				.Visibility(bShowDiffColumns ? EVisibility::Visible : EVisibility::Collapsed)
 				.Text(LOCTEXT("ApplyToProjectButton", "Apply to Project..."))
 				.ToolTipText(LOCTEXT("ApplyToProjectButtonToolTip", "このプリセットを、対象タグに一致するプロジェクト内の全ノードへ適用します / Applies this preset to every node in the project that matches its target tags."))
+				.IsEnabled_Lambda([this]()
+				{
+					return PresetPath.IsValid();
+				})
 				.OnClicked(this, &SKawaiiPhysicsNodeAuditWindow::OnApplyToProjectClicked)
 			]
 		]

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.h
@@ -11,12 +11,14 @@
 #include "Widgets/Views/SListView.h"
 
 class ITableRow;
-class SWindow;
+class FSpawnTabArgs;
+class FWorkspaceItem;
+class SDockTab;
 class STableViewBase;
 
 struct FKawaiiPhysicsNodeAuditWindowArgs
 {
-	/** ウィンドウタイトル / Window title. */
+	/** タブラベル / Tab label. */
 	FText WindowTitle;
 
 	/** サマリ表示テキスト（初期表示用。以降は内部で再計算される） / Summary text for the initial display (recalculated internally afterwards). */
@@ -40,12 +42,23 @@ public:
 		}
 	SLATE_END_ARGS()
 
-	void Construct(const FArguments& InArgs, FKawaiiPhysicsNodeAuditWindowArgs InitArgs);
+	void Construct(const FArguments& InArgs, FKawaiiPhysicsNodeAuditWindowArgs InitArgs = FKawaiiPhysicsNodeAuditWindowArgs());
 
-	/** 監査ウィンドウを開くか既存ウィンドウを更新する / Opens the audit window or updates the existing one. */
+	static const FName NodeAuditTabId;
+
+	/** 監査タブスポナーを登録する / Registers the audit tab spawner. */
+	static void RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup);
+
+	/** 監査タブスポナーを解除する / Unregisters the audit tab spawner. */
+	static void UnregisterTabSpawner();
+
+	/** 監査タブを生成する / Spawns the audit tab. */
+	static TSharedRef<SDockTab> SpawnNodeAuditTab(const FSpawnTabArgs& SpawnTabArgs);
+
+	/** 監査タブを開くか既存タブを更新する / Opens the audit tab or updates the existing one. */
 	static void OpenWindow(FKawaiiPhysicsNodeAuditWindowArgs Args);
 
-	/** 開いている監査ウィンドウをすべて閉じる / Closes all open audit windows. */
+	/** 開いている監査タブをすべて閉じる / Closes all open audit tabs. */
 	static void CloseAllWindows();
 
 	/** 現在の引数でウィジェット状態を置き換える / Replaces the widget state with the current arguments. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
@@ -5,17 +5,21 @@
 #include "AnimGraphNode_KawaiiPhysics.h"
 #include "Animation/AnimBlueprint.h"
 #include "BlueprintEditorModule.h"
-#include "Misc/MessageDialog.h"
 #include "EdGraph/EdGraph.h"
-#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Docking/WorkspaceItem.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
 #include "KawaiiPhysicsEditorLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/MessageDialog.h"
 #include "ScopedTransaction.h"
 #include "Styling/AppStyle.h"
 #include "Subsystems/AssetEditorSubsystem.h"
+#include "Textures/SlateIcon.h"
 #include "UObject/UnrealType.h"
+#include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SCheckBox.h"
@@ -26,6 +30,7 @@
 #include "Widgets/Layout/SSeparator.h"
 #include "Widgets/Layout/SWrapBox.h"
 #include "Widgets/Notifications/SNotificationList.h"
+#include "Widgets/SWidget.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Views/SHeaderRow.h"
 #include "Widgets/Views/SListView.h"
@@ -40,11 +45,8 @@ namespace
 	const FName PropertyColumnName(TEXT("Property"));
 	const FName NodeValueColumnName(TEXT("NodeValue"));
 	const FName PresetValueColumnName(TEXT("PresetValue"));
-	const TCHAR* PresetDiffConfigSection = TEXT("KawaiiPhysicsEd");
-	const TCHAR* PresetDiffPositionKey = TEXT("PresetDiffWindowPos");
-	const TCHAR* PresetDiffSizeKey = TEXT("PresetDiffWindowSize");
 
-	TWeakPtr<SWindow> DiffWindowWeak;
+	TWeakPtr<SDockTab> DiffTabWeak;
 	TWeakPtr<SKawaiiPhysicsPresetDiffWindow> DiffWidgetWeak;
 
 	FKawaiiPhysicsGraphNodeHandle MakePresetDiffHandle(UAnimGraphNode_KawaiiPhysics* GraphNode)
@@ -281,6 +283,8 @@ namespace
 	};
 }
 
+const FName SKawaiiPhysicsPresetDiffWindow::PresetDiffTabId(TEXT("KawaiiPhysicsPresetDiff"));
+
 void SKawaiiPhysicsPresetDiffWindow::Construct(const FArguments& InArgs, FKawaiiPhysicsPresetDiffWindowArgs DiffArgs)
 {
 	(void)InArgs;
@@ -296,6 +300,10 @@ void SKawaiiPhysicsPresetDiffWindow::Construct(const FArguments& InArgs, FKawaii
 			SNew(STextBlock)
 			.Text_Lambda([this]()
 			{
+				if (Snapshots.IsEmpty() && !NodeGuid.IsValid())
+				{
+					return LOCTEXT("NoDiffSelectedGuidance", "差分未選択: KawaiiPhysics ノードの [Check Preset Diff] から開いてください / No diff selected: open from a KawaiiPhysics node's [Check Preset Diff].");
+				}
 				return ContextLabel;
 			})
 		]
@@ -474,74 +482,94 @@ void SKawaiiPhysicsPresetDiffWindow::Construct(const FArguments& InArgs, FKawaii
 					.OnClicked(this, &SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked)
 				]
 			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Top)
-			.Padding(8.0f, 2.0f, 0.0f, 0.0f)
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("CloseButton", "Close"))
-				.ToolTipText(LOCTEXT("CloseButtonToolTip", "この差分ウィンドウを閉じます / Closes this diff window."))
-				.OnClicked(this, &SKawaiiPhysicsPresetDiffWindow::OnCloseClicked)
-			]
 		]
 	];
 
 	RefreshFilteredRows();
 }
 
-void SKawaiiPhysicsPresetDiffWindow::OpenWindow(FKawaiiPhysicsPresetDiffWindowArgs Args)
+void SKawaiiPhysicsPresetDiffWindow::RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup)
 {
-	if (TSharedPtr<SWindow> ExistingWindow = DiffWindowWeak.Pin())
-	{
-		if (TSharedPtr<SKawaiiPhysicsPresetDiffWindow> ExistingWidget = DiffWidgetWeak.Pin())
+	const FSlateIcon KawaiiPhysicsIcon(
+		FKawaiiPhysicsEdStyle::GetStyleSetName(),
+		TEXT("KawaiiPhysics.TabIcon"));
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
+			PresetDiffTabId,
+			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsPresetDiffWindow::SpawnPresetDiffTab))
+		.SetDisplayName(LOCTEXT("PresetDiffMenuDisplayName", "Kawaii Physics: Preset Diff"))
+		.SetTooltipText(LOCTEXT("PresetDiffMenuTooltip", "KawaiiPhysics のプリセット差分タブを開きます / Opens the KawaiiPhysics preset diff tab."))
+		.SetGroup(InMenuGroup)
+		.SetIcon(KawaiiPhysicsIcon);
+}
+
+void SKawaiiPhysicsPresetDiffWindow::UnregisterTabSpawner()
+{
+	FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(PresetDiffTabId);
+}
+
+TSharedRef<SDockTab> SKawaiiPhysicsPresetDiffWindow::SpawnPresetDiffTab(const FSpawnTabArgs& SpawnTabArgs)
+{
+	(void)SpawnTabArgs;
+
+	TSharedRef<SKawaiiPhysicsPresetDiffWindow> DiffWidget = SNew(SKawaiiPhysicsPresetDiffWindow);
+	TSharedRef<SDockTab> DiffTab = SNew(SDockTab)
+		.TabRole(ETabRole::NomadTab)
+		.Label(LOCTEXT("PresetDiffTabLabel", "Kawaii Preset Diff"))
+		.OnTabClosed_Lambda([](TSharedRef<SDockTab> ClosedTab)
 		{
-			ExistingWidget->SetArgs(MoveTemp(Args));
-		}
-		ExistingWindow->BringToFront();
-		return;
-	}
-
-	TSharedRef<SKawaiiPhysicsPresetDiffWindow> DiffWidget =
-		SNew(SKawaiiPhysicsPresetDiffWindow, MoveTemp(Args));
-
-	TSharedRef<SWindow> Window = SNew(SWindow)
-		.Title(LOCTEXT("WindowTitle", "Kawaii Physics Preset Diff"))
-		.ClientSize(FVector2D(900.0f, 520.0f))
-		.MinWidth(560.0f)
-		.MinHeight(320.0f)
-		.AutoCenter(EAutoCenter::PreferredWorkArea)
+			(void)ClosedTab;
+			DiffTabWeak.Reset();
+			DiffWidgetWeak.Reset();
+		})
 		[
 			DiffWidget
 		];
 
-	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
-	{
-		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
-			ClosedWindow,
-			PresetDiffConfigSection,
-			PresetDiffPositionKey,
-			PresetDiffSizeKey);
-		DiffWindowWeak.Reset();
-		DiffWidgetWeak.Reset();
-	}));
-
-	DiffWindowWeak = Window;
+	DiffTabWeak = DiffTab;
 	DiffWidgetWeak = DiffWidget;
-	FSlateApplication::Get().AddWindow(Window);
-	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
-		Window,
-		PresetDiffConfigSection,
-		PresetDiffPositionKey,
-		PresetDiffSizeKey);
+	return DiffTab;
+}
+
+void SKawaiiPhysicsPresetDiffWindow::OpenWindow(FKawaiiPhysicsPresetDiffWindowArgs Args)
+{
+	// タブを呼び出してから、差分対象の引数を既存コンテンツへ注入する
+	TSharedPtr<SDockTab> InvokedTab = FGlobalTabmanager::Get()->TryInvokeTab(PresetDiffTabId);
+	if (!InvokedTab.IsValid())
+	{
+		return;
+	}
+
+	TSharedPtr<SWidget> TabContent = InvokedTab->GetContent();
+	if (!TabContent.IsValid())
+	{
+		return;
+	}
+
+	if (TSharedPtr<SKawaiiPhysicsPresetDiffWindow> ExistingWidget = DiffWidgetWeak.Pin())
+	{
+		ExistingWidget->SetArgs(MoveTemp(Args));
+		return;
+	}
+
+	// Hot Reload等でファイルスコープの弱参照だけが失効した場合、タブ内容から復旧する
+	if (TabContent->GetType() == FName(TEXT("SKawaiiPhysicsPresetDiffWindow")))
+	{
+		TSharedPtr<SKawaiiPhysicsPresetDiffWindow> RecoveredWidget =
+			StaticCastSharedPtr<SKawaiiPhysicsPresetDiffWindow>(TabContent);
+		DiffTabWeak = InvokedTab;
+		DiffWidgetWeak = RecoveredWidget;
+		RecoveredWidget->SetArgs(MoveTemp(Args));
+	}
 }
 
 void SKawaiiPhysicsPresetDiffWindow::CloseAllWindows()
 {
-	if (TSharedPtr<SWindow> Window = DiffWindowWeak.Pin())
+	if (TSharedPtr<SDockTab> DiffTab = DiffTabWeak.Pin())
 	{
-		Window->RequestDestroyWindow();
+		DiffTab->RequestCloseTab();
 	}
+	DiffTabWeak.Reset();
+	DiffWidgetWeak.Reset();
 }
 
 void SKawaiiPhysicsPresetDiffWindow::SetArgs(FKawaiiPhysicsPresetDiffWindowArgs Args)
@@ -713,6 +741,11 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnCopyClicked()
 
 FReply SKawaiiPhysicsPresetDiffWindow::OnRefreshClicked()
 {
+	if (!NodeGuid.IsValid())
+	{
+		return FReply::Handled();
+	}
+
 	if (!RebuildAllSnapshotsKeepingPreset())
 	{
 		KawaiiPhysicsEdWindowUtils::ShowNotification(
@@ -912,15 +945,6 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnUpdatePresetFromNodeClicked()
 	return FReply::Handled();
 }
 
-FReply SKawaiiPhysicsPresetDiffWindow::OnCloseClicked()
-{
-	if (TSharedPtr<SWindow> Window = FSlateApplication::Get().FindWidgetWindow(AsShared()))
-	{
-		Window->RequestDestroyWindow();
-	}
-	return FReply::Handled();
-}
-
 void SKawaiiPhysicsPresetDiffWindow::RefreshFilteredRows()
 {
 	FilteredRows.Reset();
@@ -979,6 +1003,11 @@ void SKawaiiPhysicsPresetDiffWindow::ReplaceSelectedSnapshot(
 
 bool SKawaiiPhysicsPresetDiffWindow::RebuildAllSnapshotsKeepingPreset()
 {
+	if (!NodeGuid.IsValid())
+	{
+		return false;
+	}
+
 	UAnimGraphNode_KawaiiPhysics* GraphNode =
 		UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(AnimBlueprintPath, NodeGuid);
 	if (!GraphNode)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.h
@@ -10,7 +10,9 @@
 #include "Widgets/Views/SListView.h"
 
 class ITableRow;
-class SWindow;
+class FSpawnTabArgs;
+class FWorkspaceItem;
+class SDockTab;
 class STableViewBase;
 
 struct FKawaiiPhysicsPresetDiffWindowArgs
@@ -36,12 +38,23 @@ public:
 		}
 	SLATE_END_ARGS()
 
-	void Construct(const FArguments& InArgs, FKawaiiPhysicsPresetDiffWindowArgs DiffArgs);
+	void Construct(const FArguments& InArgs, FKawaiiPhysicsPresetDiffWindowArgs DiffArgs = FKawaiiPhysicsPresetDiffWindowArgs());
 
-	/** 差分ウィンドウを開くか既存ウィンドウを更新する / Opens the diff window or updates the existing one. */
+	static const FName PresetDiffTabId;
+
+	/** 差分タブスポナーを登録する / Registers the diff tab spawner. */
+	static void RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup);
+
+	/** 差分タブスポナーを解除する / Unregisters the diff tab spawner. */
+	static void UnregisterTabSpawner();
+
+	/** 差分タブを生成する / Spawns the diff tab. */
+	static TSharedRef<SDockTab> SpawnPresetDiffTab(const FSpawnTabArgs& SpawnTabArgs);
+
+	/** 差分タブを開くか既存タブを更新する / Opens the diff tab or updates the existing one. */
 	static void OpenWindow(FKawaiiPhysicsPresetDiffWindowArgs Args);
 
-	/** 開いている差分ウィンドウをすべて閉じる / Closes all open diff windows. */
+	/** 開いている差分タブをすべて閉じる / Closes all open diff tabs. */
 	static void CloseAllWindows();
 
 	/** 現在の引数でウィジェット状態を置き換える / Replaces the widget state with the current arguments. */
@@ -70,7 +83,6 @@ private:
 	FReply OnApplySelectedClicked();
 	FReply OnApplyPresetToNodeClicked();
 	FReply OnUpdatePresetFromNodeClicked();
-	FReply OnCloseClicked();
 
 	void RefreshFilteredRows();
 	void ReplaceSelectedSnapshot(TSharedRef<FKawaiiPhysicsPresetDiffSnapshot> NewSnapshot);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -5,20 +5,28 @@
 #include "AnimGraphNode_KawaiiPhysics.h"
 #include "Animation/AnimBlueprint.h"
 #include "Animation/AnimInstance.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "Engine/AssetManager.h"
+#include "Engine/StreamableManager.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
-#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Framework/Docking/WorkspaceItem.h"
 #include "HAL/CriticalSection.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
+#include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdUtils.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
-#include "KawaiiPhysicsEditorLibrary.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeLock.h"
 #include "Rendering/DrawElements.h"
 #include "ScopedTransaction.h"
 #include "Styling/AppStyle.h"
 #include "Styling/CoreStyle.h"
+#include "Textures/SlateIcon.h"
 #include "Widgets/Colors/SColorBlock.h"
+#include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboBox.h"
@@ -34,9 +42,6 @@
 
 namespace
 {
-	const TCHAR* WindScopeConfigSectionName = TEXT("KawaiiPhysicsEd");
-	const TCHAR* WindScopeWindowPosConfigKey = TEXT("WindScopeWindowPos");
-	const TCHAR* WindScopeWindowSizeConfigKey = TEXT("WindScopeWindowSize");
 	constexpr int32 WindScopePreviewSampleCount = 240;
 	constexpr float WindScopeGraphPaddingLeft = 42.0f;
 	constexpr float WindScopeGraphPaddingTop = 12.0f;
@@ -45,9 +50,51 @@ namespace
 	constexpr float WindScopeGustStrength = 6.0f;
 	constexpr float WindScopeGustRiseTime = 0.1f;
 	constexpr float WindScopeGustDecayTime = 0.5f;
+	constexpr float WindScopeReconnectTryLoadDelay = 5.0f;
+	const TCHAR* WindScopeConfigSectionName = TEXT("KawaiiPhysicsEd");
+	const TCHAR* WindScopeLastAnimBlueprintKey = TEXT("WindScopeLastAnimBlueprint");
+	const TCHAR* WindScopeLastNodeGuidKey = TEXT("WindScopeLastNodeGuid");
+	const TCHAR* WindScopeLastForceIndexKey = TEXT("WindScopeLastForceIndex");
 
-	TWeakPtr<SWindow> KawaiiWindScopeWindowWeak;
+	TWeakPtr<SDockTab> KawaiiWindScopeTabWeak;
 	TWeakPtr<SKawaiiPhysicsWindScopeWindow> KawaiiWindScopeWidgetWeak;
+
+	bool AreReconnectArgsSame(const FKawaiiPhysicsWindScopeWindowArgs& Lhs, const FKawaiiPhysicsWindScopeWindowArgs& Rhs)
+	{
+		return Lhs.AnimBlueprintPath == Rhs.AnimBlueprintPath &&
+			Lhs.NodeGuid == Rhs.NodeGuid &&
+			Lhs.ExternalForceIndex == Rhs.ExternalForceIndex;
+	}
+
+	UAnimGraphNode_KawaiiPhysics* FindLoadedGraphNodeByGuid(UObject* AnimBlueprintObject, const FGuid& NodeGuid)
+	{
+		UAnimBlueprint* AnimBlueprint = Cast<UAnimBlueprint>(AnimBlueprintObject);
+		if (!AnimBlueprint || !NodeGuid.IsValid())
+		{
+			return nullptr;
+		}
+
+		TArray<UEdGraph*> Graphs;
+		AnimBlueprint->GetAllGraphs(Graphs);
+		for (UEdGraph* Graph : Graphs)
+		{
+			if (!Graph)
+			{
+				continue;
+			}
+
+			for (UEdGraphNode* Node : Graph->Nodes)
+			{
+				UAnimGraphNode_KawaiiPhysics* KawaiiPhysicsGraphNode = Cast<UAnimGraphNode_KawaiiPhysics>(Node);
+				if (KawaiiPhysicsGraphNode && KawaiiPhysicsGraphNode->NodeGuid == NodeGuid)
+				{
+					return KawaiiPhysicsGraphNode;
+				}
+			}
+		}
+
+		return nullptr;
+	}
 
 	struct FKawaiiWindScopeComponentStyle
 	{
@@ -392,6 +439,8 @@ namespace
 	}
 }
 
+const FName SKawaiiPhysicsWindScopeWindow::WindScopeTabId(TEXT("KawaiiPhysicsWindScope"));
+
 bool FKawaiiPhysicsWindScopeSeriesVisibility::IsVisible(EKawaiiPhysicsWindScopeComponent Component) const
 {
 	switch (Component)
@@ -632,7 +681,10 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 {
 	(void)InArgs;
 	CurrentModeText = LOCTEXT("InitialMode", "Preview");
-	SetArgs(MoveTemp(InitArgs));
+	if (HasTargetArgs(InitArgs))
+	{
+		SetArgs(MoveTemp(InitArgs));
+	}
 
 	ChildSlot
 	[
@@ -818,78 +870,130 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		]
 	];
 
-	RebuildPresetButtons();
+	if (HasTargetArgs())
+	{
+		RebuildPresetButtons();
+	}
 
 	// 60fps 相当でティックし、Live/Preview のサンプル更新とグラフ再描画を行う
 	RegisterActiveTimer(1.0f / 60.0f, FWidgetActiveTimerDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::TickWindScope));
 }
 
-void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args)
+SKawaiiPhysicsWindScopeWindow::~SKawaiiPhysicsWindScopeWindow()
 {
-	// 既存ウィンドウがあれば引数を差し替えて前面に出すだけ（ウィンドウは常に1つに集約する）
-	if (TSharedPtr<SWindow> ExistingWindow = KawaiiWindScopeWindowWeak.Pin())
+	ClearPendingReconnect();
+}
+
+void SKawaiiPhysicsWindScopeWindow::RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup)
+{
+	const FSlateIcon KawaiiPhysicsIcon(
+		FKawaiiPhysicsEdStyle::GetStyleSetName(),
+		TEXT("KawaiiPhysics.TabIcon"));
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
+			WindScopeTabId,
+			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsWindScopeWindow::SpawnWindScopeTab))
+		.SetDisplayName(LOCTEXT("WindScopeMenuDisplayName", "Kawaii Physics: Wind Scope"))
+		.SetTooltipText(LOCTEXT("WindScopeMenuTooltip", "KawaiiPhysics の風プレビュータブを開きます / Opens the KawaiiPhysics wind preview tab."))
+		.SetGroup(InMenuGroup)
+		.SetIcon(KawaiiPhysicsIcon);
+}
+
+void SKawaiiPhysicsWindScopeWindow::UnregisterTabSpawner()
+{
+	FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(WindScopeTabId);
+}
+
+TSharedRef<SDockTab> SKawaiiPhysicsWindScopeWindow::SpawnWindScopeTab(const FSpawnTabArgs& SpawnTabArgs)
+{
+	(void)SpawnTabArgs;
+
+	TSharedRef<SKawaiiPhysicsWindScopeWindow> ScopeWidget = SNew(SKawaiiPhysicsWindScopeWindow);
+	if (!ScopeWidget->HasTargetArgs())
 	{
-		if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> ExistingWidget = KawaiiWindScopeWidgetWeak.Pin())
-		{
-			ExistingWidget->SetArgs(MoveTemp(Args));
-		}
-		ExistingWindow->BringToFront();
-		return;
+		ScopeWidget->LoadPendingReconnectFromConfig();
 	}
 
-	// 新規ウィンドウを生成
-	TSharedRef<SKawaiiPhysicsWindScopeWindow> ScopeWidget =
-		SNew(SKawaiiPhysicsWindScopeWindow, MoveTemp(Args));
-
-	TSharedRef<SWindow> Window = SNew(SWindow)
-		.Title(LOCTEXT("WindowTitle", "Kawaii Physics: Wind Scope"))
-		.ClientSize(FVector2D(720.0f, 420.0f))
-		.MinWidth(520.0f)
-		.MinHeight(320.0f)
-		.AutoCenter(EAutoCenter::PreferredWorkArea)
+	TSharedRef<SDockTab> ScopeTab = SNew(SDockTab)
+		.TabRole(ETabRole::NomadTab)
+		.Label(LOCTEXT("WindScopeTabLabel", "Kawaii Wind Scope"))
+		.OnTabClosed_Lambda([](TSharedRef<SDockTab> ClosedTab)
+		{
+			(void)ClosedTab;
+			KawaiiWindScopeTabWeak.Reset();
+			KawaiiWindScopeWidgetWeak.Reset();
+		})
 		[
 			ScopeWidget
 		];
 
-	// 閉じたら配置を保存し弱参照をクリアする（次回 OpenWindow 時は上のブロックで新規生成される）
-	Window->SetOnWindowClosed(FOnWindowClosed::CreateLambda([](const TSharedRef<SWindow>& ClosedWindow)
-	{
-		KawaiiPhysicsEdWindowUtils::PersistWindowPlacement(
-			ClosedWindow,
-			WindScopeConfigSectionName,
-			WindScopeWindowPosConfigKey,
-			WindScopeWindowSizeConfigKey);
-		KawaiiWindScopeWindowWeak.Reset();
-		KawaiiWindScopeWidgetWeak.Reset();
-	}));
-
-	KawaiiWindScopeWindowWeak = Window;
+	KawaiiWindScopeTabWeak = ScopeTab;
 	KawaiiWindScopeWidgetWeak = ScopeWidget;
-	FSlateApplication::Get().AddWindow(Window);
-	KawaiiPhysicsEdWindowUtils::RestoreWindowPlacement(
-		Window,
-		WindScopeConfigSectionName,
-		WindScopeWindowPosConfigKey,
-		WindScopeWindowSizeConfigKey);
+	return ScopeTab;
+}
+
+void SKawaiiPhysicsWindScopeWindow::OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args)
+{
+	if (HasTargetArgs(Args))
+	{
+		SaveLastTargetArgs(Args);
+	}
+
+	// タブを呼び出してから、選択ノード由来の引数を既存コンテンツへ注入する
+	TSharedPtr<SDockTab> InvokedTab = FGlobalTabmanager::Get()->TryInvokeTab(WindScopeTabId);
+	if (!InvokedTab.IsValid())
+	{
+		return;
+	}
+
+	TSharedPtr<SWidget> TabContent = InvokedTab->GetContent();
+	if (!TabContent.IsValid())
+	{
+		return;
+	}
+
+	if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> ExistingWidget = KawaiiWindScopeWidgetWeak.Pin())
+	{
+		ExistingWidget->ClearPendingReconnect();
+		ExistingWidget->SetArgs(MoveTemp(Args));
+		return;
+	}
+
+	// Hot Reload等でファイルスコープの弱参照だけが失効した場合、タブ内容から復旧する
+	if (TabContent->GetType() == FName(TEXT("SKawaiiPhysicsWindScopeWindow")))
+	{
+		TSharedPtr<SKawaiiPhysicsWindScopeWindow> RecoveredWidget =
+			StaticCastSharedPtr<SKawaiiPhysicsWindScopeWindow>(TabContent);
+		KawaiiWindScopeTabWeak = InvokedTab;
+		KawaiiWindScopeWidgetWeak = RecoveredWidget;
+		RecoveredWidget->ClearPendingReconnect();
+		RecoveredWidget->SetArgs(MoveTemp(Args));
+	}
 }
 
 void SKawaiiPhysicsWindScopeWindow::CloseAllWindows()
 {
-	if (TSharedPtr<SWindow> Window = KawaiiWindScopeWindowWeak.Pin())
+	if (TSharedPtr<SDockTab> ScopeTab = KawaiiWindScopeTabWeak.Pin())
 	{
-		Window->RequestDestroyWindow();
+		ScopeTab->RequestCloseTab();
 	}
+	KawaiiWindScopeTabWeak.Reset();
+	KawaiiWindScopeWidgetWeak.Reset();
 }
 
 void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs InArgs)
 {
 	// 対象引数を差し替え、表示状態をリセットして外力一覧を再構築する
+	ResolvedGraphNodeCache.Reset();
 	Args = MoveTemp(InArgs);
 	DisplaySamples.Reset();
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
 	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
 	RefreshExternalForceItems();
+	if (HasTargetArgs())
+	{
+		RebuildPresetButtons();
+	}
 }
 
 TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateExternalForceComboWidget(FExternalForceIndexPtr Item) const
@@ -922,6 +1026,11 @@ FText SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText() const
 
 FText SKawaiiPhysicsWindScopeWindow::GetTargetNodeText() const
 {
+	if (!HasTargetArgs())
+	{
+		return LOCTEXT("NoTargetNodeGuidance", "ノード未選択: KawaiiPhysics ノードの [Wind Scope] から開いてください / No node selected: open from [Wind Scope] on a KawaiiPhysics node.");
+	}
+
 	if (const UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode())
 	{
 		return GraphNode->GetNodeTitle(ENodeTitleType::ListView);
@@ -1121,6 +1230,8 @@ bool SKawaiiPhysicsWindScopeWindow::PushGustToLiveRuntime(
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)
 {
 	(void)InCurrentTime;
+	TryResolvePendingReconnect(InDeltaTime);
+
 	if (bPaused)
 	{
 		return EActiveTimerReturnType::Continue;
@@ -1200,7 +1311,7 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
 	}
 
 	// エディタ経過時間を積算し、直近 DisplaySeconds 秒分を等間隔サンプリングする
-	PreviewTime += FMath::Max(InDeltaTime, 0.0f);
+	PreviewTime += FMath::Clamp(InDeltaTime, 0.0f, 0.1f);
 	DisplaySamples.Reset();
 	DisplaySamples.Reserve(WindScopePreviewSampleCount);
 	const float EndTime = PreviewTime;
@@ -1313,12 +1424,180 @@ UAnimGraphNode_KawaiiPhysics* SKawaiiPhysicsWindScopeWindow::ResolveGraphNode() 
 		return Args.GraphNode.Get();
 	}
 
+	if (ResolvedGraphNodeCache.IsValid())
+	{
+		return ResolvedGraphNodeCache.Get();
+	}
+
 	if (Args.AnimBlueprintPath.IsValid() && Args.NodeGuid.IsValid())
 	{
-		return UKawaiiPhysicsEditorLibrary::FindGraphNodeByGuid(Args.AnimBlueprintPath, Args.NodeGuid);
+		if (UAnimGraphNode_KawaiiPhysics* ResolvedGraphNode = FindLoadedGraphNodeByGuid(
+			Args.AnimBlueprintPath.ResolveObject(),
+			Args.NodeGuid))
+		{
+			ResolvedGraphNodeCache = ResolvedGraphNode;
+			return ResolvedGraphNode;
+		}
 	}
 
 	return nullptr;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::HasTargetArgs() const
+{
+	return HasTargetArgs(Args);
+}
+
+bool SKawaiiPhysicsWindScopeWindow::HasTargetArgs(const FKawaiiPhysicsWindScopeWindowArgs& InArgs)
+{
+	return InArgs.GraphNode.IsValid() || (InArgs.AnimBlueprintPath.IsValid() && InArgs.NodeGuid.IsValid());
+}
+
+void SKawaiiPhysicsWindScopeWindow::SaveLastTargetArgs(const FKawaiiPhysicsWindScopeWindowArgs& InArgs)
+{
+	if (!GConfig || !InArgs.AnimBlueprintPath.IsValid() || !InArgs.NodeGuid.IsValid())
+	{
+		return;
+	}
+
+	GConfig->SetString(
+		WindScopeConfigSectionName,
+		WindScopeLastAnimBlueprintKey,
+		*InArgs.AnimBlueprintPath.ToString(),
+		GEditorPerProjectIni);
+	GConfig->SetString(
+		WindScopeConfigSectionName,
+		WindScopeLastNodeGuidKey,
+		*InArgs.NodeGuid.ToString(EGuidFormats::DigitsWithHyphens),
+		GEditorPerProjectIni);
+	GConfig->SetInt(
+		WindScopeConfigSectionName,
+		WindScopeLastForceIndexKey,
+		InArgs.ExternalForceIndex,
+		GEditorPerProjectIni);
+	GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+void SKawaiiPhysicsWindScopeWindow::LoadPendingReconnectFromConfig()
+{
+	ClearPendingReconnect();
+	if (!GConfig)
+	{
+		return;
+	}
+
+	FString AnimBlueprintPathString;
+	FString NodeGuidString;
+	if (!GConfig->GetString(WindScopeConfigSectionName, WindScopeLastAnimBlueprintKey, AnimBlueprintPathString, GEditorPerProjectIni) ||
+		!GConfig->GetString(WindScopeConfigSectionName, WindScopeLastNodeGuidKey, NodeGuidString, GEditorPerProjectIni))
+	{
+		return;
+	}
+
+	FGuid ParsedNodeGuid;
+	if (!FGuid::Parse(NodeGuidString, ParsedNodeGuid))
+	{
+		return;
+	}
+
+	FSoftObjectPath ParsedAnimBlueprintPath(AnimBlueprintPathString);
+	if (!ParsedAnimBlueprintPath.IsValid() || !ParsedNodeGuid.IsValid())
+	{
+		return;
+	}
+
+	PendingReconnectArgs.AnimBlueprintPath = ParsedAnimBlueprintPath;
+	PendingReconnectArgs.NodeGuid = ParsedNodeGuid;
+	PendingReconnectArgs.ExternalForceIndex = INDEX_NONE;
+	GConfig->GetInt(
+		WindScopeConfigSectionName,
+		WindScopeLastForceIndexKey,
+		PendingReconnectArgs.ExternalForceIndex,
+		GEditorPerProjectIni);
+	bHasPendingReconnect = true;
+	bPendingReconnectAsyncLoadStarted = false;
+	PendingReconnectElapsedTime = 0.0f;
+}
+
+void SKawaiiPhysicsWindScopeWindow::ClearPendingReconnect(bool bCancelAsyncLoad)
+{
+	if (bCancelAsyncLoad && PendingReconnectAsyncLoadHandle.IsValid())
+	{
+		PendingReconnectAsyncLoadHandle->CancelHandle();
+	}
+	PendingReconnectAsyncLoadHandle.Reset();
+	ResolvedGraphNodeCache.Reset();
+	PendingReconnectArgs = FKawaiiPhysicsWindScopeWindowArgs();
+	bHasPendingReconnect = false;
+	bPendingReconnectAsyncLoadStarted = false;
+	PendingReconnectElapsedTime = 0.0f;
+}
+
+void SKawaiiPhysicsWindScopeWindow::TryResolvePendingReconnect(float InDeltaTime)
+{
+	if (!bHasPendingReconnect)
+	{
+		return;
+	}
+
+	if (!HasTargetArgs(PendingReconnectArgs))
+	{
+		ClearPendingReconnect();
+		return;
+	}
+
+	if (Cast<UAnimBlueprint>(PendingReconnectArgs.AnimBlueprintPath.ResolveObject()))
+	{
+		FKawaiiPhysicsWindScopeWindowArgs ReconnectArgs = PendingReconnectArgs;
+		ClearPendingReconnect();
+		SetArgs(MoveTemp(ReconnectArgs));
+		return;
+	}
+
+	PendingReconnectElapsedTime += FMath::Max(InDeltaTime, 0.0f);
+	if (bPendingReconnectAsyncLoadStarted || PendingReconnectElapsedTime < WindScopeReconnectTryLoadDelay)
+	{
+		return;
+	}
+
+	StartPendingReconnectAsyncLoad();
+}
+
+void SKawaiiPhysicsWindScopeWindow::StartPendingReconnectAsyncLoad()
+{
+	if (!bHasPendingReconnect || bPendingReconnectAsyncLoadStarted || !HasTargetArgs(PendingReconnectArgs))
+	{
+		return;
+	}
+
+	bPendingReconnectAsyncLoadStarted = true;
+	const FKawaiiPhysicsWindScopeWindowArgs ExpectedArgs = PendingReconnectArgs;
+	PendingReconnectAsyncLoadHandle = UAssetManager::GetStreamableManager().RequestAsyncLoad(
+		PendingReconnectArgs.AnimBlueprintPath,
+		FStreamableDelegate::CreateSP(
+			this,
+			&SKawaiiPhysicsWindScopeWindow::OnPendingReconnectAsyncLoadComplete,
+			ExpectedArgs));
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnPendingReconnectAsyncLoadComplete(FKawaiiPhysicsWindScopeWindowArgs ExpectedArgs)
+{
+	PendingReconnectAsyncLoadHandle.Reset();
+	if (!bHasPendingReconnect || !AreReconnectArgsSame(PendingReconnectArgs, ExpectedArgs))
+	{
+		return;
+	}
+
+	if (Cast<UAnimBlueprint>(PendingReconnectArgs.AnimBlueprintPath.ResolveObject()))
+	{
+		FKawaiiPhysicsWindScopeWindowArgs ReconnectArgs = PendingReconnectArgs;
+		ClearPendingReconnect(false);
+		SetArgs(MoveTemp(ReconnectArgs));
+	}
+	else
+	{
+		ClearPendingReconnect(false);
+	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -11,9 +11,12 @@
 #include "Widgets/Input/SCheckBox.h"
 #include "Widgets/Input/SComboBox.h"
 
+class FSpawnTabArgs;
+struct FStreamableHandle;
+class FWorkspaceItem;
+class SDockTab;
 class SComboBoxBase;
 class SWrapBox;
-class SWindow;
 class UAnimGraphNode_KawaiiPhysics;
 
 struct FKawaiiPhysicsWindScopeWindowArgs
@@ -31,7 +34,7 @@ struct FKawaiiPhysicsWindScopeWindowArgs
 	int32 ExternalForceIndex = INDEX_NONE;
 };
 
-// グラフに表示する波形成分の種別（ランタイム側 FKawaiiPhysicsProceduralWindSample の各フィールドに対応）
+// グラフに表示する波形成分の種別 / Waveform component shown in the graph.
 enum class EKawaiiPhysicsWindScopeComponent : uint8
 {
 	Total,
@@ -43,7 +46,7 @@ enum class EKawaiiPhysicsWindScopeComponent : uint8
 	Gust,
 };
 
-// 上記各成分の表示ON/OFFを凡例チェックボックスと連動して保持する
+// 上記各成分の表示ON/OFFを凡例チェックボックスと連動して保持する / Stores per-series visibility controlled by legend checkboxes.
 struct FKawaiiPhysicsWindScopeSeriesVisibility
 {
 	bool bTotal = true;
@@ -58,7 +61,7 @@ struct FKawaiiPhysicsWindScopeSeriesVisibility
 	void SetVisible(EKawaiiPhysicsWindScopeComponent Component, bool bVisible);
 };
 
-// 波形グラフ本体。SLeafWidget を継承し OnPaint でポリラインを直接描画する
+// 波形グラフ本体 / Waveform graph widget.
 class SKawaiiPhysicsWindScopeGraph : public SLeafWidget
 {
 public:
@@ -73,7 +76,7 @@ public:
 	void SetDisplaySeconds(float InDisplaySeconds);
 	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
 
-	// グラフの描画本体（Slate のペイントコールバック）
+	// グラフの描画本体 / Slate paint callback for the graph.
 	virtual int32 OnPaint(const FPaintArgs& Args,
 	                      const FGeometry& AllottedGeometry,
 	                      const FSlateRect& MyCullingRect,
@@ -90,7 +93,7 @@ private:
 	float DisplaySeconds = 8.0f;
 };
 
-// Wind Scope ツールウィンドウ本体。ツールバー・凡例・グラフ・プリセットボタンをまとめる SCompoundWidget
+// Wind Scope タブ本体 / Wind Scope tab content widget.
 class SKawaiiPhysicsWindScopeWindow : public SCompoundWidget
 {
 public:
@@ -99,12 +102,24 @@ public:
 		}
 	SLATE_END_ARGS()
 
-	void Construct(const FArguments& InArgs, FKawaiiPhysicsWindScopeWindowArgs InitArgs);
+	void Construct(const FArguments& InArgs, FKawaiiPhysicsWindScopeWindowArgs InitArgs = FKawaiiPhysicsWindScopeWindowArgs());
+	virtual ~SKawaiiPhysicsWindScopeWindow() override;
 
-	/** Wind Scope ウィンドウを開くか既存ウィンドウを更新する / Opens the Wind Scope window or updates the existing one. */
+	static const FName WindScopeTabId;
+
+	/** Wind Scope タブスポナーを登録する / Registers the Wind Scope tab spawner. */
+	static void RegisterTabSpawner(const TSharedRef<FWorkspaceItem>& InMenuGroup);
+
+	/** Wind Scope タブスポナーを解除する / Unregisters the Wind Scope tab spawner. */
+	static void UnregisterTabSpawner();
+
+	/** Wind Scope タブを生成する / Spawns the Wind Scope tab. */
+	static TSharedRef<SDockTab> SpawnWindScopeTab(const FSpawnTabArgs& SpawnTabArgs);
+
+	/** Wind Scope タブを開くか既存タブを更新する / Opens the Wind Scope tab or updates the existing one. */
 	static void OpenWindow(FKawaiiPhysicsWindScopeWindowArgs Args);
 
-	/** 開いている Wind Scope ウィンドウをすべて閉じる / Closes all open Wind Scope windows. */
+	/** 開いている Wind Scope タブをすべて閉じる / Closes all open Wind Scope tabs. */
 	static void CloseAllWindows();
 
 	/** 現在の引数でウィジェット状態を置き換える / Replaces the widget state with the current arguments. */
@@ -114,7 +129,7 @@ public:
 	void OnSeriesCheckStateChanged(ECheckBoxState NewState, EKawaiiPhysicsWindScopeComponent Component);
 
 private:
-	// ExternalForces 配列のインデックスを保持するコンボボックス項目型（SComboBox は TSharedPtr 項目を要求する）
+	// ExternalForces 配列のインデックスを保持するコンボボックス項目型 / Combo item type storing an ExternalForces array index.
 	using FExternalForceIndexPtr = TSharedPtr<int32>;
 
 	TSharedRef<SWidget> GenerateExternalForceComboWidget(FExternalForceIndexPtr Item) const;
@@ -134,35 +149,50 @@ private:
 	bool PushPresetToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
 
-	// 毎フレームの active timer コールバック。Live/Preview いずれかでサンプルを更新し再描画する
+	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);
 	void RefreshExternalForceItems();
-	// Live 実行中でない場合の理論波形（Preview）を再計算する
+	// Live 実行中でない場合の理論波形を再計算する / Rebuilds theoretical Preview samples when Live data is unavailable.
 	void RebuildPreviewSamples(float InDeltaTime);
-	// 実行中の RuntimeState からライブ波形を取得する。取得できなければ false（呼び出し側は Preview へフォールバック）
+	// 実行中の RuntimeState からライブ波形を取得する / Reads Live samples from RuntimeState.
 	bool TryUpdateFromLiveRuntime();
-	// Preview 計算用に ProceduralWind 設定値のコピーを取得する
+	// Preview 計算用に ProceduralWind 設定値のコピーを取得する / Gets a ProceduralWind copy for Preview calculation.
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
-	// 弱参照、または AnimBlueprintPath+NodeGuid から対象ノードを再解決する（BP再コンパイル等でポインタが失効しても追従できる）
+	// 弱参照、または AnimBlueprintPath+NodeGuid から対象ノードを再解決する / Resolves the target node from weak reference or AnimBlueprintPath+NodeGuid.
 	UAnimGraphNode_KawaiiPhysics* ResolveGraphNode() const;
+	bool HasTargetArgs() const;
+	static bool HasTargetArgs(const FKawaiiPhysicsWindScopeWindowArgs& InArgs);
+	static void SaveLastTargetArgs(const FKawaiiPhysicsWindScopeWindowArgs& InArgs);
+	void LoadPendingReconnectFromConfig();
+	void ClearPendingReconnect(bool bCancelAsyncLoad = true);
+	void TryResolvePendingReconnect(float InDeltaTime);
+	void StartPendingReconnectAsyncLoad();
+	void OnPendingReconnectAsyncLoadComplete(FKawaiiPhysicsWindScopeWindowArgs ExpectedArgs);
 
 	FKawaiiPhysicsWindScopeWindowArgs Args;
+	FKawaiiPhysicsWindScopeWindowArgs PendingReconnectArgs;
+	// GUID再解決済みノードの弱キャッシュ / Weak cache for the node resolved by GUID.
+	mutable TWeakObjectPtr<UAnimGraphNode_KawaiiPhysics> ResolvedGraphNodeCache;
 	TArray<FExternalForceIndexPtr> ExternalForceItems;
 	FExternalForceIndexPtr SelectedExternalForceItem;
 	FKawaiiPhysicsWindScopeSeriesVisibility SeriesVisibility;
-	// 現在グラフに描画中のサンプル列（Live/Preview 共通）
+	// 現在グラフに描画中のサンプル列 / Samples currently drawn in the graph.
 	TArray<FKawaiiProceduralWindScopeSample> DisplaySamples;
 	FText CurrentModeText;
 	float DisplaySeconds = 8.0f;
-	// Preview モードでの積算経過時間
+	// Preview モードでの積算経過時間 / Accumulated elapsed time in Preview mode.
 	float PreviewTime = 0.0f;
-	// 直前に読み取った RuntimeState->ScopeSampleCount。差分が無ければ新規サンプル無しと判断する
+	// 直前に読み取った RuntimeState->ScopeSampleCount / Last RuntimeState->ScopeSampleCount read.
 	uint64 LastLiveSampleCount = 0;
+	float PendingReconnectElapsedTime = 0.0f;
 	bool bPaused = false;
+	bool bHasPendingReconnect = false;
+	bool bPendingReconnectAsyncLoadStarted = false;
+	TSharedPtr<FStreamableHandle> PendingReconnectAsyncLoadHandle;
 
 	TSharedPtr<SComboBox<FExternalForceIndexPtr>> ExternalForceComboBox;
 	TSharedPtr<SKawaiiPhysicsWindScopeGraph> GraphWidget;
-	// ボタンindexとの整合を保つプリセットスナップショット
+	// ボタンindexとの整合を保つプリセットスナップショット / Preset snapshot aligned with button indices.
 	TArray<FKawaiiProceduralWindPreset> CachedPresets;
 	TSharedPtr<SWrapBox> PresetButtonBox;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsDockableTabsTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsDockableTabsTest.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "../SKawaiiPhysicsNodeAuditWindow.h"
+#include "../SKawaiiPhysicsPresetDiffWindow.h"
+#include "../SKawaiiPhysicsWindScopeWindow.h"
+
+#include "CoreGlobals.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Docking/TabManager.h"
+#include "Misc/App.h"
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsDockableTabsSpawnersTest,
+                                 "KawaiiPhysics.Editor.DockableTabs.Spawners",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsDockableTabsSpawnersTest::RunTest(const FString& Parameters)
+{
+	if (!GIsEditor || IsRunningCommandlet() || !FSlateApplication::IsInitialized())
+	{
+		AddInfo(TEXT("Slateが初期化されていない環境のため、DockableTabsスポナー登録テストをスキップします。"));
+		return true;
+	}
+
+	const FName WindScopeTabId = SKawaiiPhysicsWindScopeWindow::WindScopeTabId;
+	const FName PresetDiffTabId = SKawaiiPhysicsPresetDiffWindow::PresetDiffTabId;
+	const FName NodeAuditTabId = SKawaiiPhysicsNodeAuditWindow::NodeAuditTabId;
+
+	bool bOk = true;
+	bOk &= TestTrue(TEXT("Wind Scope tab spawner is registered"),
+	                FGlobalTabmanager::Get()->HasTabSpawner(WindScopeTabId));
+	bOk &= TestTrue(TEXT("Preset Diff tab spawner is registered"),
+	                FGlobalTabmanager::Get()->HasTabSpawner(PresetDiffTabId));
+	bOk &= TestTrue(TEXT("Node Audit tab spawner is registered"),
+	                FGlobalTabmanager::Get()->HasTabSpawner(NodeAuditTabId));
+	bOk &= TestTrue(TEXT("Wind Scope and Preset Diff tab ids are distinct"),
+	                WindScopeTabId != PresetDiffTabId);
+	bOk &= TestTrue(TEXT("Wind Scope and Node Audit tab ids are distinct"),
+	                WindScopeTabId != NodeAuditTabId);
+	bOk &= TestTrue(TEXT("Preset Diff and Node Audit tab ids are distinct"),
+	                PresetDiffTabId != NodeAuditTabId);
+	return bOk;
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEd.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEd.h
@@ -2,12 +2,23 @@
 
 #pragma once
 
+#include "Delegates/Delegate.h"
 #include "Modules/ModuleInterface.h"
+#include "Templates/SharedPointer.h"
+
+class FWorkspaceItem;
 
 class FKawaiiPhysicsEdModule : public IModuleInterface
 {
 public:
-	/** IModuleInterface implementation */
+	/** IModuleInterface 実装 / IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
+
+private:
+	void RegisterTabSpawners();
+
+	FDelegateHandle PostEngineInitHandle;
+	TSharedPtr<FWorkspaceItem> KawaiiPhysicsMenuGroup;
+	bool bTabSpawnersRegistered = false;
 };


### PR DESCRIPTION
## 概要

Wind Scope / Preset Diff / Node Audit の3つのエディタウィンドウを、浮動 SWindow からドッキング可能な Nomad タブへ移行しました。エディタ本体をクリックするとウィンドウが背面に隠れて見えなくなる問題の解消が目的です。

## 変更内容

- **Nomadタブ化**: 3ウィンドウを `FGlobalTabmanager::RegisterNomadTabSpawner` で登録。ドッキング・フローティング・サイドバードロワー格納・エディタレイアウトへの位置保存が可能に
- **ウィンドウメニュー統合**: メニュー直下に「Kawaii Physics」グループを新設し、3タブをプラグインアイコン（Icon128.png、新設の `FKawaiiPhysicsEdStyle`）付きで表示
- **プレースホルダ表示**: メニューやレイアウト復元から対象未指定で開かれた場合は案内文を表示し、全ボタンが安全に動作
- **Wind Scope 自動再接続**: ノードから開いた対象を EditorPerProjectIni に記録し、エディタ再起動後のレイアウト復元時に前回ノードへ自動再接続。未ロード時は `FStreamableManager::RequestAsyncLoad` による一回限りの非同期ロードで、起動時の同期ロードによるヒッチなし
- **Preset Diff の Close ボタン削除**: 旧実装の `FindWidgetWindow()->RequestDestroyWindow()` はドッキング時にエディタ本体ウィンドウを破棄してしまうため、ボタン自体を削除しタブ標準の×に一本化
- **Node Audit の動的タイトル**: `SDockTab::SetLabel` で "Find Target Nodes: {Preset}" 等の文脈をタブラベルに反映
- **堅牢性**: 登録ガード（commandlet / -game では登録しない）＋ `OnPostEngineInit` 再試行、`OnTabClosed` とモジュール Shutdown の双方で弱参照を明示クリーンアップ、ホットリロードで弱参照だけ失効した場合はタブ内容から復旧
- **後片付け**: 不要になったウィンドウ位置永続化ユーティリティ（Persist/RestoreWindowPlacement）を削除、UI文言を「ウィンドウ」→「タブ」へ更新
- **テスト**: タブスポナー登録を検証する Automation テストを追加

## 互換性

- UE5.0〜5.8 対応。バージョン分岐は `FCoreDelegates::OnPostEngineInit` の非推奨化（5.8）に対する `UE_VERSION_OLDER_THAN(5, 8, 0)` ガード1箇所のみ
- 呼び出し元（ノード詳細パネル / 右クリックメニュー / プリセットDataAsset詳細）の static API は維持しており、既存フローへの変更なし

## 検証

- UE5.8: ビルド警告ゼロ、Automation テスト 119/119 green（新規 `KawaiiPhysics.Editor.DockableTabs.Spawners` 含む）
- UE5.3: BuildPlugin クロスビルド成功（KawaiiPhysicsEd のコンパイル・リンク確認）
- 手動確認は `DockTabs_PIE_Checklist.md`（ローカル運用）に基づき実施予定