### PR TITLE
Add gust direction control and migrate gusts to transient external forces

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -40,6 +40,41 @@
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AnimNode_KawaiiPhysics)
 
+namespace
+{
+	void DropOldestPendingTransientForceIfFull(FKawaiiPhysicsTransientForceQueue& Queue, const bool bAppendingGust)
+	{
+		if (Queue.PendingForces.Num() + Queue.PendingGusts.Num() < FAnimNode_KawaiiPhysics::MaxTransientExternalForces)
+		{
+			return;
+		}
+
+		// 評価が走らないノードへの連打でも pending 合計が MaxTransientExternalForces を超えないよう最古から破棄する。
+		if (bAppendingGust)
+		{
+			if (Queue.PendingGusts.Num() > 0)
+			{
+				Queue.PendingGusts.RemoveAt(0);
+			}
+			else
+			{
+				Queue.PendingForces.RemoveAt(0);
+			}
+		}
+		else
+		{
+			if (Queue.PendingForces.Num() > 0)
+			{
+				Queue.PendingForces.RemoveAt(0);
+			}
+			else
+			{
+				Queue.PendingGusts.RemoveAt(0);
+			}
+		}
+	}
+}
+
 #if ENABLE_ANIM_DEBUG
 TAutoConsoleVariable<bool> CVarAnimNodeKawaiiPhysicsEnable(
 	TEXT("a.AnimNode.KawaiiPhysics.Enable"), true, TEXT("Enable/Disable KawaiiPhysics"));
@@ -167,6 +202,15 @@ void FAnimNode_KawaiiPhysics::Initialize_AnyThread(const FAnimationInitializeCon
 	SubstepAccumulator = 0.0f;
 	bSubstepPoseInitialized = false;
 
+	// ノード再初期化時は実行時専用の一時外力を破棄する
+	TransientForceStore.Items.Reset();
+	if (TransientForceStore.Queue.IsValid())
+	{
+		FScopeLock Lock(&TransientForceStore.Queue->Mutex);
+		TransientForceStore.Queue->PendingForces.Reset();
+		TransientForceStore.Queue->PendingGusts.Reset();
+	}
+
 	for (int i = 0; i < ExternalForces.Num(); ++i)
 	{
 		if (ExternalForces[i].IsValid())
@@ -208,6 +252,33 @@ void FAnimNode_KawaiiPhysics::ResetDynamics(ETeleportType InTeleportType)
 	// サブステップ：未消費時間を破棄し、ポーズ補間の前フレーム値を次フレームで再初期化させる
 	SubstepAccumulator = 0.0f;
 	bSubstepPoseInitialized = false;
+}
+
+void FAnimNode_KawaiiPhysics::RequestTransientExternalForce(FInstancedStruct&& InForce, const float InLifetimeSeconds)
+{
+	FScopeLock Lock(&TransientForceStore.Queue->Mutex);
+	DropOldestPendingTransientForceIfFull(*TransientForceStore.Queue, false);
+
+	FKawaiiPhysicsTransientExternalForce Entry;
+	Entry.Force = MoveTemp(InForce);
+	Entry.RemainingLifetime = InLifetimeSeconds;
+
+	TransientForceStore.Queue->PendingForces.Emplace(MoveTemp(Entry));
+}
+
+void FAnimNode_KawaiiPhysics::RequestTransientGust(const float Strength, const float RiseTime, const float DecayTime,
+                                                   const FVector& GustDirection, const int32 InheritForceIndex)
+{
+	FKawaiiPhysicsTransientGustRequest Request;
+	Request.Strength = Strength;
+	Request.RiseTime = RiseTime;
+	Request.DecayTime = DecayTime;
+	Request.Direction = GustDirection;
+	Request.InheritForceIndex = InheritForceIndex;
+
+	FScopeLock Lock(&TransientForceStore.Queue->Mutex);
+	DropOldestPendingTransientForceIfFull(*TransientForceStore.Queue, true);
+	TransientForceStore.Queue->PendingGusts.Emplace(Request);
 }
 
 void FAnimNode_KawaiiPhysics::UpdateInternal(const FAnimationUpdateContext& Context)
@@ -527,6 +598,9 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 
 	// World SpaceでのSkeletalMeshComponentの移動を更新する
 	UpdateSkelCompMove(Output, ComponentTransform);
+
+	// 一時外力は評価ごとに1回だけ取り込み、WarmUpの反復やTeleport時のSimulateスキップに左右されないようにする
+	ConsumeAndSweepTransientExternalForces(DeltaTime);
 
 	// 物理の荒ぶりを回避するための空回し処理
 	if (bNeedWarmUp && WarmUpFrames > 0)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -7,6 +7,7 @@
 #include "KawaiiPhysicsCustomExternalForce.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
 #include "KawaiiPhysicsLimitsDataAsset.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
 #include "Animation/AnimInstanceProxy.h"
@@ -32,6 +33,125 @@
 
 #include "KawaiiPhysics.h"
 #include "AnimNode_KawaiiPhysicsInternal.h"
+
+namespace
+{
+	constexpr float TransientGustLifetimeMargin = 0.2f;
+
+	// InstancedStructがProceduralWindであれば可変ポインタを返す（型不一致・無効ならnullptr）
+	FKawaiiPhysics_ExternalForce_ProceduralWind* GetMutableProceduralWindInNode(FInstancedStruct& InstancedStruct)
+	{
+		if (!InstancedStruct.IsValid() ||
+			InstancedStruct.GetScriptStruct() != FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
+		{
+			return nullptr;
+		}
+
+		return InstancedStruct.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	}
+
+	// worker上で突風用ProceduralWindを構築する
+	void BuildTransientGustForceFromSource(FAnimNode_KawaiiPhysics& Node,
+	                                       const FKawaiiPhysicsTransientGustRequest& Request,
+	                                       FKawaiiPhysics_ExternalForce_ProceduralWind* Source)
+	{
+		FKawaiiPhysicsTransientExternalForce& Entry = Node.TransientForceStore.Items.AddDefaulted_GetRef();
+		Entry.Force = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+			Entry.Force.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+		if (!Wind)
+		{
+			Node.TransientForceStore.Items.Pop();
+			return;
+		}
+
+		if (Source)
+		{
+			Wind->ApplyBoneFilter = Source->ApplyBoneFilter;
+			Wind->IgnoreBoneFilter = Source->IgnoreBoneFilter;
+			Wind->ForceRateByBoneLengthRate = Source->ForceRateByBoneLengthRate;
+			Wind->RandomForceScaleRange = Source->RandomForceScaleRange;
+			Wind->TimeScale = Source->TimeScale;
+		}
+
+		// 明示方向は決定論的なバーストとしてノイズ無し、方向継承時は旧挙動（authored のノイズ入り方向）に合わせて揺らぎも継承する。
+		if (!Request.Direction.IsNearlyZero(KINDA_SMALL_NUMBER))
+		{
+			Wind->ExternalForceSpace = EExternalForceSpace::WorldSpace;
+			Wind->WindDirection = Request.Direction;
+		}
+		else if (Source)
+		{
+			Wind->ExternalForceSpace = Source->ExternalForceSpace;
+			Wind->WindDirection = Source->WindDirection;
+			Wind->DirectionNoiseAngle = Source->DirectionNoiseAngle;
+			Wind->DirectionNoisePeriod = Source->DirectionNoisePeriod;
+			Wind->RandomSeed = Source->RandomSeed;
+		}
+
+		const float EffectiveTimeScale = Wind->TimeScale;
+		Entry.RemainingLifetime =
+			(FMath::Max(Request.RiseTime, 0.0f) + FMath::Max(Request.DecayTime, 0.0f)) /
+			FMath::Max(EffectiveTimeScale, KINDA_SMALL_NUMBER) + TransientGustLifetimeMargin;
+
+		// RequestGust後にProceduralWind本体をコピーするとRuntimeState内のPendingGustが失われる
+		Wind->RequestGust(Request.Strength, Request.RiseTime, Request.DecayTime);
+	}
+
+	// worker上で突風用ProceduralWindを構築する
+	void BuildTransientGustForce(FAnimNode_KawaiiPhysics& Node, const FKawaiiPhysicsTransientGustRequest& Request)
+	{
+		if (Request.InheritForceIndex == FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds)
+		{
+			// Component API 用: authored wind ごとの旧挙動＝各 wind のフィルタ/空間/方向で突風、を transient で再現する
+			TArray<FKawaiiPhysics_ExternalForce_ProceduralWind*> Sources;
+			for (int32 i = 0; i < Node.ExternalForces.Num(); ++i)
+			{
+				FKawaiiPhysics_ExternalForce_ProceduralWind* Candidate =
+					GetMutableProceduralWindInNode(Node.ExternalForces[i]);
+				if (Candidate && Candidate->bIsEnabled)
+				{
+					Sources.Add(Candidate);
+				}
+			}
+
+			if (Sources.IsEmpty())
+			{
+				BuildTransientGustForceFromSource(Node, Request, nullptr);
+				return;
+			}
+
+			for (FKawaiiPhysics_ExternalForce_ProceduralWind* Source : Sources)
+			{
+				BuildTransientGustForceFromSource(Node, Request, Source);
+			}
+			return;
+		}
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Source = nullptr;
+		if (Node.ExternalForces.IsValidIndex(Request.InheritForceIndex))
+		{
+			Source = GetMutableProceduralWindInNode(Node.ExternalForces[Request.InheritForceIndex]);
+		}
+
+		if (!Source)
+		{
+			for (int32 i = 0; i < Node.ExternalForces.Num(); ++i)
+			{
+				FKawaiiPhysics_ExternalForce_ProceduralWind* Candidate =
+					GetMutableProceduralWindInNode(Node.ExternalForces[i]);
+				if (Candidate && Candidate->bIsEnabled)
+				{
+					Source = Candidate;
+					break;
+				}
+			}
+		}
+
+		BuildTransientGustForceFromSource(Node, Request, Source);
+	}
+}
 
 void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 {
@@ -70,6 +190,47 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 		Bone.PhysicsSettings.LimitAngle = FMath::Max(
 			PhysicsSettings.LimitAngle * LimitAngleCurveData.GetRichCurveConst()->Eval(
 				LengthRate, 1.0f), 0.0f);
+	}
+}
+
+void FAnimNode_KawaiiPhysics::ConsumeAndSweepTransientExternalForces(const float InFrameDeltaTime)
+{
+	for (int32 i = TransientForceStore.Items.Num() - 1; i >= 0; --i)
+	{
+		TransientForceStore.Items[i].RemainingLifetime -= InFrameDeltaTime;
+		if (TransientForceStore.Items[i].RemainingLifetime <= 0.0f)
+		{
+			TransientForceStore.Items.RemoveAt(i);
+		}
+	}
+
+	TArray<FKawaiiPhysicsTransientExternalForce> PendingForces;
+	TArray<FKawaiiPhysicsTransientGustRequest> PendingGusts;
+	if (TransientForceStore.Queue.IsValid())
+	{
+		FScopeLock Lock(&TransientForceStore.Queue->Mutex);
+		PendingForces = MoveTemp(TransientForceStore.Queue->PendingForces);
+		PendingGusts = MoveTemp(TransientForceStore.Queue->PendingGusts);
+	}
+
+	for (FKawaiiPhysicsTransientExternalForce& PendingForce : PendingForces)
+	{
+		if (FKawaiiPhysics_ExternalForce* Force = PendingForce.Force.GetMutablePtr<FKawaiiPhysics_ExternalForce>())
+		{
+			// PostApplyのone-shot削除はNode.ExternalForcesを走査するため、一時外力では必ず無効化する
+			Force->bIsOneShot = false;
+		}
+		TransientForceStore.Items.Emplace(MoveTemp(PendingForce));
+	}
+
+	for (const FKawaiiPhysicsTransientGustRequest& PendingGust : PendingGusts)
+	{
+		BuildTransientGustForce(*this, PendingGust);
+	}
+
+	while (TransientForceStore.Items.Num() > MaxTransientExternalForces)
+	{
+		TransientForceStore.Items.RemoveAt(0);
 	}
 }
 
@@ -164,6 +325,16 @@ void FAnimNode_KawaiiPhysics::SimulateModifyBones(FComponentSpacePoseContext& Ou
 		{
 			auto& Force = ExternalForces[i].GetMutable<FKawaiiPhysics_ExternalForce>();
 			Force.PreApply(*this, Output);
+		}
+	}
+	for (int i = 0; i < TransientForceStore.Items.Num(); ++i)
+	{
+		if (TransientForceStore.Items[i].Force.IsValid())
+		{
+			if (auto* Force = TransientForceStore.Items[i].Force.GetMutablePtr<FKawaiiPhysics_ExternalForce>())
+			{
+				Force->PreApply(*this, Output);
+			}
 		}
 	}
 
@@ -369,6 +540,16 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 		{
 			auto& Force = ExternalForces[i].GetMutable<FKawaiiPhysics_ExternalForce>();
 			Force.PostApply(*this, Output);
+		}
+	}
+	for (int i = 0; i < TransientForceStore.Items.Num(); ++i)
+	{
+		if (TransientForceStore.Items[i].Force.IsValid())
+		{
+			if (auto* Force = TransientForceStore.Items[i].Force.GetMutablePtr<FKawaiiPhysics_ExternalForce>())
+			{
+				Force->PostApply(*this, Output);
+			}
 		}
 	}
 
@@ -581,6 +762,20 @@ void FAnimNode_KawaiiPhysics::Simulate(FKawaiiPhysicsModifyBone& Bone, const FSc
 			}
 		}
 	}
+	for (int i = 0; i < TransientForceStore.Items.Num(); ++i)
+	{
+		if (TransientForceStore.Items[i].Force.IsValid())
+		{
+			if (const auto ExForce =
+				TransientForceStore.Items[i].Force.GetMutablePtr<FKawaiiPhysics_ExternalForce>())
+			{
+				if (ExForce->bIsEnabled)
+				{
+					ExForce->ApplyToVelocity(Bone, *this, Output, Velocity);
+				}
+			}
+		}
+	}
 
 	// 速度のぶんだけ位置を進める。
 	IntegrateVerletStepPosition(Bone, Velocity);
@@ -638,6 +833,28 @@ void FAnimNode_KawaiiPhysics::Simulate(FKawaiiPhysicsModifyBone& Bone, const FSc
 				else
 				{
 					ExForce->Apply(Bone, *this, Output);
+				}
+			}
+		}
+	}
+	for (int i = 0; i < TransientForceStore.Items.Num(); ++i)
+	{
+		if (TransientForceStore.Items[i].Force.IsValid())
+		{
+			if (const auto ExForce =
+				TransientForceStore.Items[i].Force.GetMutablePtr<FKawaiiPhysics_ExternalForce>())
+			{
+				if (ExForce->bIsEnabled)
+				{
+					if (ExForce->ExternalForceSpace == EExternalForceSpace::BoneSpace)
+					{
+						const FTransform BoneTM = ResolveExternalForceBoneTransform(Output, Bone, ParentBone);
+						ExForce->Apply(Bone, *this, Output, BoneTM);
+					}
+					else
+					{
+						ExForce->Apply(Bone, *this, Output);
+					}
 				}
 			}
 		}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.cpp
@@ -31,9 +31,9 @@ void UAnimNotify_KawaiiPhysicsTriggerGust::Notify(USkeletalMeshComponent* MeshCo
 		return;
 	}
 
-	// タグでフィルタしつつ、Component内の対象ノードのProceduralWindへ突風をキューイングする
+	// タグでフィルタしつつ、Component内の対象ノードへ突風をキューイングする
 	UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(MeshComp, Strength, RiseTime, DecayTime,
-	                                                            FilterTags, bFilterExactMatch);
+	                                                            FilterTags, bFilterExactMatch, GustDirection);
 
 	Super::Notify(MeshComp, Animation, EventReference);
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -77,14 +77,6 @@ namespace
 		return InstancedStruct.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
 	}
 
-	// 突風リクエストをMutex経由でキューイングする（GameThread側の呼び出しをWorker側のPreApplyへスレッドセーフに橋渡し）
-	bool QueueProceduralWindGust(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
-	                             const float Strength, const float RiseTime, const float DecayTime)
-	{
-		ProceduralWind.RequestGust(Strength, RiseTime, DecayTime);
-		return true;
-	}
-
 	// 動的パラメータ更新も同様にMutex経由でキューイングする
 	bool QueueProceduralWindParams(FKawaiiPhysics_ExternalForce_ProceduralWind& ProceduralWind,
 	                               const FKawaiiProceduralWindDynamicParams& Params)
@@ -600,34 +592,25 @@ bool UKawaiiPhysicsLibrary::RemoveExternalForcesFromComponent(USkeletalMeshCompo
 	return bResult;
 }
 
-// 指定したExternalForceIndexのProceduralWindへ突風をトリガーする（実体は上記ヘルパーでのキューイング）
+// 一時ProceduralWindとして突風をノードへキューイングする
 FKawaiiPhysicsReference UKawaiiPhysicsLibrary::TriggerProceduralWindGust(
 	EKawaiiPhysicsAccessExternalForceResult& ExecResult,
 	const FKawaiiPhysicsReference& KawaiiPhysics,
 	const int32 ExternalForceIndex,
 	const float Strength,
 	const float RiseTime,
-	const float DecayTime)
+	const float DecayTime,
+	const FVector GustDirection)
 {
 	ExecResult = EKawaiiPhysicsAccessExternalForceResult::NotValid;
 
 	KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
 		TEXT("TriggerProceduralWindGust"),
-		[&ExecResult, ExternalForceIndex, Strength, RiseTime, DecayTime](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+		[&ExecResult, ExternalForceIndex, Strength, RiseTime, DecayTime, GustDirection](
+			FAnimNode_KawaiiPhysics& InKawaiiPhysics)
 		{
-			if (!InKawaiiPhysics.ExternalForces.IsValidIndex(ExternalForceIndex))
-			{
-				return;
-			}
-
-			if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
-				GetMutableProceduralWind(InKawaiiPhysics.ExternalForces[ExternalForceIndex]))
-			{
-				if (QueueProceduralWindGust(*ProceduralWind, Strength, RiseTime, DecayTime))
-				{
-					ExecResult = EKawaiiPhysicsAccessExternalForceResult::Valid;
-				}
-			}
+			InKawaiiPhysics.RequestTransientGust(Strength, RiseTime, DecayTime, GustDirection, ExternalForceIndex);
+			ExecResult = EKawaiiPhysicsAccessExternalForceResult::Valid;
 		});
 
 	return KawaiiPhysics;
@@ -664,16 +647,17 @@ FKawaiiPhysicsReference UKawaiiPhysicsLibrary::SetProceduralWindParameters(
 	return KawaiiPhysics;
 }
 
-// Component内の対象ノード（Tagフィルタ適用）を走査し、ProceduralWindへ一括で突風をトリガーする
+// Component内の対象ノード（Tagフィルタ適用）を走査し、一時ProceduralWindとして突風をキューイングする
 int32 UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(
 	USkeletalMeshComponent* MeshComp,
 	const float Strength,
 	const float RiseTime,
 	const float DecayTime,
 	const FGameplayTagContainer& FilterTags,
-	const bool bFilterExactMatch)
+	const bool bFilterExactMatch,
+	const FVector GustDirection)
 {
-	int32 AppliedForceCount = 0;
+	int32 AppliedNodeCount = 0;
 
 	TArray<FKawaiiPhysicsReference> KawaiiPhysicsReferences;
 	CollectKawaiiPhysicsNodes(KawaiiPhysicsReferences, MeshComp, FilterTags, bFilterExactMatch);
@@ -681,23 +665,16 @@ int32 UKawaiiPhysicsLibrary::TriggerProceduralWindGustOnComponent(
 	{
 		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
 			TEXT("TriggerProceduralWindGustOnComponent"),
-			[&AppliedForceCount, Strength, RiseTime, DecayTime](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+			[&AppliedNodeCount, Strength, RiseTime, DecayTime, GustDirection](
+				FAnimNode_KawaiiPhysics& InKawaiiPhysics)
 			{
-				for (FInstancedStruct& InstancedStruct : InKawaiiPhysics.ExternalForces)
-				{
-					if (FKawaiiPhysics_ExternalForce_ProceduralWind* ProceduralWind =
-						GetMutableProceduralWind(InstancedStruct))
-					{
-						if (QueueProceduralWindGust(*ProceduralWind, Strength, RiseTime, DecayTime))
-						{
-							++AppliedForceCount;
-						}
-					}
-				}
+				InKawaiiPhysics.RequestTransientGust(Strength, RiseTime, DecayTime, GustDirection,
+				                                     FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
+				++AppliedNodeCount;
 			});
 	}
 
-	return AppliedForceCount;
+	return AppliedNodeCount;
 }
 
 // Component内の対象ノード（Tagフィルタ適用）を走査し、ProceduralWindへ一括でパラメータ更新をリクエストする

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
@@ -1,0 +1,575 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "AnimNode_KawaiiPhysics.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "KawaiiPhysicsPresetDataAsset.h"
+
+#include "Animation/AnimInstanceProxy.h"
+#include "Animation/AnimNodeBase.h"
+#include "Curves/CurveFloat.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+constexpr float GTransientForceTol = 0.000001f;
+
+FKawaiiPhysics_ExternalForce_ProceduralWind* GetTransientWind(FAnimNode_KawaiiPhysics& Node, const int32 Index = 0)
+{
+	if (!Node.TransientForceStore.Items.IsValidIndex(Index))
+	{
+		return nullptr;
+	}
+
+	return Node.TransientForceStore.Items[Index].Force.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+}
+
+bool TestFloatNear(FAutomationTestBase& Test, const TCHAR* Name, const float Actual, const float Expected)
+{
+	return Test.TestTrue(FString::Printf(TEXT("%s: got %.9f expected %.9f"), Name, Actual, Expected),
+	                     FMath::IsNearlyEqual(Actual, Expected, GTransientForceTol));
+}
+
+void RunPreApply(FAnimNode_KawaiiPhysics& Node, FKawaiiPhysics_ExternalForce_ProceduralWind& Wind)
+{
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+	Wind.PreApply(Node, PoseContext);
+}
+
+int32 GetPendingGustCount(FAnimNode_KawaiiPhysics& Node)
+{
+	if (!Node.TransientForceStore.Queue.IsValid())
+	{
+		return 0;
+	}
+
+	FScopeLock Lock(&Node.TransientForceStore.Queue->Mutex);
+	return Node.TransientForceStore.Queue->PendingGusts.Num();
+}
+
+void AddAuthoredProceduralWind(FAnimNode_KawaiiPhysics& Node, const bool bIsEnabled, const FVector& Direction,
+                               const EExternalForceSpace ForceSpace, const float TimeScale,
+                               const bool bWithFiltersAndCurve, const float DirectionNoiseAngle = 0.0f,
+                               const float DirectionNoisePeriod = 1.0f, const int32 RandomSeed = 0,
+                               const FFloatInterval RandomForceScaleRange = FFloatInterval(1.0f, 1.0f))
+{
+	FInstancedStruct InstancedWind = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		InstancedWind.GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	check(Wind);
+
+	Wind->bIsEnabled = bIsEnabled;
+	Wind->WindDirection = Direction;
+	Wind->ExternalForceSpace = ForceSpace;
+	Wind->TimeScale = TimeScale;
+	Wind->DirectionNoiseAngle = DirectionNoiseAngle;
+	Wind->DirectionNoisePeriod = DirectionNoisePeriod;
+	Wind->RandomSeed = RandomSeed;
+	Wind->RandomForceScaleRange = RandomForceScaleRange;
+
+	if (bWithFiltersAndCurve)
+	{
+		FBoneReference BoneReference;
+		BoneReference.BoneName = TEXT("transient_force_test_bone");
+		Wind->ApplyBoneFilter.Add(BoneReference);
+		Wind->ForceRateByBoneLengthRate.GetRichCurve()->AddKey(0.25f, 0.75f);
+	}
+
+	Node.ExternalForces.Emplace(MoveTemp(InstancedWind));
+}
+
+void AddStandardAuthoredWinds(FAnimNode_KawaiiPhysics& Node)
+{
+	AddAuthoredProceduralWind(Node, false, FVector(1.0f, 0.0f, 0.0f),
+	                          EExternalForceSpace::WorldSpace, 1.0f, false);
+	AddAuthoredProceduralWind(Node, true, FVector(0.0f, 1.0f, 0.0f),
+	                          EExternalForceSpace::ComponentSpace, 2.0f, true, 15.0f, 0.5f, 42,
+	                          FFloatInterval(0.5f, 2.0f));
+}
+
+bool TestInheritedRuntimeFields(FAutomationTestBase& Test, FKawaiiPhysics_ExternalForce_ProceduralWind& Wind)
+{
+	bool bOk = true;
+	bOk &= Test.TestEqual(TEXT("ApplyBoneFilter.Num"), Wind.ApplyBoneFilter.Num(), 1);
+	bOk &= Test.TestEqual(TEXT("Curve key count"), Wind.ForceRateByBoneLengthRate.GetRichCurveConst()->GetNumKeys(), 1);
+	bOk &= TestFloatNear(Test, TEXT("RandomForceScaleRange.Min"), Wind.RandomForceScaleRange.Min, 0.5f);
+	bOk &= TestFloatNear(Test, TEXT("RandomForceScaleRange.Max"), Wind.RandomForceScaleRange.Max, 2.0f);
+	bOk &= TestFloatNear(Test, TEXT("TimeScale"), Wind.TimeScale, 2.0f);
+	return bOk;
+}
+
+void ApplyDefaultPresetStyleCopy(FAnimNode_KawaiiPhysics& TargetNode)
+{
+	FAnimNode_KawaiiPhysics DefaultNode;
+	const FKawaiiPhysicsPresetApplyOptions Options;
+
+	for (TFieldIterator<FProperty> PropertyIt(FAnimNode_KawaiiPhysics::StaticStruct(), EFieldIteratorFlags::ExcludeSuper);
+	     PropertyIt; ++PropertyIt)
+	{
+		const FProperty& Property = **PropertyIt;
+		if (!UKawaiiPhysicsPresetDataAsset::ShouldApplyNodeProperty(Property, Options))
+		{
+			continue;
+		}
+
+		const FName PropertyName = Property.GetFName();
+		if (PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, ExternalForces) ||
+			PropertyName == GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, CustomExternalForces))
+		{
+			continue;
+		}
+
+		Property.CopyCompleteValue_InContainer(&TargetNode, &DefaultNode);
+	}
+}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceGustConsumeCreatesActiveGustTest,
+                                 "KawaiiPhysics.TransientForce.GustConsumeCreatesActiveGust",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceGustConsumeCreatesActiveGustTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 2.0f), INDEX_NONE);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+	bool bOk = true;
+	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+	bOk &= TestTrue(TEXT("Transient force is ProceduralWind"), Wind != nullptr);
+	if (!Wind)
+	{
+		return false;
+	}
+
+	bOk &= TestTrue(TEXT("ExternalForceSpace"), Wind->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+	bOk &= TestTrue(TEXT("WindDirection"), Wind->WindDirection.Equals(FVector(0.0f, 0.0f, 2.0f)));
+
+	RunPreApply(Node, *Wind);
+
+	bOk &= TestTrue(TEXT("ActiveGust active"), Wind->RuntimeState->ActiveGust.bIsActive);
+	TestFloatNear(*this, TEXT("ActiveGust Strength"), Wind->RuntimeState->ActiveGust.Strength, 4.0f);
+	TestFloatNear(*this, TEXT("ActiveGust RiseTime"), Wind->RuntimeState->ActiveGust.RiseTime, 0.2f);
+	TestFloatNear(*this, TEXT("ActiveGust DecayTime"), Wind->RuntimeState->ActiveGust.DecayTime, 0.6f);
+	TestFloatNear(*this, TEXT("RemainingLifetime"),
+	              Node.TransientForceStore.Items[0].RemainingLifetime, 1.0f);
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceLifetimeSweepTest,
+                                 "KawaiiPhysics.TransientForce.LifetimeSweep",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceLifetimeSweepTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	Node.RequestTransientGust(1.0f, 0.05f, 0.0f, FVector::ForwardVector, INDEX_NONE);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	bool bOk = TestEqual(TEXT("Initial consume"), Node.TransientForceStore.Items.Num(), 1);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.13f);
+	bOk &= TestEqual(TEXT("Still alive"), Node.TransientForceStore.Items.Num(), 1);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.13f);
+	bOk &= TestEqual(TEXT("Expired"), Node.TransientForceStore.Items.Num(), 0);
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceMultiGustTest,
+                                 "KawaiiPhysics.TransientForce.MultiGust",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceMultiGustTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(1.0f, 0.0f, 0.0f), INDEX_NONE);
+	Node.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector(0.0f, 1.0f, 0.0f), INDEX_NONE);
+	Node.RequestTransientGust(3.0f, 0.1f, 0.1f, FVector(0.0f, 0.0f, 1.0f), INDEX_NONE);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+	return TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceCapDropsOldestTest,
+                                 "KawaiiPhysics.TransientForce.CapDropsOldest",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceCapDropsOldestTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	for (int32 Index = 0; Index < 10; ++Index)
+	{
+		Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(static_cast<float>(Index), 1.0f, 0.0f), INDEX_NONE);
+	}
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), FAnimNode_KawaiiPhysics::MaxTransientExternalForces);
+	for (int32 Index = 0; Index < Node.TransientForceStore.Items.Num(); ++Index)
+	{
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node, Index);
+		bOk &= TestTrue(FString::Printf(TEXT("Wind %d valid"), Index), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestTrue(FString::Printf(TEXT("Direction %d"), Index),
+			                Wind->WindDirection.Equals(FVector(static_cast<float>(Index + 2), 1.0f, 0.0f)));
+		}
+	}
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForcePendingCapBoundsQueueTest,
+                                 "KawaiiPhysics.TransientForce.PendingCapBoundsQueue",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForcePendingCapBoundsQueueTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	for (int32 Index = 1; Index <= 12; ++Index)
+	{
+		Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(static_cast<float>(Index), 0.0f, 0.0f), INDEX_NONE);
+	}
+
+	bool bOk = TestTrue(TEXT("Queue valid"), Node.TransientForceStore.Queue.IsValid());
+	if (Node.TransientForceStore.Queue.IsValid())
+	{
+		FScopeLock Lock(&Node.TransientForceStore.Queue->Mutex);
+		bOk &= TestEqual(TEXT("PendingGusts.Num"), Node.TransientForceStore.Queue->PendingGusts.Num(), 8);
+		if (Node.TransientForceStore.Queue->PendingGusts.IsValidIndex(0))
+		{
+			bOk &= TestTrue(TEXT("PendingGusts[0].Direction.X"),
+			                FMath::IsNearlyEqual(Node.TransientForceStore.Queue->PendingGusts[0].Direction.X,
+			                                     5.0f, GTransientForceTol));
+		}
+		else
+		{
+			bOk = false;
+		}
+	}
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 8);
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceDirectionSentinelBoundaryTest,
+                                 "KawaiiPhysics.TransientForce.DirectionSentinelBoundary",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceDirectionSentinelBoundaryTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics Node;
+	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ZeroVector, INDEX_NONE);
+	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 0.5f, 0.0f, 0.0f), INDEX_NONE);
+	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 10.0f, 0.0f, 0.0f), INDEX_NONE);
+
+	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* ZeroWind = GetTransientWind(Node, 0);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* NearZeroWind = GetTransientWind(Node, 1);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* ExplicitWind = GetTransientWind(Node, 2);
+	bOk &= TestTrue(TEXT("ZeroWind valid"), ZeroWind != nullptr);
+	bOk &= TestTrue(TEXT("NearZeroWind valid"), NearZeroWind != nullptr);
+	bOk &= TestTrue(TEXT("ExplicitWind valid"), ExplicitWind != nullptr);
+	if (!ZeroWind || !NearZeroWind || !ExplicitWind)
+	{
+		return false;
+	}
+
+	bOk &= TestTrue(TEXT("Zero direction default"), ZeroWind->WindDirection.Equals(FVector::ForwardVector));
+	bOk &= TestTrue(TEXT("Zero space default"), ZeroWind->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+	bOk &= TestTrue(TEXT("Near-zero direction default"), NearZeroWind->WindDirection.Equals(FVector::ForwardVector));
+	bOk &= TestTrue(TEXT("Near-zero space default"), NearZeroWind->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+	bOk &= TestTrue(TEXT("Explicit direction"), ExplicitWind->WindDirection.Equals(FVector(KINDA_SMALL_NUMBER * 10.0f, 0.0f, 0.0f)));
+	bOk &= TestTrue(TEXT("Explicit space"), ExplicitWind->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceInheritFromAuthoredTest,
+                                 "KawaiiPhysics.TransientForce.InheritFromAuthored",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString& Parameters)
+{
+	bool bOk = true;
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		AddStandardAuthoredWinds(Node);
+		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, 1);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+		bOk &= TestTrue(TEXT("Indexed inherited wind valid"), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestTrue(TEXT("Indexed WindDirection"), Wind->WindDirection.Equals(FVector(0.0f, 1.0f, 0.0f)));
+			bOk &= TestTrue(TEXT("Indexed ExternalForceSpace"), Wind->ExternalForceSpace == EExternalForceSpace::ComponentSpace);
+			bOk &= TestInheritedRuntimeFields(*this, *Wind);
+			bOk &= TestFloatNear(*this, TEXT("Indexed DirectionNoiseAngle"), Wind->DirectionNoiseAngle, 15.0f);
+			bOk &= TestFloatNear(*this, TEXT("Indexed DirectionNoisePeriod"), Wind->DirectionNoisePeriod, 0.5f);
+			bOk &= TestEqual(TEXT("Indexed RandomSeed"), Wind->RandomSeed, 42);
+			bOk &= TestFloatNear(*this, TEXT("Indexed lifetime"), Node.TransientForceStore.Items[0].RemainingLifetime, 0.6f);
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		AddStandardAuthoredWinds(Node);
+		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+		bOk &= TestTrue(TEXT("Fallback inherited wind valid"), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestTrue(TEXT("Fallback skips disabled"), Wind->WindDirection.Equals(FVector(0.0f, 1.0f, 0.0f)));
+			bOk &= TestTrue(TEXT("Fallback ExternalForceSpace"), Wind->ExternalForceSpace == EExternalForceSpace::ComponentSpace);
+			bOk &= TestInheritedRuntimeFields(*this, *Wind);
+			bOk &= TestFloatNear(*this, TEXT("Fallback DirectionNoiseAngle"), Wind->DirectionNoiseAngle, 15.0f);
+			bOk &= TestFloatNear(*this, TEXT("Fallback DirectionNoisePeriod"), Wind->DirectionNoisePeriod, 0.5f);
+			bOk &= TestEqual(TEXT("Fallback RandomSeed"), Wind->RandomSeed, 42);
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		AddStandardAuthoredWinds(Node);
+		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 3.0f), 1);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+		bOk &= TestTrue(TEXT("Explicit inherited wind valid"), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestTrue(TEXT("Explicit WindDirection"), Wind->WindDirection.Equals(FVector(0.0f, 0.0f, 3.0f)));
+			bOk &= TestTrue(TEXT("Explicit ExternalForceSpace"), Wind->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+			bOk &= TestInheritedRuntimeFields(*this, *Wind);
+			bOk &= TestFloatNear(*this, TEXT("Explicit DirectionNoiseAngle"), Wind->DirectionNoiseAngle, 0.0f);
+			bOk &= TestFloatNear(*this, TEXT("Explicit DirectionNoisePeriod"), Wind->DirectionNoisePeriod, 1.0f);
+			bOk &= TestEqual(TEXT("Explicit RandomSeed"), Wind->RandomSeed, 0);
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+		bOk &= TestTrue(TEXT("Default inherited wind valid"), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestFloatNear(*this, TEXT("Default RandomForceScaleRange.Min"),
+			                      Wind->RandomForceScaleRange.Min, 1.0f);
+			bOk &= TestFloatNear(*this, TEXT("Default RandomForceScaleRange.Max"),
+			                      Wind->RandomForceScaleRange.Max, 1.0f);
+		}
+	}
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest,
+                                 "KawaiiPhysics.TransientForce.SpreadAcrossAuthoredWinds",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FString& Parameters)
+{
+	bool bOk = true;
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		AddAuthoredProceduralWind(Node, true, FVector(0.0f, 1.0f, 0.0f),
+		                          EExternalForceSpace::ComponentSpace, 1.0f, true, 10.0f, 0.5f, 11);
+		AddAuthoredProceduralWind(Node, true, FVector(0.0f, 0.0f, 1.0f),
+		                          EExternalForceSpace::WorldSpace, 2.0f, false, 20.0f, 0.75f, 22);
+		AddAuthoredProceduralWind(Node, false, FVector(1.0f, 0.0f, 0.0f),
+		                          EExternalForceSpace::WorldSpace, 3.0f, false, 30.0f, 1.0f, 33);
+
+		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
+		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		bOk &= TestEqual(TEXT("Spread Items.Num"), Node.TransientForceStore.Items.Num(), 2);
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind1 = GetTransientWind(Node, 1);
+		bOk &= TestTrue(TEXT("Spread Wind0 valid"), Wind0 != nullptr);
+		bOk &= TestTrue(TEXT("Spread Wind1 valid"), Wind1 != nullptr);
+		if (Wind0)
+		{
+			bOk &= TestTrue(TEXT("Spread Wind0 direction"), Wind0->WindDirection.Equals(FVector(0.0f, 1.0f, 0.0f)));
+			bOk &= TestEqual(TEXT("Spread Wind0 ApplyBoneFilter.Num"), Wind0->ApplyBoneFilter.Num(), 1);
+		}
+		if (Wind1)
+		{
+			bOk &= TestTrue(TEXT("Spread Wind1 direction"), Wind1->WindDirection.Equals(FVector(0.0f, 0.0f, 1.0f)));
+			bOk &= TestFloatNear(*this, TEXT("Spread Wind1 TimeScale"), Wind1->TimeScale, 2.0f);
+			bOk &= TestFloatNear(*this, TEXT("Spread Wind1 lifetime"),
+			                      Node.TransientForceStore.Items[1].RemainingLifetime, 0.4f);
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		for (int32 Index = 1; Index <= 10; ++Index)
+		{
+			AddAuthoredProceduralWind(Node, true, FVector(static_cast<float>(Index), 0.0f, 0.0f),
+			                          EExternalForceSpace::WorldSpace, 1.0f, false);
+		}
+
+		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
+		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		// cap を超える authored wind では最古（先頭側）から切り捨てられる仕様を固定する。
+		bOk &= TestEqual(TEXT("Spread cap Items.Num"), Node.TransientForceStore.Items.Num(),
+		                 FAnimNode_KawaiiPhysics::MaxTransientExternalForces);
+		for (int32 ItemIndex = 0; ItemIndex < Node.TransientForceStore.Items.Num(); ++ItemIndex)
+		{
+			FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node, ItemIndex);
+			bOk &= TestTrue(FString::Printf(TEXT("Spread cap Wind %d valid"), ItemIndex), Wind != nullptr);
+			if (Wind)
+			{
+				const float ExpectedDirectionX = static_cast<float>(ItemIndex + 3);
+				bOk &= TestFloatNear(*this,
+				                      *FString::Printf(TEXT("Spread cap Wind %d direction X"), ItemIndex),
+				                      Wind->WindDirection.X,
+				                      ExpectedDirectionX);
+			}
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
+		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		bOk &= TestEqual(TEXT("Default Items.Num"), Node.TransientForceStore.Items.Num(), 1);
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
+		bOk &= TestTrue(TEXT("Default Wind valid"), Wind != nullptr);
+		if (Wind)
+		{
+			bOk &= TestTrue(TEXT("Default direction"), Wind->WindDirection.Equals(FVector::ForwardVector));
+		}
+	}
+
+	{
+		FAnimNode_KawaiiPhysics Node;
+		AddAuthoredProceduralWind(Node, true, FVector(0.0f, 1.0f, 0.0f),
+		                          EExternalForceSpace::ComponentSpace, 1.0f, true, 10.0f, 0.5f, 11);
+		AddAuthoredProceduralWind(Node, true, FVector(0.0f, 0.0f, 1.0f),
+		                          EExternalForceSpace::WorldSpace, 2.0f, false, 20.0f, 0.75f, 22);
+		AddAuthoredProceduralWind(Node, false, FVector(1.0f, 0.0f, 0.0f),
+		                          EExternalForceSpace::WorldSpace, 3.0f, false, 30.0f, 1.0f, 33);
+
+		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector(5.0f, 0.0f, 0.0f),
+		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
+		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+
+		bOk &= TestEqual(TEXT("Explicit Items.Num"), Node.TransientForceStore.Items.Num(), 2);
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
+		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind1 = GetTransientWind(Node, 1);
+		bOk &= TestTrue(TEXT("Explicit Wind0 valid"), Wind0 != nullptr);
+		bOk &= TestTrue(TEXT("Explicit Wind1 valid"), Wind1 != nullptr);
+		if (Wind0)
+		{
+			bOk &= TestTrue(TEXT("Explicit Wind0 direction"), Wind0->WindDirection.Equals(FVector(5.0f, 0.0f, 0.0f)));
+			bOk &= TestTrue(TEXT("Explicit Wind0 space"), Wind0->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+			bOk &= TestEqual(TEXT("Explicit Wind0 ApplyBoneFilter.Num"), Wind0->ApplyBoneFilter.Num(), 1);
+			bOk &= TestFloatNear(*this, TEXT("Explicit Wind0 DirectionNoiseAngle"), Wind0->DirectionNoiseAngle, 0.0f);
+		}
+		if (Wind1)
+		{
+			bOk &= TestTrue(TEXT("Explicit Wind1 direction"), Wind1->WindDirection.Equals(FVector(5.0f, 0.0f, 0.0f)));
+			bOk &= TestTrue(TEXT("Explicit Wind1 space"), Wind1->ExternalForceSpace == EExternalForceSpace::WorldSpace);
+			bOk &= TestFloatNear(*this, TEXT("Explicit Wind1 TimeScale"), Wind1->TimeScale, 2.0f);
+			bOk &= TestFloatNear(*this, TEXT("Explicit Wind1 DirectionNoiseAngle"), Wind1->DirectionNoiseAngle, 0.0f);
+		}
+	}
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest,
+                                 "KawaiiPhysics.TransientForce.StoreCopyIsIndependent",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest::RunTest(const FString& Parameters)
+{
+	bool bOk = true;
+
+	{
+		FAnimNode_KawaiiPhysics A;
+		A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
+		FAnimNode_KawaiiPhysics B = A;
+
+		bOk &= TestTrue(TEXT("Copied queue is distinct"),
+		                A.TransientForceStore.Queue.Get() != B.TransientForceStore.Queue.Get());
+		bOk &= TestEqual(TEXT("B pending is empty after copy"), GetPendingGustCount(B), 0);
+		B.ConsumeAndSweepTransientExternalForces(0.0f);
+		bOk &= TestEqual(TEXT("B consume yields no items"), B.TransientForceStore.Items.Num(), 0);
+
+		A.ConsumeAndSweepTransientExternalForces(0.0f);
+		bOk &= TestEqual(TEXT("A consume still yields one item"), A.TransientForceStore.Items.Num(), 1);
+
+		B.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
+		B.ConsumeAndSweepTransientExternalForces(0.0f);
+		bOk &= TestEqual(TEXT("B new consume yields one item"), B.TransientForceStore.Items.Num(), 1);
+		bOk &= TestEqual(TEXT("A items unaffected by B"), A.TransientForceStore.Items.Num(), 1);
+	}
+
+	{
+		FAnimNode_KawaiiPhysics A;
+		A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
+		A.ConsumeAndSweepTransientExternalForces(0.0f);
+		FAnimNode_KawaiiPhysics B = A;
+
+		bOk &= TestEqual(TEXT("B copied Items empty"), B.TransientForceStore.Items.Num(), 0);
+		bOk &= TestEqual(TEXT("A copied-from Items preserved"), A.TransientForceStore.Items.Num(), 1);
+	}
+
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsTransientForceSurviveReflectionCopyTest,
+                                 "KawaiiPhysics.TransientForce.SurviveReflectionCopy",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsTransientForceSurviveReflectionCopyTest::RunTest(const FString& Parameters)
+{
+	FAnimNode_KawaiiPhysics A;
+	A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
+	A.ConsumeAndSweepTransientExternalForces(0.0f);
+	A.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
+
+	bool bOk = true;
+	bOk &= TestEqual(TEXT("Initial Items"), A.TransientForceStore.Items.Num(), 1);
+	bOk &= TestEqual(TEXT("Initial pending"), GetPendingGustCount(A), 1);
+	bOk &= TestTrue(TEXT("TransientForceStore is not reflected"),
+	                FindFProperty<FProperty>(FAnimNode_KawaiiPhysics::StaticStruct(), TEXT("TransientForceStore")) == nullptr);
+
+	ApplyDefaultPresetStyleCopy(A);
+
+	bOk &= TestEqual(TEXT("Items survive preset-style copy"), A.TransientForceStore.Items.Num(), 1);
+	bOk &= TestEqual(TEXT("Pending survives preset-style copy"), GetPendingGustCount(A), 1);
+
+	return bOk;
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -9,6 +9,8 @@
 #include "BoneControllers/AnimNode_AnimDynamics.h"
 #include "BoneControllers/AnimNode_SkeletalControlBase.h"
 #include "Engine/HitResult.h"
+#include "HAL/CriticalSection.h"
+#include "Templates/SharedPointer.h"
 
 #if !UE_VERSION_OLDER_THAN(5, 5, 0)
 #include "StructUtils/InstancedStruct.h"
@@ -41,6 +43,44 @@ extern KAWAIIPHYSICS_API TAutoConsoleVariable<float> CVarAnimNodeKawaiiPhysicsDe
 #endif
 
 extern KAWAIIPHYSICS_API TAutoConsoleVariable<bool> CVarAnimNodeKawaiiPhysicsUseBoneContainerRefSkeletonWhenInit;
+
+// 一時外力の実体と寿命
+struct FKawaiiPhysicsTransientExternalForce
+{
+	FInstancedStruct Force;
+	float RemainingLifetime = 0.0f;
+};
+
+// 一時突風の構築リクエスト
+struct FKawaiiPhysicsTransientGustRequest
+{
+	float Strength = 0.0f;
+	float RiseTime = 0.0f;
+	float DecayTime = 0.0f;
+	FVector Direction = FVector::ZeroVector;
+	int32 InheritForceIndex = INDEX_NONE;
+};
+
+// 任意スレッドからの一時外力キュー
+struct FKawaiiPhysicsTransientForceQueue
+{
+	FCriticalSection Mutex;
+	TArray<FKawaiiPhysicsTransientExternalForce> PendingForces;
+	TArray<FKawaiiPhysicsTransientGustRequest> PendingGusts;
+};
+
+// worker専用ストアと共有キュー
+struct FKawaiiPhysicsTransientForceStore
+{
+	TArray<FKawaiiPhysicsTransientExternalForce> Items;
+	TSharedPtr<FKawaiiPhysicsTransientForceQueue, ESPMode::ThreadSafe> Queue =
+		MakeShared<FKawaiiPhysicsTransientForceQueue, ESPMode::ThreadSafe>();
+
+	FKawaiiPhysicsTransientForceStore() = default;
+	// コピー先は独立した空ストアにして二重消費を避ける
+	FKawaiiPhysicsTransientForceStore(const FKawaiiPhysicsTransientForceStore&) : FKawaiiPhysicsTransientForceStore() {}
+	FKawaiiPhysicsTransientForceStore& operator=(const FKawaiiPhysicsTransientForceStore&) { return *this; }
+};
 
 USTRUCT(BlueprintType)
 struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalControlBase
@@ -548,6 +588,43 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Force|External Force",
 		meta = (BaseStruct = "/Script/KawaiiPhysics.KawaiiPhysics_ExternalForce", ExcludeBaseStruct))
 	TArray<FInstancedStruct> ExternalForces;
+
+	FKawaiiPhysicsTransientForceStore TransientForceStore;
+	static constexpr int32 MaxTransientExternalForces = 8;
+	// InheritForceIndex 用センチネル: 有効な authored ProceduralWind すべてに 1 つずつ transient 突風を展開する（展開はノードの一時外力上限 MaxTransientExternalForces の範囲内）
+	// Sentinel for InheritForceIndex: spawn one transient gust per enabled authored ProceduralWind (expansion is bounded by MaxTransientExternalForces).
+	static constexpr int32 TransientGustInheritAllWinds = -2;
+
+	/**
+	 * 実行時専用の一時外力をリクエストする。任意スレッド可で、Mutex 保護されたキューへ積む。
+	 * BP再コンパイルやノード再初期化で失われる。Initialize(Context) は呼ばれないため汎用外力では制限あり
+	 * （ProceduralWind は PreApply で RuntimeState を遅延生成するため安全）。
+	 * Request a runtime-only transient external force. Callable from any thread; it is queued under a mutex.
+	 * Lost on BP recompile or node re-init. Initialize(Context) is not called, which limits generic use
+	 * (ProceduralWind is safe because it lazily creates RuntimeState in PreApply).
+	 */
+	void RequestTransientExternalForce(FInstancedStruct&& InForce, float InLifetimeSeconds);
+
+	/**
+	 * 実行時専用の一時突風をリクエストする。任意スレッド可で、Mutex 保護されたキューへパラメータだけを積む。
+	 * BP再コンパイルやノード再初期化で失われる。Initialize(Context) は呼ばれないため汎用外力では制限あり
+	 * （ProceduralWind は PreApply で RuntimeState を遅延生成するため安全）。
+	 * Request a runtime-only transient gust. Callable from any thread; only parameters are queued under a mutex.
+	 * Lost on BP recompile or node re-init. Initialize(Context) is not called, which limits generic use
+	 * (ProceduralWind is safe because it lazily creates RuntimeState in PreApply).
+	 */
+	void RequestTransientGust(float Strength, float RiseTime, float DecayTime,
+	                          const FVector& GustDirection, int32 InheritForceIndex = INDEX_NONE);
+
+	/**
+	 * キュー済み一時外力を worker で取り込み、寿命切れを掃除する。worker 専用で 1 evaluate 1 回だけ呼ぶ。
+	 * BP再コンパイルやノード再初期化で失われる。Initialize(Context) は呼ばれないため汎用外力では制限あり
+	 * （ProceduralWind は PreApply で RuntimeState を遅延生成するため安全）。
+	 * Consume queued transient forces on the worker and sweep expired entries. Worker-only; call once per evaluate.
+	 * Lost on BP recompile or node re-init. Initialize(Context) is not called, which limits generic use
+	 * (ProceduralWind is safe because it lazily creates RuntimeState in PreApply).
+	 */
+	void ConsumeAndSweepTransientExternalForces(float InFrameDeltaTime);
 
 	/**
 	* EXPERIMENTAL: 外力のプリセット。BP・C++で独自のプリセットを追加可能(Instanced Property)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
 #include "GameplayTagContainer.h"
 #include "Animation/AnimNotifies/AnimNotify.h"
 
@@ -37,6 +38,10 @@ public:
 	/** 減衰時間（秒） / Decay time, in seconds. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ProceduralWind", meta=(ClampMin="0.0", UIMin="0.0"))
 	float DecayTime = 0.0f;
+
+	/** 突風の方向（ワールド空間・非正規化可）。ゼロなら既存 ProceduralWind の風向き等を継承 / Gust direction (world space; may be non-normalized). Zero inherits from an authored ProceduralWind. */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ProceduralWind")
+	FVector GustDirection = FVector::ZeroVector;
 
 	/** 適用するノードを Tag でフィルタ（空なら全ノード対象） / Tags used to filter target nodes; empty targets all nodes. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Filter")

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
@@ -466,8 +466,17 @@ public:
 	                                              bool bFilterExactMatch = false);
 
 	/**
-	 * ProceduralWind の突風をリクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
-	 * Request a ProceduralWind gust. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * ランタイム専用の一時 ProceduralWind として突風をスポーンする。ノードに作成済み ProceduralWind がなくても動作し、複数の同時突風は加算される。
+	 * 突風はノード再初期化時に失われる。キュー経由でスレッドセーフに適用され、次回 Evaluate から反映される。
+	 * Spawn a gust as a runtime-only transient ProceduralWind. Works even without an authored ProceduralWind on the node, and multiple simultaneous gusts stack.
+	 * Gusts are lost on node re-initialization. Applied thread-safely through a queue and takes effect from the next Evaluate.
+	 * @param ExecResult ノード参照の解決結果 / Result of resolving the node reference.
+	 * @param KawaiiPhysics 対象の KawaiiPhysics ノード参照 / Target KawaiiPhysics node reference.
+	 * @param ExternalForceIndex 方向継承元の ExternalForces インデックス（無効なら最初の有効な ProceduralWind から継承） / ExternalForces index used as the inheritance source; falls back to the first enabled ProceduralWind when invalid.
+	 * @param Strength 突風のピーク強度 / Peak gust strength.
+	 * @param RiseTime 0->ピークまでの立ち上がり時間（秒） / Time in seconds to rise from zero to peak.
+	 * @param DecayTime ピーク->0 までの減衰時間（秒） / Time in seconds to decay from peak to zero.
+	 * @param GustDirection 突風の方向（ワールド空間・非正規化可）。ゼロベクトルなら既存 ProceduralWind の風向き・空間・ボーンフィルタ等を継承 / Gust direction (world space; may be non-normalized). Zero vector inherits direction, space, and bone filters from an authored ProceduralWind if present.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
@@ -477,11 +486,16 @@ public:
 		int32 ExternalForceIndex,
 		float Strength,
 		float RiseTime,
-		float DecayTime);
+		float DecayTime,
+		FVector GustDirection = FVector(0, 0, 0));
 
 	/**
 	 * ProceduralWind の動的パラメータ更新をリクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
 	 * Request a ProceduralWind dynamic parameter update. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * @param ExecResult 対象 ProceduralWind へのアクセス結果 / Result of accessing the target ProceduralWind.
+	 * @param KawaiiPhysics 対象の KawaiiPhysics ノード参照 / Target KawaiiPhysics node reference.
+	 * @param ExternalForceIndex 対象の ExternalForces インデックス / Target ExternalForces index.
+	 * @param Params ProceduralWind に適用する動的パラメータ / Dynamic parameters to apply to ProceduralWind.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
@@ -492,8 +506,22 @@ public:
 		const FKawaiiProceduralWindDynamicParams& Params);
 
 	/**
-	 * Component 内の ProceduralWind へ突風を一括リクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
-	 * Request a gust for ProceduralWind entries in a component. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * Component 内の対象 KawaiiPhysics ノードへ、enabled な authored ProceduralWind ごとにランタイム専用の一時 ProceduralWind 突風をスポーンする。有効な authored ProceduralWind がないノードではデフォルト突風を 1 つスポーンし、複数の同時突風は加算される。
+	 * 突風は明示的な gameplay イベントとして扱われ、authored ProceduralWind の有無・有効無効に関わらず対象ノードで発火する（対象を絞るには FilterTags を使用）。
+	 * 突風はノード再初期化時に失われる。キュー経由でスレッドセーフに適用され、次回 Evaluate から反映される。
+	 * 同時に保持できる一時外力はノードあたり MaxTransientExternalForces（8）件までで、超過分は最古から破棄される。
+	 * Spawn gusts on target KawaiiPhysics nodes in a component as runtime-only transient ProceduralWind entries, one per enabled authored ProceduralWind. Nodes without enabled authored ProceduralWind entries spawn one default gust, and multiple simultaneous gusts stack.
+	 * Gusts are explicit gameplay events: they fire on matched nodes regardless of whether authored ProceduralWind entries exist or are enabled (use FilterTags to narrow targets).
+	 * Gusts are lost on node re-initialization. Applied thread-safely through a queue and takes effect from the next Evaluate.
+	 * Transient forces are capped at MaxTransientExternalForces (8) per node; the oldest entries are dropped beyond that.
+	 * @param MeshComp 対象の SkeletalMeshComponent / Target SkeletalMeshComponent.
+	 * @param Strength 突風のピーク強度 / Peak gust strength.
+	 * @param RiseTime 0->ピークまでの立ち上がり時間（秒） / Time in seconds to rise from zero to peak.
+	 * @param DecayTime ピーク->0 までの減衰時間（秒） / Time in seconds to decay from peak to zero.
+	 * @param FilterTags ノードの KawaiiPhysicsTag に対するフィルタ（空なら全ノード対象） / Filter against each node KawaiiPhysicsTag; empty matches all nodes.
+	 * @param bFilterExactMatch タグを完全一致で比較するか / Whether tags must match exactly.
+	 * @param GustDirection 突風の方向（ワールド空間・非正規化可）。ゼロベクトルなら既存 ProceduralWind の風向き・空間・ボーンフィルタ等を継承 / Gust direction (world space; may be non-normalized). Zero vector inherits direction, space, and bone filters from an authored ProceduralWind if present.
+	 * @return 突風リクエストをキューしたノード数 / Number of nodes where gust requests were queued.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))
@@ -503,11 +531,16 @@ public:
 		float RiseTime,
 		float DecayTime,
 		const FGameplayTagContainer& FilterTags,
-		bool bFilterExactMatch = false);
+		bool bFilterExactMatch = false,
+		FVector GustDirection = FVector(0, 0, 0));
 
 	/**
 	 * Component 内の ProceduralWind へ動的パラメータ更新を一括リクエストする。PendingRequest 経由でスレッドセーフ。次フレームの PreApply で反映。
 	 * Request dynamic parameter updates for ProceduralWind entries in a component. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
+	 * @param MeshComp 対象の SkeletalMeshComponent / Target SkeletalMeshComponent.
+	 * @param Params ProceduralWind に適用する動的パラメータ / Dynamic parameters to apply to ProceduralWind.
+	 * @param FilterTags ノードの KawaiiPhysicsTag に対するフィルタ（空なら全ノード対象） / Filter against each node KawaiiPhysicsTag; empty matches all nodes.
+	 * @param bFilterExactMatch タグを完全一致で比較するか / Whether tags must match exactly.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))
@@ -526,6 +559,11 @@ public:
 	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, and DirectionNoisePeriod are left untouched. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
 	 * When PresetDataAsset is null or its Presets array is empty, the tag is matched against the 3 built-in default presets (KawaiiPhysics.WindPreset.Breeze / Strong / Storm).
 	 * The DataAsset must be pre-loaded by the caller and must not be edited or reloaded while simulation is running.
+	 * @param ExecResult 対象 ProceduralWind へのアクセス結果 / Result of accessing the target ProceduralWind.
+	 * @param KawaiiPhysics 対象の KawaiiPhysics ノード参照 / Target KawaiiPhysics node reference.
+	 * @param ExternalForceIndex 対象の ExternalForces インデックス / Target ExternalForces index.
+	 * @param PresetDataAsset 参照する風プリセット DataAsset（null なら組み込みプリセット） / Wind preset DataAsset to resolve; null uses built-in presets.
+	 * @param PresetTag 適用するプリセットタグ / Preset tag to apply.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, ExpandEnumAsExecs = "ExecResult"))
@@ -545,6 +583,11 @@ public:
 	 * TimeScale, WindDirection, WavePhase, EnvelopePhase, and DirectionNoisePeriod are left untouched. Thread-safe via PendingRequest. Applied in the next frame's PreApply.
 	 * When PresetDataAsset is null or its Presets array is empty, the tag is matched against the 3 built-in default presets (KawaiiPhysics.WindPreset.Breeze / Strong / Storm).
 	 * The DataAsset must be pre-loaded by the caller and must not be edited or reloaded while simulation is running.
+	 * @param MeshComp 対象の SkeletalMeshComponent / Target SkeletalMeshComponent.
+	 * @param PresetDataAsset 参照する風プリセット DataAsset（null なら組み込みプリセット） / Wind preset DataAsset to resolve; null uses built-in presets.
+	 * @param PresetTag 適用するプリセットタグ / Preset tag to apply.
+	 * @param FilterTags ノードの KawaiiPhysicsTag に対するフィルタ（空なら全ノード対象） / Filter against each node KawaiiPhysicsTag; empty matches all nodes.
+	 * @param bFilterExactMatch タグを完全一致で比較するか / Whether tags must match exactly.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics",
 		meta=(BlueprintThreadSafe, AutoCreateRefTerm = "FilterTags"))


### PR DESCRIPTION
## 概要

`TriggerProceduralWindGust` / `TriggerProceduralWindGustOnComponent` で撃つ突風に **風向きを指定できるように** しました。あわせて、突風の仕組みを「作成済み ProceduralWind への相乗り」から **ランタイム専用の一時外力（transient external force）** へ移行し、BP ノード上で引数の意味が分かるよう **日英併記の @param ツールチップ** を整備しています。

### これまでの課題

1. 突風は方向を指定できず、ノードに設定済みの ProceduralWind の風向きに完全に相乗りしていた（爆発の向きなど gameplay 由来の方向で撃てない）
2. ノードの ExternalForces に ProceduralWind が無いと突風を撃てなかった
3. 突風スロットが 1 つしかなく、減衰中に再トリガーすると前の突風が破棄されていた（重ね掛け不可）
4. BP ノード上で各引数（Strength / RiseTime / DecayTime 等）の意味が分からなかった

## 変更内容

### 1. 一時外力（transient external force）の仕組みを新設

`FAnimNode_KawaiiPhysics` に **非 UPROPERTY** の `FKawaiiPhysicsTransientForceStore` を追加しました。

- **worker 専有の `Items`** ＋ **`TSharedPtr` のスレッドセーフキュー**（Mutex 保護）の 2 層構成
- `RequestTransientGust()` は任意スレッドから **パラメータのみ** をキューへ積む（呼び出しスレッドでは `ExternalForces` を読まない）
- 消費・寿命減算・掃引は `EvaluateSkeletalControl_AnyThread` で **1 evaluate につき 1 回**（warm-up ループ・teleport スキップの影響を受けない位置）
- 一時外力は authored 配列と同型のループで `PreApply` / `ApplyToVelocity` / `Apply` / `PostApply` を通る
- **非リフレクションのため**、エディタ同期（`CopyNodeDataToPreviewNode`）・プリセット適用（`TFieldIterator` 反映）・シリアライズのいずれからも不可視。既存の index ベース API・UI を一切壊しません
- 上限 8 件（キュー投入時・消費後の二段で最古から破棄）。ABP 再コンパイル／ノード再初期化で破棄されます（一時外力として意図的な仕様）

内部構造は「任意の外力 FInstancedStruct ＋ 寿命」を持てる汎用設計で、公開 API は今回突風専用に絞っています。

### 2. 突風の方向指定

`TriggerProceduralWindGust` / `TriggerProceduralWindGustOnComponent` / `AnimNotify_KawaiiPhysicsTriggerGust` に `GustDirection`（`FVector`・ワールド空間・非正規化可）を追加しました。

- **ゼロベクトル（既定）** → 従来どおり、設定済み ProceduralWind から風向き・空間・DirectionNoise・ボーンフィルタ・ForceRate カーブ・TimeScale・RandomForceScaleRange を継承
- **方向を指定** → その方向へ決定論的に発火（DirectionNoise は乗せない）。フィルタや TimeScale 等は継承したまま

突風は default 構築の ProceduralWind（環境成分がすべて 0 ＝突風成分のみ）として生成されるため、設定済み ProceduralWind が無いノードでも撃てます。また 1 トリガー＝1 インスタンスなので、**多重突風が自然に重なります**。

Component 版は、有効な ProceduralWind ごとに 1 つずつ突風を展開します（旧実装の「各 wind へ突風をキュー」と等価な挙動。ProceduralWind が無ければ既定の突風を 1 つ）。

### 3. ツールチップ（@param）整備

ProceduralWind 系 6 関数（Trigger ×2 / SetParameters ×2 / ApplyPreset ×2）の全引数に日英併記の `@param` を追加し、BP ノードのピンにホバーすると説明が出るようにしました。

## 挙動の変更点（意図的・要注意）

| 項目 | 旧 | 新 |
|---|---|---|
| `TriggerProceduralWindGust` の ExecResult | index が ProceduralWind を指すときのみ Valid | ノード参照が解決できれば常に Valid（`ExternalForceIndex` は方向継承のヒントに転用） |
| `TriggerProceduralWindGustOnComponent` の戻り値 | 突風をキューした force 数 | 突風をスポーンしたノード数 |
| ProceduralWind 未設置・全無効のノード | 何も起きない | 突風は発火する（突風＝明示的な gameplay イベントという設計。対象を絞るには `FilterTags`） |
| 突風の重ね掛け | 不可（再トリガーで仕切り直し） | 可（同時 8 件まで） |

既存 BP は既定値付きの末尾引数追加のため互換ですが、新ピンの表示にはノードの Refresh が必要です。
