### PR TITLE
Wind Scope parameter edit panel (docked on the right)

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -277,117 +277,117 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	* Corrects the Force Rate applied to each bone.
 	* Multiplies the ForceRate by the curve value for "Length from RootBone to specific bone / Length from RootBone to end bone" (0.0~1.0)
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=2),
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=21),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	FRuntimeFloatCurve ForceRateByBoneLengthRate;
 
 	/**
-	* 常に一定で掛かる風の強さ。上げるとボーンが風下へ流されたままになる
-	* Constant wind strength. Higher values keep bones pushed downwind.
+	* 常に一定で掛かる風の強さ。上げるとボーンが風下へ流されたままになる。Wind Scope の Steady 系列に対応
+	* Constant wind strength. Higher values keep bones pushed downwind. Corresponds to the Steady series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float SteadyForce = 0.0f;
 
 	/**
-	* サイン波で周期的に強弱する成分の振幅。上げると規則的な揺れが強くなる
-	* Amplitude of the sine-based oscillation. Higher values strengthen the rhythmic sway.
+	* サイン波で周期的に強弱する成分の振幅。上げると規則的な揺れが強くなる。Wind Scope の Oscillation 系列に対応
+	* Amplitude of the sine-based oscillation. Higher values strengthen the rhythmic sway. Corresponds to the Oscillation series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=7, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float OscillationForce = 0.0f;
 
 	/**
-	* 振動の周期（秒）。短いほど速く揺れる
-	* Oscillation period in seconds. Shorter values sway faster.
+	* 振動の周期（秒）。短いほど速く揺れる。Wind Scope の Oscillation 系列に対応
+	* Oscillation period in seconds. Shorter values sway faster. Corresponds to the Oscillation series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=8, ClampMin=0.01, UIMin=0.01,
 		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float OscillationPeriod = 1.0f;
 
 	/**
-	* ボーン列に沿って伝わる波成分の振幅。WaveSpatialOffset と組で使う
-	* Amplitude of the traveling wave along the bone chain. Use together with WaveSpatialOffset.
+	* ボーン列に沿って伝わる波成分の振幅。WaveSpatialOffset と組で使う。Wind Scope の Wave 系列に対応
+	* Amplitude of the traveling wave along the bone chain. Use together with WaveSpatialOffset. Corresponds to the Wave series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=9, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WaveAmplitude = 0.0f;
 
 	/**
-	* 波の周期（秒）
-	* Wave period in seconds.
+	* 波の周期（秒）。Wind Scope の Wave 系列に対応
+	* Wave period in seconds. Corresponds to the Wave series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=10, ClampMin=0.01, UIMin=0.01,
 		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WavePeriod = 1.0f;
 
 	/**
-	* 開始位相のオフセット。複数キャラや複数外力の揺れタイミングをずらす用途
-	* Initial phase offset. Use to desynchronize multiple characters or forces.
+	* 波成分の開始位相オフセット。複数キャラや複数外力の波のタイミングをずらす用途。Wind Scope の Wave 系列に対応
+	* Start phase offset of the wave component. Use to stagger wave timing across multiple characters or external forces. Corresponds to the Wave series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=11, Units="Degrees", PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WavePhase = 0.0f;
 
 	/**
-	* 毛先（LengthRate=1）での位相遅れ量。正の値で根元から毛先へ波が走って見える。0なら全ボーン同時に揺れる
-	* Phase delay at the tip. Positive values make the wave travel from root to tip; 0 sways all bones together.
+	* 毛先（LengthRate=1）での位相遅れ量。正の値で根元から毛先へ波が走って見える。0なら全ボーン同時に揺れる。Wind Scope の Wave 系列に対応
+	* Phase delay at the tip. Positive values make the wave travel from root to tip; 0 sways all bones together. Corresponds to the Wave series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=12, Units="Degrees", PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float WaveSpatialOffset = 0.0f;
 
 	/**
-	* 風全体の強弱のうねり（低周波変調）の上限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効
-	* Upper multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1.
+	* 風全体の強弱のうねり（低周波変調）の上限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効。Wind Scope の Envelope 系列に対応
+	* Upper multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1. Corresponds to the Envelope series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=13, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeMax = 1.0f;
 
 	/**
-	* 風全体の強弱のうねり（低周波変調）の下限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効
-	* Lower multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1.
+	* 風全体の強弱のうねり（低周波変調）の下限倍率。Min を下げると凪↔強風の緩急が生まれる。Min=Max=1 で無効。Wind Scope の Envelope 系列に対応
+	* Lower multiplier of the slow global intensity swell. Lower Min creates calm-to-gust dynamics. Disabled when Min=Max=1. Corresponds to the Envelope series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=14, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeMin = 1.0f;
 
 	/**
-	* うねりの速さ（Hz）。低いほどゆったり
-	* Swell speed in Hz. Lower is slower.
+	* うねりの速さ（Hz）。低いほどゆったり。Wind Scope の Envelope 系列に対応
+	* Swell speed in Hz. Lower is slower. Corresponds to the Envelope series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=15, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopeFrequency = 0.1f;
 
 	/**
-	* 開始位相のオフセット。複数キャラや複数外力の揺れタイミングをずらす用途
-	* Initial phase offset. Use to desynchronize multiple characters or forces.
+	* エンベロープ（強弱のうねり）の開始位相オフセット。複数キャラや複数外力のうねりタイミングをずらす用途。Wind Scope の Envelope 系列に対応
+	* Start phase offset of the envelope (strength undulation). Use to stagger envelope timing across multiple characters or external forces. Corresponds to the Envelope series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=16, Units="Degrees", PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float EnvelopePhase = 0.0f;
 
 	/**
-	* 不規則な揺らぎ成分の強さ。自然なランダム感を足す
-	* Strength of the irregular fluctuation. Adds natural randomness.
+	* 不規則な揺らぎ成分の強さ。自然なランダム感を足す。Wind Scope の Random 系列に対応
+	* Strength of the irregular fluctuation. Adds natural randomness. Corresponds to the Random series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=17, ClampMin=0, UIMin=0, PinHiddenByDefault),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float RandomForce = 0.0f;
 
 	/**
-	* 揺らぎが変化する速さ（秒）。短いほど細かく震える
-	* How fast the fluctuation changes, in seconds. Shorter values jitter faster.
+	* 揺らぎが変化する速さ（秒）。短いほど細かく震える。Wind Scope の Random 系列に対応
+	* How fast the fluctuation changes, in seconds. Shorter values jitter faster. Corresponds to the Random series in Wind Scope.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=18, ClampMin=0.01, UIMin=0.01,
 		PinHiddenByDefault), Category="KawaiiPhysics|ExternalForce|Procedural Wind")
 	float RandomPeriod = 0.5f;
 
 	/**
-	* ランダム系列のシード。同じ値なら同じ揺らぎを再現できる。基底の RandomForceScaleRange が (1,1) 以外の場合は再現性が失われる
-	* Seed of the random sequence. Same seed reproduces the same fluctuation. Reproducibility is lost if the base RandomForceScaleRange is not (1,1).
+	* ランダム系列のシード。同じ値なら同じ揺らぎを再現できる。基底の RandomForceScaleRange が (1,1) 以外の場合は再現性が失われる。PIE中のライブ反映対象外（ノード値のみ・次回再生から反映）
+	* Seed of the random sequence. Same seed reproduces the same fluctuation. Reproducibility is lost if the base RandomForceScaleRange is not (1,1). Not live-updated during PIE; the node value takes effect from the next play session.
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=19),
 		Category="KawaiiPhysics|ExternalForce|Procedural Wind")

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/KawaiiPhysicsEd.Build.cs
@@ -28,6 +28,7 @@ public class KawaiiPhysicsEd : ModuleRules
 			"Slate",
 			"SlateCore",
 			"DeveloperSettings",
+			"Settings",
 			"PropertyEditor",
 			"ContentBrowser",
 			"SourceControl",

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -126,6 +126,12 @@ namespace
 			FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct()->FindPropertyByName(PropertyName) != nullptr;
 	}
 
+	bool IsProceduralWindExternalForce(const FInstancedStruct& ExternalForce)
+	{
+		return ExternalForce.IsValid() &&
+			ExternalForce.GetScriptStruct() == FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
+	}
+
 	bool IsOtherExternalForceStructProperty(const FProperty* Property)
 	{
 		const UStruct* OwnerStruct = Property ? Property->GetOwnerStruct() : nullptr;
@@ -1148,18 +1154,18 @@ void UAnimGraphNode_KawaiiPhysics::CheckPresetDiff()
 	SKawaiiPhysicsPresetDiffWindow::OpenWindow(MoveTemp(Args));
 }
 
-void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow()
+void UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow(int32 ExternalForceIndex)
 {
-	// ExternalForcesから最初のProceduralWindを探す
-	int32 ExternalForceIndex = INDEX_NONE;
-	for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+	if (ExternalForceIndex == INDEX_NONE)
 	{
-		if (Node.ExternalForces[Index].IsValid() &&
-			Node.ExternalForces[Index].GetScriptStruct() ==
-			FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct())
+		// ExternalForcesから最初のProceduralWindを探す
+		for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
 		{
-			ExternalForceIndex = Index;
-			break;
+			if (IsProceduralWindExternalForce(Node.ExternalForces[Index]))
+			{
+				ExternalForceIndex = Index;
+				break;
+			}
 		}
 	}
 
@@ -1211,14 +1217,48 @@ void UAnimGraphNode_KawaiiPhysics::GetNodeContextMenuActions(UToolMenu* Menu, UG
 		FSlateIcon(),
 		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::ApplyPresetDataAsset)));
 
-	// コンテキストメニューにも Wind Scope を追加
-	Section.AddMenuEntry(
-		"KawaiiPhysicsWindScope",
-		LOCTEXT("WindScopeContextMenu", "Wind Scope"),
-		LOCTEXT("WindScopeMenuToolTip",
-		        "Procedural Wind の波形プレビュータブを開きます / Opens the waveform preview tab for Procedural Wind."),
-		FSlateIcon(),
-		FUIAction(FExecuteAction::CreateUObject(MutableThis, &UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow)));
+	TArray<int32> ProceduralWindExternalForceIndices;
+	for (int32 Index = 0; Index < Node.ExternalForces.Num(); ++Index)
+	{
+		if (IsProceduralWindExternalForce(Node.ExternalForces[Index]))
+		{
+			ProceduralWindExternalForceIndices.Add(Index);
+		}
+	}
+
+	if (ProceduralWindExternalForceIndices.Num() >= 2)
+	{
+		for (const int32 ExternalForceIndex : ProceduralWindExternalForceIndices)
+		{
+			const int32 MenuExternalForceIndex = ExternalForceIndex;
+			Section.AddMenuEntry(
+				FName(*FString::Printf(TEXT("KawaiiPhysicsWindScope_%d"), MenuExternalForceIndex)),
+				FText::Format(
+					LOCTEXT("WindScopeContextMenuWithForceIndex", "Wind Scope (Force [{0}])"),
+					FText::AsNumber(MenuExternalForceIndex)),
+				LOCTEXT("WindScopeMenuToolTip",
+				        "Procedural Wind の波形プレビュータブを開きます / Opens the waveform preview tab for Procedural Wind."),
+				FSlateIcon(),
+				FUIAction(FExecuteAction::CreateUObject(
+					MutableThis,
+					&UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow,
+					MenuExternalForceIndex)));
+		}
+	}
+	else
+	{
+		// コンテキストメニューにも Wind Scope を追加
+		Section.AddMenuEntry(
+			"KawaiiPhysicsWindScope",
+			LOCTEXT("WindScopeContextMenu", "Wind Scope"),
+			LOCTEXT("WindScopeMenuToolTip",
+			        "Procedural Wind の波形プレビュータブを開きます / Opens the waveform preview tab for Procedural Wind."),
+			FSlateIcon(),
+			FUIAction(FExecuteAction::CreateUObject(
+				MutableThis,
+				&UAnimGraphNode_KawaiiPhysics::OpenWindScopeWindow,
+				static_cast<int32>(INDEX_NONE))));
+	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsWindScopeStyle.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsWindScopeStyle.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+// Wind Scope の系列表示スタイルを共有する private ヘッダ。
+
+#include "SKawaiiPhysicsWindScopeWindow.h"
+
+struct FKawaiiWindScopeComponentStyle
+{
+	EKawaiiPhysicsWindScopeComponent Component;
+	FText Label;
+	FLinearColor Color;
+	float Thickness = 1.0f;
+	bool bDashed = false;
+};
+
+// 各波形成分の表示スタイル（色・凡例ラベル・線種）を定義する
+inline const TArray<FKawaiiWindScopeComponentStyle>& GetWindScopeComponentStyles()
+{
+	static const TArray<FKawaiiWindScopeComponentStyle> Styles =
+	{
+		{EKawaiiPhysicsWindScopeComponent::Total, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "TotalLabel", "Total"), FLinearColor::White, 2.0f, false},
+		{EKawaiiPhysicsWindScopeComponent::Steady, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "SteadyLabel", "Steady"), FLinearColor(1.0f, 0.48f, 0.08f), 1.0f, false},
+		{EKawaiiPhysicsWindScopeComponent::Oscillation, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "OscillationLabel", "Oscillation"), FLinearColor(1.0f, 0.86f, 0.05f), 1.0f, false},
+		{EKawaiiPhysicsWindScopeComponent::Wave, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "WaveLabel", "Wave"), FLinearColor(0.0f, 0.85f, 1.0f), 1.0f, false},
+		{EKawaiiPhysicsWindScopeComponent::Envelope, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "EnvelopeLabel", "Envelope"), FLinearColor(0.2f, 0.42f, 1.0f), 1.0f, true},
+		{EKawaiiPhysicsWindScopeComponent::Random, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "RandomLabel", "Random"), FLinearColor(1.0f, 0.25f, 0.78f), 1.0f, false},
+		{EKawaiiPhysicsWindScopeComponent::Gust, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "GustLabel", "Gust"), FLinearColor(1.0f, 0.12f, 0.08f), 1.0f, false},
+	};
+	return Styles;
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -1,0 +1,579 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "SKawaiiPhysicsWindScopeEditPanel.h"
+
+#include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "KawaiiPhysicsWindScopeStyle.h"
+#include "Styling/AppStyle.h"
+#include "Styling/CoreStyle.h"
+#include "UObject/UnrealType.h"
+#include "Widgets/Colors/SColorBlock.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SVectorInputBox.h"
+#include "Widgets/Input/SSpinBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "KawaiiPhysicsWindScopeEditPanel"
+
+namespace
+{
+	constexpr float LabelColumnWidth = 150.0f;
+
+	FProperty* FindWindScopeProperty(const FName PropertyName)
+	{
+		for (UStruct* Struct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct(); Struct; Struct = Struct->GetSuperStruct())
+		{
+			if (FProperty* Property = Struct->FindPropertyByName(PropertyName))
+			{
+				return Property;
+			}
+		}
+		return nullptr;
+	}
+
+	TOptional<float> GetClampMinValue(const FProperty* Property)
+	{
+		if (!Property || !Property->HasMetaData(TEXT("ClampMin")))
+		{
+			return TOptional<float>();
+		}
+
+		float ClampMin = 0.0f;
+		if (LexTryParseString(ClampMin, *Property->GetMetaData(TEXT("ClampMin"))))
+		{
+			return ClampMin;
+		}
+		return TOptional<float>();
+	}
+
+	FLinearColor ResolveGroupColor(const TOptional<EKawaiiPhysicsWindScopeComponent>& LinkedSeries)
+	{
+		if (!LinkedSeries.IsSet())
+		{
+			return FLinearColor(0.28f, 0.3f, 0.34f, 1.0f);
+		}
+
+		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		{
+			if (Style.Component == LinkedSeries.GetValue())
+			{
+				return Style.Color;
+			}
+		}
+		return FLinearColor(0.28f, 0.3f, 0.34f, 1.0f);
+	}
+
+	class SKawaiiWindScopeGroupHoverBorder : public SBorder
+	{
+	public:
+		SLATE_BEGIN_ARGS(SKawaiiWindScopeGroupHoverBorder)
+			{
+			}
+			SLATE_DEFAULT_SLOT(FArguments, Content)
+			SLATE_EVENT(FSimpleDelegate, OnHovered)
+			SLATE_EVENT(FSimpleDelegate, OnUnhovered)
+			SLATE_ARGUMENT(const FSlateBrush*, BorderImage)
+			SLATE_ATTRIBUTE(FSlateColor, BorderBackgroundColor)
+			SLATE_ATTRIBUTE(FMargin, Padding)
+		SLATE_END_ARGS()
+
+		void Construct(const FArguments& InArgs)
+		{
+			OnHovered = InArgs._OnHovered;
+			OnUnhovered = InArgs._OnUnhovered;
+			SBorder::Construct(SBorder::FArguments()
+				.BorderImage(InArgs._BorderImage)
+				.BorderBackgroundColor(InArgs._BorderBackgroundColor)
+				.Padding(InArgs._Padding)
+				[
+					InArgs._Content.Widget
+				]);
+		}
+
+		virtual void OnMouseEnter(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override
+		{
+			SBorder::OnMouseEnter(MyGeometry, MouseEvent);
+			OnHovered.ExecuteIfBound();
+		}
+
+		virtual void OnMouseLeave(const FPointerEvent& MouseEvent) override
+		{
+			SBorder::OnMouseLeave(MouseEvent);
+			OnUnhovered.ExecuteIfBound();
+		}
+
+	private:
+		FSimpleDelegate OnHovered;
+		FSimpleDelegate OnUnhovered;
+	};
+}
+
+const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
+{
+	static const TArray<FKawaiiWindScopeParamGroup> Groups =
+	{
+		{
+			LOCTEXT("CommonGroupLabel", "Common"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled), 0.0f, 1.0f, true},
+			}
+		},
+		{
+			LOCTEXT("DirectionGroupLabel", "Direction"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection), -1.0f, 1.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, DirectionNoiseAngle), 0.0f, 90.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, DirectionNoisePeriod), 0.01f, 10.0f, true},
+			}
+		},
+		{
+			LOCTEXT("SteadyGroupLabel", "Steady"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Steady),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, SteadyForce), 0.0f, 50.0f, true},
+			}
+		},
+		{
+			LOCTEXT("OscillationGroupLabel", "Oscillation"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Oscillation),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, OscillationForce), 0.0f, 50.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, OscillationPeriod), 0.01f, 10.0f, true},
+			}
+		},
+		{
+			LOCTEXT("WaveGroupLabel", "Wave"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Wave),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WaveAmplitude), 0.0f, 50.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePeriod), 0.01f, 10.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePhase), -360.0f, 360.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WaveSpatialOffset), 0.0f, 720.0f, true},
+			}
+		},
+		{
+			LOCTEXT("EnvelopeGroupLabel", "Envelope"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Envelope),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMax), 0.0f, 3.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMin), 0.0f, 3.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeFrequency), 0.0f, 2.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopePhase), -360.0f, 360.0f, true},
+			}
+		},
+		{
+			LOCTEXT("RandomGroupLabel", "Random"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Random),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomForce), 0.0f, 50.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomPeriod), 0.01f, 5.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed), 0.0f, 10000.0f, false},
+			}
+		},
+		{
+			LOCTEXT("TimeGroupLabel", "Time"),
+			TOptional<EKawaiiPhysicsWindScopeComponent>(),
+			{
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, TimeScale), 0.0f, 3.0f, true},
+			}
+		},
+	};
+	return Groups;
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
+{
+	EditValues = InArgs._EditValues;
+	OnParamEdit = InArgs._OnParamEdit;
+	OnParamReset = InArgs._OnParamReset;
+	OnFocusNode = InArgs._OnFocusNode;
+	OnHighlightSeries = InArgs._OnHighlightSeries;
+
+	TSharedRef<SScrollBox> ScrollBox = SNew(SScrollBox);
+	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	{
+		ScrollBox->AddSlot()
+		.Padding(0.0f, 0.0f, 0.0f, 6.0f)
+		[
+			MakeGroupWidget(Group)
+		];
+	}
+
+	ChildSlot
+	[
+		ScrollBox
+	];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group)
+{
+	const FLinearColor GroupColor = ResolveGroupColor(Group.LinkedSeries);
+
+	TSharedRef<SVerticalBox> GroupBox = SNew(SVerticalBox)
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		[
+			SNew(SKawaiiWindScopeGroupHoverBorder)
+			.BorderImage(FAppStyle::Get().GetBrush(TEXT("Brushes.Header")))
+			.BorderBackgroundColor(GroupColor.CopyWithNewOpacity(0.28f))
+			.Padding(FMargin(8.0f, 4.0f))
+			.OnHovered_Lambda([this, LinkedSeries = Group.LinkedSeries]()
+			{
+				OnHighlightSeries.ExecuteIfBound(LinkedSeries);
+			})
+			.OnUnhovered_Lambda([this]()
+			{
+				OnHighlightSeries.ExecuteIfBound(TOptional<EKawaiiPhysicsWindScopeComponent>());
+			})
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				.Padding(0.0f, 0.0f, 6.0f, 0.0f)
+				[
+					SNew(SColorBlock)
+					.Color(GroupColor)
+					.Size(FVector2D(10.0f, 10.0f))
+				]
+				+ SHorizontalBox::Slot()
+				.FillWidth(1.0f)
+				.VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text(Group.GroupLabel)
+					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 10, TEXT("Bold")))
+				]
+			]
+		];
+
+	for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+	{
+		GroupBox->AddSlot()
+		.AutoHeight()
+		.Padding(4.0f, 4.0f, 4.0f, 0.0f)
+		[
+			MakeParamRow(Param)
+		];
+	}
+
+	if (Group.Params.Num() > 0 &&
+		Group.Params[0].PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+	{
+		GroupBox->AddSlot()
+		.AutoHeight()
+		.Padding(4.0f, 4.0f, 4.0f, 0.0f)
+		[
+			MakeCurveRow()
+		];
+	}
+
+	return GroupBox;
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef)
+{
+	FProperty* Property = FindWindScopeProperty(ParamDef.PropertyName);
+	const FText Label = Property ? Property->GetDisplayNameText() : FText::FromString(ParamDef.PropertyName.ToString());
+	const FText ToolTipText = Property ? Property->GetToolTipText() : FText::GetEmpty();
+	const TOptional<float> ClampMin = GetClampMinValue(Property);
+
+	TSharedPtr<SWidget> ValueWidget;
+	if (CastField<FBoolProperty>(Property))
+	{
+		ValueWidget =
+			SNew(SCheckBox)
+			.IsChecked(this, &SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState, ParamDef.PropertyName)
+			.OnCheckStateChanged(this, &SKawaiiPhysicsWindScopeEditPanel::HandleBoolChanged, ParamDef.PropertyName)
+			.ToolTipText(ToolTipText);
+	}
+	else if (CastField<FIntProperty>(Property))
+	{
+		ValueWidget =
+			SNew(SSpinBox<int32>)
+			.MinValue(ClampMin.IsSet() ? TOptional<int32>(FMath::CeilToInt(ClampMin.GetValue())) : TOptional<int32>())
+			.MaxValue(TOptional<int32>())
+			.MinSliderValue(FMath::RoundToInt(ParamDef.SliderMin))
+			.MaxSliderValue(FMath::RoundToInt(ParamDef.SliderMax))
+			.Value(this, &SKawaiiPhysicsWindScopeEditPanel::GetIntValue, ParamDef.PropertyName)
+			.OnBeginSliderMovement_Lambda([this, PropertyName = ParamDef.PropertyName]()
+			{
+				HandleBegin(PropertyName, INDEX_NONE);
+			})
+			.OnValueChanged_Lambda([this, PropertyName = ParamDef.PropertyName](int32 NewValue)
+			{
+				HandleScalarChanged(PropertyName, NewValue);
+			})
+			.OnValueCommitted_Lambda([this, PropertyName = ParamDef.PropertyName](int32 NewValue, ETextCommit::Type CommitType)
+			{
+				HandleScalarCommitted(PropertyName, NewValue, CommitType);
+			})
+			.ToolTipText(ToolTipText);
+	}
+	else if (CastField<FStructProperty>(Property) && ParamDef.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+	{
+		ValueWidget =
+			SNew(SNumericVectorInputBox<FVector::FReal>)
+			.bColorAxisLabels(true)
+			.AllowSpin(true)
+			.X(this, &SKawaiiPhysicsWindScopeEditPanel::GetVectorValue, ParamDef.PropertyName, 0)
+			.Y(this, &SKawaiiPhysicsWindScopeEditPanel::GetVectorValue, ParamDef.PropertyName, 1)
+			.Z(this, &SKawaiiPhysicsWindScopeEditPanel::GetVectorValue, ParamDef.PropertyName, 2)
+			.MinSliderVector(TOptional<FVector>(FVector(ParamDef.SliderMin)))
+			.MaxSliderVector(TOptional<FVector>(FVector(ParamDef.SliderMax)))
+			.OnBeginSliderMovement_Lambda([this, PropertyName = ParamDef.PropertyName]()
+			{
+				HandleBegin(PropertyName, INDEX_NONE);
+			})
+			.OnXChanged_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue)
+			{
+				HandleVectorChanged(PropertyName, 0, NewValue);
+			})
+			.OnYChanged_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue)
+			{
+				HandleVectorChanged(PropertyName, 1, NewValue);
+			})
+			.OnZChanged_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue)
+			{
+				HandleVectorChanged(PropertyName, 2, NewValue);
+			})
+			.OnXCommitted_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue, ETextCommit::Type CommitType)
+			{
+				HandleVectorCommitted(PropertyName, 0, NewValue, CommitType);
+			})
+			.OnYCommitted_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue, ETextCommit::Type CommitType)
+			{
+				HandleVectorCommitted(PropertyName, 1, NewValue, CommitType);
+			})
+			.OnZCommitted_Lambda([this, PropertyName = ParamDef.PropertyName](FVector::FReal NewValue, ETextCommit::Type CommitType)
+			{
+				HandleVectorCommitted(PropertyName, 2, NewValue, CommitType);
+			})
+			.ToolTipText(ToolTipText);
+	}
+	else
+	{
+		ValueWidget =
+			SNew(SSpinBox<float>)
+			.MinValue(ClampMin)
+			.MaxValue(TOptional<float>())
+			.MinSliderValue(ParamDef.SliderMin)
+			.MaxSliderValue(ParamDef.SliderMax)
+			.Value(this, &SKawaiiPhysicsWindScopeEditPanel::GetFloatValue, ParamDef.PropertyName)
+			.OnBeginSliderMovement_Lambda([this, PropertyName = ParamDef.PropertyName]()
+			{
+				HandleBegin(PropertyName, INDEX_NONE);
+			})
+			.OnValueChanged_Lambda([this, PropertyName = ParamDef.PropertyName](float NewValue)
+			{
+				HandleScalarChanged(PropertyName, NewValue);
+			})
+			.OnValueCommitted_Lambda([this, PropertyName = ParamDef.PropertyName](float NewValue, ETextCommit::Type CommitType)
+			{
+				HandleScalarCommitted(PropertyName, NewValue, CommitType);
+			})
+			.ToolTipText(ToolTipText);
+	}
+
+	return SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
+		[
+			SNew(SBox)
+			.WidthOverride(LabelColumnWidth)
+			[
+				SNew(STextBlock)
+				.Text(Label)
+				.ToolTipText(ToolTipText)
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+		]
+		+ SHorizontalBox::Slot()
+		.FillWidth(1.0f)
+		.VAlign(VAlign_Center)
+		[
+			ValueWidget.ToSharedRef()
+		]
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
+		.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+		[
+			MakeResetButton(ParamDef.PropertyName)
+		];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeCurveRow() const
+{
+	return SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot()
+		.FillWidth(1.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("CurveEditGuide", "カーブ(ForceRateByBoneLengthRate)は詳細パネルで編集 / Edit the curve in the Details panel"))
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			.AutoWrapText(true)
+		]
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
+		.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+		[
+			SNew(SButton)
+			.Text(LOCTEXT("FocusNodeButton", "Focus Node"))
+			.OnClicked_Lambda([this]()
+			{
+				OnFocusNode.ExecuteIfBound();
+				return FReply::Handled();
+			})
+		];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeResetButton(FName PropertyName) const
+{
+	return SNew(SButton)
+		.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+		.ContentPadding(FMargin(2.0f))
+		.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetResetVisibility, PropertyName)
+		.ToolTipText(LOCTEXT("ResetToDefaultTooltip", "既定値へ戻します / Reset to default."))
+		.OnClicked_Lambda([this, PropertyName]()
+		{
+			if (OnParamReset.IsBound())
+			{
+				OnParamReset.Execute(PropertyName);
+			}
+			return FReply::Handled();
+		})
+		[
+			SNew(SImage)
+			.Image(FAppStyle::Get().GetBrush(TEXT("PropertyWindow.DiffersFromDefault")))
+		];
+}
+
+EVisibility SKawaiiPhysicsWindScopeEditPanel::GetResetVisibility(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	return Values && Values->ModifiedFromDefault.Contains(PropertyName)
+		       ? EVisibility::Visible
+		       : EVisibility::Hidden;
+}
+
+ECheckBoxState SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	if (!Values || !Values->bValid || PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+	{
+		return ECheckBoxState::Undetermined;
+	}
+	return Values->bIsEnabled ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+float SKawaiiPhysicsWindScopeEditPanel::GetFloatValue(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	if (!Values || !Values->bValid)
+	{
+		return 0.0f;
+	}
+
+	if (const float* Value = Values->FloatValues.Find(PropertyName))
+	{
+		return *Value;
+	}
+	return 0.0f;
+}
+
+int32 SKawaiiPhysicsWindScopeEditPanel::GetIntValue(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	if (!Values || !Values->bValid || PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed))
+	{
+		return 0;
+	}
+	return Values->RandomSeed;
+}
+
+TOptional<FVector::FReal> SKawaiiPhysicsWindScopeEditPanel::GetVectorValue(FName PropertyName, int32 ComponentIndex) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	if (!Values || !Values->bValid ||
+		PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection) ||
+		ComponentIndex < 0 || ComponentIndex > 2)
+	{
+		return TOptional<FVector::FReal>();
+	}
+	return Values->WindDirection[ComponentIndex];
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleBegin(FName PropertyName, int32 VectorComponentIndex) const
+{
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, 0.0, VectorComponentIndex, EKawaiiWindEditPhase::Begin);
+	}
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleScalarChanged(FName PropertyName, double NewValue) const
+{
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Interactive);
+	}
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleScalarCommitted(
+	FName PropertyName,
+	double NewValue,
+	ETextCommit::Type CommitType) const
+{
+	(void)CommitType;
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Committed);
+	}
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleVectorChanged(
+	FName PropertyName,
+	int32 ComponentIndex,
+	FVector::FReal NewValue) const
+{
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiWindEditPhase::Interactive);
+	}
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleVectorCommitted(
+	FName PropertyName,
+	int32 ComponentIndex,
+	FVector::FReal NewValue,
+	ETextCommit::Type CommitType) const
+{
+	(void)CommitType;
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiWindEditPhase::Committed);
+	}
+}
+
+void SKawaiiPhysicsWindScopeEditPanel::HandleBoolChanged(ECheckBoxState NewState, FName PropertyName) const
+{
+	const double NewValue = NewState == ECheckBoxState::Checked ? 1.0 : 0.0;
+	if (OnParamEdit.IsBound())
+	{
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Committed);
+	}
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -12,11 +12,13 @@
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SVectorInputBox.h"
 #include "Widgets/Input/SSpinBox.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Layout/SWrapBox.h"
 #include "Widgets/Text/STextBlock.h"
 
 #define LOCTEXT_NAMESPACE "KawaiiPhysicsWindScopeEditPanel"
@@ -24,6 +26,7 @@
 namespace
 {
 	constexpr float LabelColumnWidth = 150.0f;
+	constexpr float LiveValueTolerance = 0.01f;
 
 	FText GetPinDrivenWarningText()
 	{
@@ -72,6 +75,39 @@ namespace
 			}
 		}
 		return FLinearColor(0.28f, 0.3f, 0.34f, 1.0f);
+	}
+
+	FLinearColor ResolveComponentColor(EKawaiiPhysicsWindScopeComponent Component)
+	{
+		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		{
+			if (Style.Component == Component)
+			{
+				return Style.Color;
+			}
+		}
+		return FLinearColor::White;
+	}
+
+	FSlateColor ResolveLiveWarningColor()
+	{
+		return FSlateColor(FLinearColor(1.0f, 0.7f, 0.2f));
+	}
+
+	FText FormatLiveFloat(float Value)
+	{
+		FNumberFormattingOptions Options;
+		Options.MinimumFractionalDigits = 2;
+		Options.MaximumFractionalDigits = 2;
+		return FText::AsNumber(Value, &Options);
+	}
+
+	TSharedRef<STextBlock> MakeFormulaText(const FText& Text, const FSlateColor& Color = FSlateColor::UseForeground())
+	{
+		return SNew(STextBlock)
+			.Text(Text)
+			.ColorAndOpacity(Color)
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9));
 	}
 
 	class SKawaiiWindScopeGroupHoverBorder : public SBorder
@@ -197,6 +233,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 {
 	EditValues = InArgs._EditValues;
+	LiveEditValues = InArgs._LiveEditValues;
 	OnParamEdit = InArgs._OnParamEdit;
 	OnParamReset = InArgs._OnParamReset;
 	IsParamPinExposed = InArgs._IsParamPinExposed;
@@ -204,6 +241,25 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 	OnHighlightSeries = InArgs._OnHighlightSeries;
 
 	TSharedRef<SScrollBox> ScrollBox = SNew(SScrollBox);
+	ScrollBox->AddSlot()
+	.Padding(0.0f, 0.0f, 0.0f, 6.0f)
+	[
+		SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot()
+		.FillWidth(1.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("EditPanelHeader", "Procedural Wind"))
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 10, TEXT("Bold")))
+		]
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
+		[
+			MakeFormulaHelpButton()
+		]
+	];
 	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		ScrollBox->AddSlot()
@@ -226,6 +282,72 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 	[
 		ScrollBox
 	];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeFormulaHelpButton() const
+{
+	return SNew(SComboButton)
+		.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+		.ContentPadding(FMargin(4.0f, 1.0f))
+		.ToolTipText(LOCTEXT("FormulaHelpTooltip", "合成式のヘルプ / Composition formula help."))
+		.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeEditPanel::MakeFormulaHelpContent)
+		.ButtonContent()
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("FormulaHelpButton", "?"))
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9, TEXT("Bold")))
+		];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeFormulaHelpContent() const
+{
+	return SNew(SBox)
+		.WidthOverride(500.0f)
+		.Padding(10.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot()
+			.AutoHeight()
+			.Padding(0.0f, 0.0f, 0.0f, 8.0f)
+			[
+				SNew(SWrapBox)
+				.UseAllottedSize(true)
+				.InnerSlotPadding(FVector2D(1.0f, 1.0f))
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaTotalPrefix", "Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaTotal", "Total"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Total))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaEquals", " = ("))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaSteadyPrefix", "Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaSteady", "Steady"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Steady))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaPlusOscillation", " + Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaOscillation", "Oscillation"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Oscillation))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaPlusWave", " + Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaWave", "Wave"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Wave))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaEnvelopePrefix", ") * Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaEnvelope", "Envelope"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Envelope))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaPlusRandom", " + Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaRandom", "Random"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Random))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaPlusGust", " + Sample."))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaGust", "Gust"), ResolveComponentColor(EKawaiiPhysicsWindScopeComponent::Gust))]
+				+ SWrapBox::Slot()[MakeFormulaText(LOCTEXT("FormulaSemicolon", ";"))]
+			]
+			+ SVerticalBox::Slot()
+			.AutoHeight()
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("FormulaHelpGroupLine1", "Steady/Oscillation/Wave/Envelope/Random は同名グループに対応 / Steady, Oscillation, Wave, Envelope, and Random map to their groups."))
+				.AutoWrapText(true)
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SVerticalBox::Slot()
+			.AutoHeight()
+			.Padding(0.0f, 3.0f, 0.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("FormulaHelpGroupLine2", "Gust は上部の Gust ボタンと S/R/D 入力に対応 / Gust maps to the Gust button and S/R/D inputs above."))
+				.AutoWrapText(true)
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+		];
 }
 
 TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group)
@@ -434,6 +556,17 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 		+ SHorizontalBox::Slot()
 		.AutoWidth()
 		.VAlign(VAlign_Center)
+		.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+		[
+			SNew(STextBlock)
+			.Text(this, &SKawaiiPhysicsWindScopeEditPanel::GetLiveValueText, ParamDef.PropertyName)
+			.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetLiveValueVisibility, ParamDef.PropertyName)
+			.ColorAndOpacity(ResolveLiveWarningColor())
+			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+		]
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
 		.Padding(4.0f, 0.0f, 0.0f, 0.0f)
 		[
 			MakeResetButton(ParamDef.PropertyName)
@@ -510,6 +643,94 @@ EVisibility SKawaiiPhysicsWindScopeEditPanel::GetPinWarningVisibility(FName Prop
 	return IsParamPinExposed.IsBound() && IsParamPinExposed.Execute(PropertyName)
 		       ? EVisibility::Visible
 		       : EVisibility::Collapsed;
+}
+
+EVisibility SKawaiiPhysicsWindScopeEditPanel::GetLiveValueVisibility(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiWindScopeEditValues* LiveValues = LiveEditValues.Get();
+	if (!Values || !Values->bValid || !LiveValues || !LiveValues->bValid)
+	{
+		return EVisibility::Collapsed;
+	}
+
+	FProperty* Property = FindWindScopeProperty(PropertyName);
+	if (CastField<FBoolProperty>(Property))
+	{
+		return PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled) &&
+			Values->bIsEnabled != LiveValues->bIsEnabled
+			       ? EVisibility::Visible
+			       : EVisibility::Collapsed;
+	}
+	if (CastField<FIntProperty>(Property))
+	{
+		return PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed) &&
+			Values->RandomSeed != LiveValues->RandomSeed
+			       ? EVisibility::Visible
+			       : EVisibility::Collapsed;
+	}
+	if (CastField<FStructProperty>(Property) &&
+		PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+	{
+		for (int32 ComponentIndex = 0; ComponentIndex < 3; ++ComponentIndex)
+		{
+			if (!FMath::IsNearlyEqual(
+				static_cast<float>(Values->WindDirection[ComponentIndex]),
+				static_cast<float>(LiveValues->WindDirection[ComponentIndex]),
+				LiveValueTolerance))
+			{
+				return EVisibility::Visible;
+			}
+		}
+		return EVisibility::Collapsed;
+	}
+
+	const float* Value = Values->FloatValues.Find(PropertyName);
+	const float* LiveValue = LiveValues->FloatValues.Find(PropertyName);
+	return Value && LiveValue && !FMath::IsNearlyEqual(*Value, *LiveValue, LiveValueTolerance)
+		       ? EVisibility::Visible
+		       : EVisibility::Collapsed;
+}
+
+FText SKawaiiPhysicsWindScopeEditPanel::GetLiveValueText(FName PropertyName) const
+{
+	const FKawaiiWindScopeEditValues* LiveValues = LiveEditValues.Get();
+	if (!LiveValues || !LiveValues->bValid)
+	{
+		return FText::GetEmpty();
+	}
+
+	FProperty* Property = FindWindScopeProperty(PropertyName);
+	FText ValueText;
+	if (CastField<FBoolProperty>(Property) &&
+		PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+	{
+		ValueText = LiveValues->bIsEnabled ? LOCTEXT("LiveBoolTrue", "true") : LOCTEXT("LiveBoolFalse", "false");
+	}
+	else if (CastField<FIntProperty>(Property) &&
+		PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed))
+	{
+		ValueText = FText::AsNumber(LiveValues->RandomSeed);
+	}
+	else if (CastField<FStructProperty>(Property) &&
+		PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+	{
+		ValueText = FText::Format(
+			LOCTEXT("LiveVectorValueFormat", "({0}, {1}, {2})"),
+			FormatLiveFloat(static_cast<float>(LiveValues->WindDirection.X)),
+			FormatLiveFloat(static_cast<float>(LiveValues->WindDirection.Y)),
+			FormatLiveFloat(static_cast<float>(LiveValues->WindDirection.Z)));
+	}
+	else if (const float* LiveValue = LiveValues->FloatValues.Find(PropertyName))
+	{
+		ValueText = FormatLiveFloat(*LiveValue);
+	}
+	else
+	{
+		return FText::GetEmpty();
+	}
+
+	return FText::Format(LOCTEXT("LiveValueFormat", "→ {0} (live)"), ValueText);
 }
 
 ECheckBoxState SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState(FName PropertyName) const

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -25,6 +25,11 @@ namespace
 {
 	constexpr float LabelColumnWidth = 150.0f;
 
+	FText GetPinDrivenWarningText()
+	{
+		return LOCTEXT("PinDrivenWarningTooltip", "ピン接続中のパラメータはグラフ側の値が優先されます / Pin-driven values take precedence over panel edits.");
+	}
+
 	FProperty* FindWindScopeProperty(const FName PropertyName)
 	{
 		for (UStruct* Struct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct(); Struct; Struct = Struct->GetSuperStruct())
@@ -194,6 +199,7 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 	EditValues = InArgs._EditValues;
 	OnParamEdit = InArgs._OnParamEdit;
 	OnParamReset = InArgs._OnParamReset;
+	IsParamPinExposed = InArgs._IsParamPinExposed;
 	OnFocusNode = InArgs._OnFocusNode;
 	OnHighlightSeries = InArgs._OnHighlightSeries;
 
@@ -206,6 +212,15 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 			MakeGroupWidget(Group)
 		];
 	}
+	ScrollBox->AddSlot()
+	.Padding(0.0f, 2.0f, 0.0f, 0.0f)
+	[
+		SNew(STextBlock)
+		.Text(GetPinDrivenWarningText())
+		.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+		.AutoWrapText(true)
+		.ColorAndOpacity(FLinearColor(0.78f, 0.78f, 0.72f, 1.0f))
+	];
 
 	ChildSlot
 	[
@@ -391,10 +406,23 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 			SNew(SBox)
 			.WidthOverride(LabelColumnWidth)
 			[
-				SNew(STextBlock)
-				.Text(Label)
-				.ToolTipText(ToolTipText)
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot()
+				.FillWidth(1.0f)
+				.VAlign(VAlign_Center)
+				[
+					SNew(STextBlock)
+					.Text(Label)
+					.ToolTipText(ToolTipText)
+					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+				]
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+				[
+					MakePinWarningIcon(ParamDef.PropertyName)
+				]
 			]
 		]
 		+ SHorizontalBox::Slot()
@@ -410,6 +438,15 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 		[
 			MakeResetButton(ParamDef.PropertyName)
 		];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakePinWarningIcon(FName PropertyName) const
+{
+	return SNew(SImage)
+		.Image(FAppStyle::Get().GetBrush(TEXT("Icons.Warning")))
+		.ColorAndOpacity(FLinearColor(1.0f, 0.72f, 0.18f, 1.0f))
+		.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetPinWarningVisibility, PropertyName)
+		.ToolTipText(GetPinDrivenWarningText());
 }
 
 TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeCurveRow() const
@@ -466,6 +503,13 @@ EVisibility SKawaiiPhysicsWindScopeEditPanel::GetResetVisibility(FName PropertyN
 	return Values && Values->ModifiedFromDefault.Contains(PropertyName)
 		       ? EVisibility::Visible
 		       : EVisibility::Hidden;
+}
+
+EVisibility SKawaiiPhysicsWindScopeEditPanel::GetPinWarningVisibility(FName PropertyName) const
+{
+	return IsParamPinExposed.IsBound() && IsParamPinExposed.Execute(PropertyName)
+		       ? EVisibility::Visible
+		       : EVisibility::Collapsed;
 }
 
 ECheckBoxState SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState(FName PropertyName) const

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -27,6 +27,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups();
 
 DECLARE_DELEGATE_RetVal_FourParams(bool, FOnWindParamEdit, FName, double, int32, EKawaiiWindEditPhase);
 DECLARE_DELEGATE_RetVal_OneParam(bool, FOnWindParamReset, FName);
+DECLARE_DELEGATE_RetVal_OneParam(bool, FIsWindParamPinExposed, FName);
 DECLARE_DELEGATE_OneParam(FOnWindScopeHighlightSeries, TOptional<EKawaiiPhysicsWindScopeComponent>);
 
 // Wind Scope の ProceduralWind パラメータ編集パネル
@@ -39,6 +40,7 @@ public:
 		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, EditValues)
 		SLATE_EVENT(FOnWindParamEdit, OnParamEdit)
 		SLATE_EVENT(FOnWindParamReset, OnParamReset)
+		SLATE_EVENT(FIsWindParamPinExposed, IsParamPinExposed)
 		SLATE_EVENT(FSimpleDelegate, OnFocusNode)
 		SLATE_EVENT(FOnWindScopeHighlightSeries, OnHighlightSeries)
 	SLATE_END_ARGS()
@@ -50,8 +52,10 @@ private:
 	TSharedRef<SWidget> MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef);
 	TSharedRef<SWidget> MakeCurveRow() const;
 	TSharedRef<SWidget> MakeResetButton(FName PropertyName) const;
+	TSharedRef<SWidget> MakePinWarningIcon(FName PropertyName) const;
 
 	EVisibility GetResetVisibility(FName PropertyName) const;
+	EVisibility GetPinWarningVisibility(FName PropertyName) const;
 	ECheckBoxState GetBoolCheckState(FName PropertyName) const;
 	float GetFloatValue(FName PropertyName) const;
 	int32 GetIntValue(FName PropertyName) const;
@@ -67,6 +71,7 @@ private:
 	TAttribute<const FKawaiiWindScopeEditValues*> EditValues;
 	FOnWindParamEdit OnParamEdit;
 	FOnWindParamReset OnParamReset;
+	FIsWindParamPinExposed IsParamPinExposed;
 	FSimpleDelegate OnFocusNode;
 	FOnWindScopeHighlightSeries OnHighlightSeries;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -1,0 +1,72 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SKawaiiPhysicsWindScopeWindow.h"
+#include "Widgets/SCompoundWidget.h"
+
+// Wind Scope 編集パネルの1プロパティ定義
+struct FKawaiiWindScopeParamDef
+{
+	FName PropertyName;
+	float SliderMin = 0.0f;
+	float SliderMax = 10.0f;
+	bool bDynamicParamsSupported = true;
+};
+
+// Wind Scope 編集パネルのグループ定義
+struct FKawaiiWindScopeParamGroup
+{
+	FText GroupLabel;
+	TOptional<EKawaiiPhysicsWindScopeComponent> LinkedSeries;
+	TArray<FKawaiiWindScopeParamDef> Params;
+};
+
+const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups();
+
+DECLARE_DELEGATE_RetVal_FourParams(bool, FOnWindParamEdit, FName, double, int32, EKawaiiWindEditPhase);
+DECLARE_DELEGATE_RetVal_OneParam(bool, FOnWindParamReset, FName);
+DECLARE_DELEGATE_OneParam(FOnWindScopeHighlightSeries, TOptional<EKawaiiPhysicsWindScopeComponent>);
+
+// Wind Scope の ProceduralWind パラメータ編集パネル
+class SKawaiiPhysicsWindScopeEditPanel : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeEditPanel)
+		{
+		}
+		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, EditValues)
+		SLATE_EVENT(FOnWindParamEdit, OnParamEdit)
+		SLATE_EVENT(FOnWindParamReset, OnParamReset)
+		SLATE_EVENT(FSimpleDelegate, OnFocusNode)
+		SLATE_EVENT(FOnWindScopeHighlightSeries, OnHighlightSeries)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedRef<SWidget> MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group);
+	TSharedRef<SWidget> MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef);
+	TSharedRef<SWidget> MakeCurveRow() const;
+	TSharedRef<SWidget> MakeResetButton(FName PropertyName) const;
+
+	EVisibility GetResetVisibility(FName PropertyName) const;
+	ECheckBoxState GetBoolCheckState(FName PropertyName) const;
+	float GetFloatValue(FName PropertyName) const;
+	int32 GetIntValue(FName PropertyName) const;
+	TOptional<FVector::FReal> GetVectorValue(FName PropertyName, int32 ComponentIndex) const;
+
+	void HandleBegin(FName PropertyName, int32 VectorComponentIndex) const;
+	void HandleScalarChanged(FName PropertyName, double NewValue) const;
+	void HandleScalarCommitted(FName PropertyName, double NewValue, ETextCommit::Type CommitType) const;
+	void HandleVectorChanged(FName PropertyName, int32 ComponentIndex, FVector::FReal NewValue) const;
+	void HandleVectorCommitted(FName PropertyName, int32 ComponentIndex, FVector::FReal NewValue, ETextCommit::Type CommitType) const;
+	void HandleBoolChanged(ECheckBoxState NewState, FName PropertyName) const;
+
+	TAttribute<const FKawaiiWindScopeEditValues*> EditValues;
+	FOnWindParamEdit OnParamEdit;
+	FOnWindParamReset OnParamReset;
+	FSimpleDelegate OnFocusNode;
+	FOnWindScopeHighlightSeries OnHighlightSeries;
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -38,6 +38,7 @@ public:
 		{
 		}
 		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, EditValues)
+		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, LiveEditValues)
 		SLATE_EVENT(FOnWindParamEdit, OnParamEdit)
 		SLATE_EVENT(FOnWindParamReset, OnParamReset)
 		SLATE_EVENT(FIsWindParamPinExposed, IsParamPinExposed)
@@ -48,6 +49,8 @@ public:
 	void Construct(const FArguments& InArgs);
 
 private:
+	TSharedRef<SWidget> MakeFormulaHelpButton() const;
+	TSharedRef<SWidget> MakeFormulaHelpContent() const;
 	TSharedRef<SWidget> MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group);
 	TSharedRef<SWidget> MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef);
 	TSharedRef<SWidget> MakeCurveRow() const;
@@ -56,6 +59,8 @@ private:
 
 	EVisibility GetResetVisibility(FName PropertyName) const;
 	EVisibility GetPinWarningVisibility(FName PropertyName) const;
+	EVisibility GetLiveValueVisibility(FName PropertyName) const;
+	FText GetLiveValueText(FName PropertyName) const;
 	ECheckBoxState GetBoolCheckState(FName PropertyName) const;
 	float GetFloatValue(FName PropertyName) const;
 	int32 GetIntValue(FName PropertyName) const;
@@ -69,6 +74,7 @@ private:
 	void HandleBoolChanged(ECheckBoxState NewState, FName PropertyName) const;
 
 	TAttribute<const FKawaiiWindScopeEditValues*> EditValues;
+	TAttribute<const FKawaiiWindScopeEditValues*> LiveEditValues;
 	FOnWindParamEdit OnParamEdit;
 	FOnWindParamReset OnParamReset;
 	FIsWindParamPinExposed IsParamPinExposed;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -17,8 +17,10 @@
 #include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdUtils.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
+#include "SKawaiiPhysicsWindScopeEditPanel.h"
 #include "KawaiiPhysicsWindScopeStyle.h"
 #include "Kismet2/BlueprintEditorUtils.h"
+#include "Kismet2/KismetEditorUtilities.h"
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeLock.h"
 #include "Rendering/DrawElements.h"
@@ -26,6 +28,7 @@
 #include "Styling/AppStyle.h"
 #include "Styling/CoreStyle.h"
 #include "Textures/SlateIcon.h"
+#include "UObject/UnrealType.h"
 #include "Widgets/Colors/SColorBlock.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Images/SImage.h"
@@ -35,6 +38,7 @@
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SSeparator.h"
+#include "Widgets/Layout/SSplitter.h"
 #include "Widgets/Layout/SWrapBox.h"
 #include "Widgets/Notifications/SNotificationList.h"
 #include "Widgets/Text/STextBlock.h"
@@ -56,6 +60,8 @@ namespace
 	const TCHAR* WindScopeLastAnimBlueprintKey = TEXT("WindScopeLastAnimBlueprint");
 	const TCHAR* WindScopeLastNodeGuidKey = TEXT("WindScopeLastNodeGuid");
 	const TCHAR* WindScopeLastForceIndexKey = TEXT("WindScopeLastForceIndex");
+	const TCHAR* WindScopeEditPanelExpandedKey = TEXT("WindScopeEditPanelExpanded");
+	const TCHAR* WindScopeEditPanelSplitterFractionKey = TEXT("WindScopeEditPanelSplitterFraction");
 
 	TWeakPtr<SDockTab> KawaiiWindScopeTabWeak;
 	TWeakPtr<SKawaiiPhysicsWindScopeWindow> KawaiiWindScopeWidgetWeak;
@@ -134,6 +140,131 @@ namespace
 	{
 		return InstancedStruct.IsValid() &&
 			InstancedStruct.GetScriptStruct() == FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
+	}
+
+	FProperty* FindProceduralWindProperty(const FName PropertyName)
+	{
+		for (UStruct* Struct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct(); Struct; Struct = Struct->GetSuperStruct())
+		{
+			if (FProperty* Property = Struct->FindPropertyByName(PropertyName))
+			{
+				return Property;
+			}
+		}
+		return nullptr;
+	}
+
+	bool IsFVectorProperty(const FProperty* Property)
+	{
+		const FStructProperty* StructProperty = CastField<FStructProperty>(Property);
+		return StructProperty && StructProperty->Struct == TBaseStructure<FVector>::Get();
+	}
+
+	bool SetProceduralWindPropertyValue(
+		FKawaiiPhysics_ExternalForce_ProceduralWind& Wind,
+		const FProperty* Property,
+		double NewValue,
+		int32 VectorComponentIndex)
+	{
+		if (!Property)
+		{
+			return false;
+		}
+
+		if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(Property))
+		{
+			BoolProperty->SetPropertyValue_InContainer(&Wind, NewValue != 0.0);
+			return true;
+		}
+
+		if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
+		{
+			FloatProperty->SetPropertyValue_InContainer(&Wind, static_cast<float>(NewValue));
+			return true;
+		}
+
+		if (const FIntProperty* IntProperty = CastField<FIntProperty>(Property))
+		{
+			IntProperty->SetPropertyValue_InContainer(&Wind, FMath::RoundToInt32(NewValue));
+			return true;
+		}
+
+		if (IsFVectorProperty(Property) && VectorComponentIndex >= 0 && VectorComponentIndex <= 2)
+		{
+			FVector* Vector = Property->ContainerPtrToValuePtr<FVector>(&Wind);
+			(*Vector)[VectorComponentIndex] = static_cast<FVector::FReal>(NewValue);
+			return true;
+		}
+
+		return false;
+	}
+
+	bool CopyProceduralWindPropertyValue(
+		FKawaiiPhysics_ExternalForce_ProceduralWind& TargetWind,
+		const FKawaiiPhysics_ExternalForce_ProceduralWind& SourceWind,
+		const FProperty* Property)
+	{
+		if (!Property)
+		{
+			return false;
+		}
+
+		void* TargetValue = Property->ContainerPtrToValuePtr<void>(&TargetWind);
+		const void* SourceValue = Property->ContainerPtrToValuePtr<void>(&SourceWind);
+		Property->CopyCompleteValue(TargetValue, SourceValue);
+		return true;
+	}
+
+	bool IsProceduralWindPropertyModifiedFromDefault(
+		const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind,
+		const FKawaiiPhysics_ExternalForce_ProceduralWind& DefaultWind,
+		const FProperty* Property)
+	{
+		if (!Property)
+		{
+			return false;
+		}
+
+		const void* Value = Property->ContainerPtrToValuePtr<void>(&Wind);
+		const void* DefaultValue = Property->ContainerPtrToValuePtr<void>(&DefaultWind);
+		return !Property->Identical(Value, DefaultValue);
+	}
+
+	bool IsProceduralWindPropertyValueEqualToEdit(
+		const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind,
+		const FProperty* Property,
+		double NewValue,
+		int32 VectorComponentIndex)
+	{
+		if (!Property)
+		{
+			return false;
+		}
+
+		if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(Property))
+		{
+			return BoolProperty->GetPropertyValue_InContainer(&Wind) == (NewValue != 0.0);
+		}
+
+		if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
+		{
+			return FMath::IsNearlyEqual(FloatProperty->GetPropertyValue_InContainer(&Wind), static_cast<float>(NewValue));
+		}
+
+		if (const FIntProperty* IntProperty = CastField<FIntProperty>(Property))
+		{
+			return IntProperty->GetPropertyValue_InContainer(&Wind) == FMath::RoundToInt32(NewValue);
+		}
+
+		if (IsFVectorProperty(Property) && VectorComponentIndex >= 0 && VectorComponentIndex <= 2)
+		{
+			const FVector* Vector = Property->ContainerPtrToValuePtr<FVector>(&Wind);
+			FVector EditedVector = *Vector;
+			EditedVector[VectorComponentIndex] = static_cast<FVector::FReal>(NewValue);
+			return Vector->Equals(EditedVector);
+		}
+
+		return false;
 	}
 
 	int32 FindFirstProceduralWindIndex(const FAnimNode_KawaiiPhysics& Node)
@@ -370,32 +501,87 @@ namespace
 		}
 	}
 
+	class SKawaiiWindScopeLegendHoverBorder : public SBorder
+	{
+	public:
+		SLATE_BEGIN_ARGS(SKawaiiWindScopeLegendHoverBorder)
+			{
+			}
+			SLATE_DEFAULT_SLOT(FArguments, Content)
+			SLATE_EVENT(FSimpleDelegate, OnHovered)
+			SLATE_EVENT(FSimpleDelegate, OnUnhovered)
+			SLATE_ARGUMENT(const FSlateBrush*, BorderImage)
+			SLATE_ATTRIBUTE(FMargin, Padding)
+		SLATE_END_ARGS()
+
+		void Construct(const FArguments& InArgs)
+		{
+			OnHovered = InArgs._OnHovered;
+			OnUnhovered = InArgs._OnUnhovered;
+			SBorder::Construct(SBorder::FArguments()
+				.BorderImage(InArgs._BorderImage)
+				.Padding(InArgs._Padding)
+				[
+					InArgs._Content.Widget
+				]);
+		}
+
+		virtual void OnMouseEnter(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override
+		{
+			SBorder::OnMouseEnter(MyGeometry, MouseEvent);
+			OnHovered.ExecuteIfBound();
+		}
+
+		virtual void OnMouseLeave(const FPointerEvent& MouseEvent) override
+		{
+			SBorder::OnMouseLeave(MouseEvent);
+			OnUnhovered.ExecuteIfBound();
+		}
+
+	private:
+		FSimpleDelegate OnHovered;
+		FSimpleDelegate OnUnhovered;
+	};
+
 	// 凡例1項目（色スウォッチ＋表示切替チェックボックス＋ラベル）を生成する
 	TSharedRef<SWidget> MakeWindScopeLegendItem(SKawaiiPhysicsWindScopeWindow* Owner,
 	                                            const FKawaiiWindScopeComponentStyle& Style)
 	{
-		return SNew(SCheckBox)
-			.IsChecked(Owner, &SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState, Style.Component)
-			.OnCheckStateChanged(Owner, &SKawaiiPhysicsWindScopeWindow::OnSeriesCheckStateChanged, Style.Component)
-			.ToolTipText(Style.Label)
+		return SNew(SKawaiiWindScopeLegendHoverBorder)
+			.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
+			.Padding(FMargin(0.0f))
+			.OnHovered_Lambda([Owner, Component = Style.Component]()
+			{
+				Owner->SetHighlightSeries(Component);
+			})
+			.OnUnhovered_Lambda([Owner]()
+			{
+				Owner->SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent>());
+			})
 			[
-				SNew(SHorizontalBox)
-				+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.VAlign(VAlign_Center)
-				.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+				SNew(SCheckBox)
+				.IsChecked(Owner, &SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState, Style.Component)
+				.OnCheckStateChanged(Owner, &SKawaiiPhysicsWindScopeWindow::OnSeriesCheckStateChanged, Style.Component)
+				.ToolTipText(Style.Label)
 				[
-					SNew(SColorBlock)
-					.Color(Style.Color)
-					.Size(FVector2D(12.0f, 8.0f))
-				]
-				+ SHorizontalBox::Slot()
-				.AutoWidth()
-				.VAlign(VAlign_Center)
-				[
-					SNew(STextBlock)
-					.Text(Style.Label)
-					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(0.0f, 0.0f, 4.0f, 0.0f)
+					[
+						SNew(SColorBlock)
+						.Color(Style.Color)
+						.Size(FVector2D(12.0f, 8.0f))
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SNew(STextBlock)
+						.Text(Style.Label)
+						.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+					]
 				]
 			];
 	}
@@ -492,6 +678,12 @@ void SKawaiiPhysicsWindScopeGraph::SetDisplaySeconds(float InDisplaySeconds)
 void SKawaiiPhysicsWindScopeGraph::SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility)
 {
 	Visibility = InVisibility;
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+void SKawaiiPhysicsWindScopeGraph::SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries)
+{
+	HighlightSeries = InHighlightSeries;
 	Invalidate(EInvalidateWidgetReason::Paint);
 }
 
@@ -601,9 +793,23 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			continue;
 		}
 
+		FLinearColor DrawColor = Style.Color;
+		float DrawThickness = Style.Thickness;
+		if (HighlightSeries.IsSet() && Style.Component != EKawaiiPhysicsWindScopeComponent::Total)
+		{
+			if (Style.Component == HighlightSeries.GetValue())
+			{
+				DrawThickness += 1.0f;
+			}
+			else
+			{
+				DrawColor.A *= 0.25f;
+			}
+		}
+
 		if (Style.bDashed)
 		{
-			DrawWindScopeDashedLine(OutDrawElements, LayerId + 3, AllottedGeometry, Points, Style.Color, Style.Thickness);
+			DrawWindScopeDashedLine(OutDrawElements, LayerId + 3, AllottedGeometry, Points, DrawColor, DrawThickness);
 		}
 		else
 		{
@@ -613,9 +819,9 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 				AllottedGeometry.ToPaintGeometry(),
 				Points,
 				ESlateDrawEffect::None,
-				Style.Color,
+				DrawColor,
 				true,
-				Style.Thickness);
+				DrawThickness);
 		}
 	}
 
@@ -657,6 +863,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 {
 	(void)InArgs;
 	CurrentModeText = LOCTEXT("InitialMode", "Preview");
+	LoadEditPanelConfig();
 	if (HasTargetArgs(InitArgs))
 	{
 		SetArgs(MoveTemp(InitArgs));
@@ -671,6 +878,21 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		.Padding(8.0f, 8.0f, 8.0f, 4.0f)
 		[
 			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(0.0f, 0.0f, 6.0f, 0.0f)
+			[
+				SNew(SButton)
+				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+				.ContentPadding(FMargin(3.0f))
+				.ToolTipText(LOCTEXT("ToggleEditPanelTooltip", "編集パネルの表示切替 / Toggle the parameter edit panel."))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked)
+				[
+					SNew(SImage)
+					.Image(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon)
+				]
+			]
 			+ SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			.VAlign(VAlign_Center)
@@ -765,28 +987,64 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				})
 			]
 		]
-		// 凡例（系列ごとの表示切替チェックボックス）
-		+ SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(8.0f, 2.0f)
-		[
-			SNew(SWrapBox)
-			.UseAllottedSize(true)
-			.InnerSlotPadding(FVector2D(6.0f, 2.0f))
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[0])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[1])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[2])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[3])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[4])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[5])]
-			+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[6])]
-		]
-		// 波形グラフ本体
+		// 編集パネル・凡例・波形グラフ本体
 		+ SVerticalBox::Slot()
 		.FillHeight(1.0f)
-		.Padding(8.0f, 4.0f)
+		.Padding(8.0f, 2.0f, 8.0f, 4.0f)
 		[
-			SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+			SAssignNew(EditPanelSplitter, SSplitter)
+			.Orientation(Orient_Horizontal)
+			+ SSplitter::Slot()
+			.Value_Lambda([this]()
+			{
+				return EditPanelSplitterFraction;
+			})
+			.MinSize(220.0f)
+			.OnSlotResized(SSplitter::FOnSlotResized::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnEditPanelSlotResized))
+			[
+				SNew(SBorder)
+				.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
+				.Visibility(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelVisibility)
+				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::IsWindEditable)
+				.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+				[
+					SNew(SKawaiiPhysicsWindScopeEditPanel)
+					.EditValues(this, &SKawaiiPhysicsWindScopeWindow::GetEditValues)
+					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
+					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
+					.OnFocusNode(FSimpleDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked))
+					.OnHighlightSeries(this, &SKawaiiPhysicsWindScopeWindow::SetHighlightSeries)
+				]
+			]
+			+ SSplitter::Slot()
+			.Value_Lambda([this]()
+			{
+				return 1.0f - EditPanelSplitterFraction;
+			})
+			.MinSize(260.0f)
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
+				[
+					SNew(SWrapBox)
+					.UseAllottedSize(true)
+					.InnerSlotPadding(FVector2D(6.0f, 2.0f))
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[0])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[1])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[2])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[3])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[4])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[5])]
+					+ SWrapBox::Slot()[MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[6])]
+				]
+				+ SVerticalBox::Slot()
+				.FillHeight(1.0f)
+				[
+					SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+				]
+			]
 		]
 		+ SVerticalBox::Slot()
 		.AutoHeight()
@@ -857,6 +1115,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 
 SKawaiiPhysicsWindScopeWindow::~SKawaiiPhysicsWindScopeWindow()
 {
+	SaveEditPanelConfig();
 	ClearPendingReconnect();
 }
 
@@ -964,6 +1223,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	DisplaySamples.Reset();
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
+	bHasDragStartWind = false;
 	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
 	RefreshExternalForceItems();
 	if (HasTargetArgs())
@@ -991,6 +1251,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	DisplaySamples.Reset();
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
+	bHasDragStartWind = false;
 }
 
 FText SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText() const
@@ -1075,6 +1336,51 @@ void SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged(float NewValue)
 	}
 }
 
+bool SKawaiiPhysicsWindScopeWindow::IsEditPanelExpanded() const
+{
+	return bEditPanelExpanded;
+}
+
+EVisibility SKawaiiPhysicsWindScopeWindow::GetEditPanelVisibility() const
+{
+	return IsEditPanelExpanded() ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
+const FSlateBrush* SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon() const
+{
+	return FAppStyle::Get().GetBrush(IsEditPanelExpanded() ? TEXT("Icons.ChevronLeft") : TEXT("Icons.ChevronRight"));
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked()
+{
+	bEditPanelExpanded = !bEditPanelExpanded;
+	SaveEditPanelConfig();
+	return FReply::Handled();
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnEditPanelSlotResized(float NewFraction)
+{
+	EditPanelSplitterFraction = FMath::Clamp(NewFraction, 0.2f, 0.8f);
+}
+
+bool SKawaiiPhysicsWindScopeWindow::IsWindEditable() const
+{
+	return ResolveGraphNode() != nullptr;
+}
+
+const FKawaiiWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetEditValues() const
+{
+	return &CachedEditValues;
+}
+
+void SKawaiiPhysicsWindScopeWindow::SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries)
+{
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetHighlightSeries(InHighlightSeries);
+	}
+}
+
 void SKawaiiPhysicsWindScopeWindow::RebuildPresetButtons()
 {
 	CachedPresets = ResolveWindScopePresets();
@@ -1147,7 +1453,8 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 
 FKawaiiPhysics_ExternalForce_ProceduralWind* SKawaiiPhysicsWindScopeWindow::ResolveEditableWind(
 	UAnimGraphNode_KawaiiPhysics*& OutGraphNode,
-	int32& OutResolvedIndex)
+	int32& OutResolvedIndex,
+	bool bShowNotification)
 {
 	OutGraphNode = nullptr;
 	OutResolvedIndex = INDEX_NONE;
@@ -1156,9 +1463,12 @@ FKawaiiPhysics_ExternalForce_ProceduralWind* SKawaiiPhysicsWindScopeWindow::Reso
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	if (!GraphNode)
 	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetNoNode", "Failed to resolve the KawaiiPhysics graph node."),
-			SNotificationItem::CS_Fail);
+		if (bShowNotification)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("ApplyPresetNoNode", "Failed to resolve the KawaiiPhysics graph node."),
+				SNotificationItem::CS_Fail);
+		}
 		return nullptr;
 	}
 
@@ -1166,9 +1476,12 @@ FKawaiiPhysics_ExternalForce_ProceduralWind* SKawaiiPhysicsWindScopeWindow::Reso
 	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
 	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
 	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetNoWind", "No ProceduralWind external force was found."),
-			SNotificationItem::CS_Fail);
+		if (bShowNotification)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("ApplyPresetNoWind", "No ProceduralWind external force was found."),
+				SNotificationItem::CS_Fail);
+		}
 		return nullptr;
 	}
 
@@ -1176,9 +1489,12 @@ FKawaiiPhysics_ExternalForce_ProceduralWind* SKawaiiPhysicsWindScopeWindow::Reso
 		GraphNode->Node.ExternalForces[ResolvedIndex].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
 	if (!Wind)
 	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetInvalidWind", "The selected external force is not ProceduralWind."),
-			SNotificationItem::CS_Fail);
+		if (bShowNotification)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("ApplyPresetInvalidWind", "The selected external force is not ProceduralWind."),
+				SNotificationItem::CS_Fail);
+		}
 		return nullptr;
 	}
 
@@ -1223,10 +1539,165 @@ bool SKawaiiPhysicsWindScopeWindow::PushGustToLiveRuntime(
 	return true;
 }
 
+bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
+	FName PropertyName,
+	double NewValue,
+	int32 VectorComponentIndex,
+	EKawaiiWindEditPhase Phase)
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(
+		GraphNode,
+		ResolvedIndex,
+		Phase == EKawaiiWindEditPhase::Committed);
+	if (!Wind)
+	{
+		return false;
+	}
+	Args.ExternalForceIndex = ResolvedIndex;
+
+	FProperty* Property = FindProceduralWindProperty(PropertyName);
+	if (!Property)
+	{
+		if (Phase == EKawaiiWindEditPhase::Committed)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("EditWindParamPropertyMissing", "Failed to resolve the wind parameter property."),
+				SNotificationItem::CS_Fail);
+		}
+		return false;
+	}
+
+	if (Phase == EKawaiiWindEditPhase::Begin)
+	{
+		DragStartWind = *Wind;
+		DragStartPropertyName = PropertyName;
+		bHasDragStartWind = true;
+		return true;
+	}
+
+	if (Phase == EKawaiiWindEditPhase::Interactive)
+	{
+		if (!SetProceduralWindPropertyValue(*Wind, Property, NewValue, VectorComponentIndex))
+		{
+			return false;
+		}
+
+		FKawaiiProceduralWindDynamicParams Params;
+		if (Wind->BuildDynamicParamsForProperty(PropertyName, Params))
+		{
+			PushParamsToLiveRuntime(Params);
+		}
+		return true;
+	}
+
+	const bool bUseDragStartValue = bHasDragStartWind && DragStartPropertyName == PropertyName;
+	const FKawaiiPhysics_ExternalForce_ProceduralWind& CompareWind = bUseDragStartValue ? DragStartWind : *Wind;
+	if (IsProceduralWindPropertyValueEqualToEdit(CompareWind, Property, NewValue, VectorComponentIndex))
+	{
+		if (bUseDragStartValue)
+		{
+			CopyProceduralWindPropertyValue(*Wind, DragStartWind, Property);
+			FKawaiiProceduralWindDynamicParams Params;
+			if (Wind->BuildDynamicParamsForProperty(PropertyName, Params))
+			{
+				PushParamsToLiveRuntime(Params);
+			}
+		}
+		bHasDragStartWind = false;
+		return true;
+	}
+
+	if (bUseDragStartValue)
+	{
+		CopyProceduralWindPropertyValue(*Wind, DragStartWind, Property);
+	}
+
+	const FScopedTransaction Transaction(LOCTEXT("EditWindParameterTransaction", "Edit Kawaii Physics Wind Parameter"));
+	GraphNode->Modify();
+	if (!SetProceduralWindPropertyValue(*Wind, Property, NewValue, VectorComponentIndex))
+	{
+		bHasDragStartWind = false;
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("EditWindParamSetFailed", "Failed to update the wind parameter."),
+			SNotificationItem::CS_Fail);
+		return false;
+	}
+
+	MarkWindScopeGraphNodeModified(GraphNode);
+	Args.ExternalForceIndex = ResolvedIndex;
+	bHasDragStartWind = false;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	if (Wind->BuildDynamicParamsForProperty(PropertyName, Params))
+	{
+		PushParamsToLiveRuntime(Params);
+	}
+	return true;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
+	if (!Wind)
+	{
+		return false;
+	}
+
+	FProperty* Property = FindProceduralWindProperty(PropertyName);
+	if (!Property)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ResetWindParamPropertyMissing", "Failed to resolve the wind parameter property."),
+			SNotificationItem::CS_Fail);
+		return false;
+	}
+
+	static const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
+	const FScopedTransaction Transaction(LOCTEXT("EditWindParameterTransaction", "Edit Kawaii Physics Wind Parameter"));
+	GraphNode->Modify();
+	CopyProceduralWindPropertyValue(*Wind, DefaultWind, Property);
+	MarkWindScopeGraphNodeModified(GraphNode);
+	Args.ExternalForceIndex = ResolvedIndex;
+	bHasDragStartWind = false;
+
+	FKawaiiProceduralWindDynamicParams Params;
+	if (Wind->BuildDynamicParamsForProperty(PropertyName, Params))
+	{
+		PushParamsToLiveRuntime(Params);
+	}
+	return true;
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked()
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("FocusWindScopeNodeFailed", "Failed to resolve the KawaiiPhysics graph node."),
+			SNotificationItem::CS_Fail);
+		return;
+	}
+
+	FKismetEditorUtilities::BringKismetToFocusAttentionOnObject(GraphNode);
+}
+
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)
 {
 	(void)InCurrentTime;
 	TryResolvePendingReconnect(InDeltaTime);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind WindSnapshot;
+	bool bHasWindSnapshot = false;
+	if (bEditPanelExpanded)
+	{
+		bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
+		UpdateEditValuesFromWind(bHasWindSnapshot ? &WindSnapshot : nullptr);
+	}
 
 	if (bPaused)
 	{
@@ -1236,7 +1707,11 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 	// Live 取得に失敗したら（PIE/デバッグ対象なし等）Preview 波形を計算する
 	if (!TryUpdateFromLiveRuntime())
 	{
-		RebuildPreviewSamples(InDeltaTime);
+		if (!bHasWindSnapshot)
+		{
+			bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
+		}
+		RebuildPreviewSamples(InDeltaTime, bHasWindSnapshot ? &WindSnapshot : nullptr);
 		CurrentModeText = LOCTEXT("PreviewModeTick", "Preview");
 	}
 	else
@@ -1296,11 +1771,17 @@ void SKawaiiPhysicsWindScopeWindow::RefreshExternalForceItems()
 	}
 }
 
-void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
+void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(
+	float InDeltaTime,
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* WindSnapshot)
 {
 	// 対象の ProceduralWind 設定を取得できなければ（未選択・ノード未解決等）表示をクリア
 	FKawaiiPhysics_ExternalForce_ProceduralWind Wind;
-	if (!TryGetPreviewForceCopy(Wind))
+	if (WindSnapshot)
+	{
+		Wind = *WindSnapshot;
+	}
+	else if (!TryGetPreviewForceCopy(Wind))
 	{
 		DisplaySamples.Reset();
 		return;
@@ -1323,6 +1804,59 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(float InDeltaTime)
 		// で計算されるため、両者は同一基準で比較できる（実ボーンの LengthRateFromRoot による Wave 位相ずれは含まない）
 		ScopeSample.Sample = Wind.ComputeWindSample(SampleTime, 0.0f);
 		DisplaySamples.Add(ScopeSample);
+	}
+}
+
+void SKawaiiPhysicsWindScopeWindow::UpdateEditValuesFromWind(
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind)
+{
+	CachedEditValues = FKawaiiWindScopeEditValues();
+	if (!Wind)
+	{
+		return;
+	}
+
+	static const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
+	CachedEditValues.bValid = true;
+	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	{
+		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		{
+			FProperty* Property = FindProceduralWindProperty(Param.PropertyName);
+			if (!Property)
+			{
+				continue;
+			}
+
+			if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(Property))
+			{
+				if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+				{
+					CachedEditValues.bIsEnabled = BoolProperty->GetPropertyValue_InContainer(Wind);
+				}
+			}
+			else if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
+			{
+				CachedEditValues.FloatValues.Add(Param.PropertyName, FloatProperty->GetPropertyValue_InContainer(Wind));
+			}
+			else if (const FIntProperty* IntProperty = CastField<FIntProperty>(Property))
+			{
+				if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed))
+				{
+					CachedEditValues.RandomSeed = IntProperty->GetPropertyValue_InContainer(Wind);
+				}
+			}
+			else if (IsFVectorProperty(Property) &&
+				Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+			{
+				CachedEditValues.WindDirection = *Property->ContainerPtrToValuePtr<FVector>(Wind);
+			}
+
+			if (IsProceduralWindPropertyModifiedFromDefault(*Wind, DefaultWind, Property))
+			{
+				CachedEditValues.ModifiedFromDefault.Add(Param.PropertyName);
+			}
+		}
 	}
 }
 
@@ -1470,6 +2004,46 @@ void SKawaiiPhysicsWindScopeWindow::SaveLastTargetArgs(const FKawaiiPhysicsWindS
 		WindScopeConfigSectionName,
 		WindScopeLastForceIndexKey,
 		InArgs.ExternalForceIndex,
+		GEditorPerProjectIni);
+	GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+void SKawaiiPhysicsWindScopeWindow::LoadEditPanelConfig()
+{
+	if (!GConfig)
+	{
+		return;
+	}
+
+	GConfig->GetBool(
+		WindScopeConfigSectionName,
+		WindScopeEditPanelExpandedKey,
+		bEditPanelExpanded,
+		GEditorPerProjectIni);
+	GConfig->GetFloat(
+		WindScopeConfigSectionName,
+		WindScopeEditPanelSplitterFractionKey,
+		EditPanelSplitterFraction,
+		GEditorPerProjectIni);
+	EditPanelSplitterFraction = FMath::Clamp(EditPanelSplitterFraction, 0.2f, 0.8f);
+}
+
+void SKawaiiPhysicsWindScopeWindow::SaveEditPanelConfig() const
+{
+	if (!GConfig)
+	{
+		return;
+	}
+
+	GConfig->SetBool(
+		WindScopeConfigSectionName,
+		WindScopeEditPanelExpandedKey,
+		bEditPanelExpanded,
+		GEditorPerProjectIni);
+	GConfig->SetFloat(
+		WindScopeConfigSectionName,
+		WindScopeEditPanelSplitterFractionKey,
+		EditPanelSplitterFraction,
 		GEditorPerProjectIni);
 	GConfig->Flush(false, GEditorPerProjectIni);
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -389,6 +389,61 @@ namespace
 		return Sample;
 	}
 
+	void FillWindScopeEditValuesFromWind(
+		const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind,
+		FKawaiiWindScopeEditValues& OutValues,
+		const bool bTrackDefaultDiff)
+	{
+		OutValues = FKawaiiWindScopeEditValues();
+		if (!Wind)
+		{
+			return;
+		}
+
+		static const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
+		OutValues.bValid = true;
+		for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+		{
+			for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+			{
+				FProperty* Property = FindProceduralWindProperty(Param.PropertyName);
+				if (!Property)
+				{
+					continue;
+				}
+
+				if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(Property))
+				{
+					if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
+					{
+						OutValues.bIsEnabled = BoolProperty->GetPropertyValue_InContainer(Wind);
+					}
+				}
+				else if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
+				{
+					OutValues.FloatValues.Add(Param.PropertyName, FloatProperty->GetPropertyValue_InContainer(Wind));
+				}
+				else if (const FIntProperty* IntProperty = CastField<FIntProperty>(Property))
+				{
+					if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed))
+					{
+						OutValues.RandomSeed = IntProperty->GetPropertyValue_InContainer(Wind);
+					}
+				}
+				else if (IsFVectorProperty(Property) &&
+					Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+				{
+					OutValues.WindDirection = *Property->ContainerPtrToValuePtr<FVector>(Wind);
+				}
+
+				if (bTrackDefaultDiff && IsProceduralWindPropertyModifiedFromDefault(*Wind, DefaultWind, Property))
+				{
+					OutValues.ModifiedFromDefault.Add(Param.PropertyName);
+				}
+			}
+		}
+	}
+
 	FText FormatFloat2(float Value)
 	{
 		FNumberFormattingOptions Options;
@@ -1546,6 +1601,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				[
 					SNew(SKawaiiPhysicsWindScopeEditPanel)
 					.EditValues(this, &SKawaiiPhysicsWindScopeWindow::GetEditValues)
+					.LiveEditValues(this, &SKawaiiPhysicsWindScopeWindow::GetLiveEditValues)
 					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
 					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
 					.IsParamPinExposed(this, &SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed)
@@ -1765,6 +1821,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	DisplaySamples.Reset();
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
+	CachedLiveEditValues = FKawaiiWindScopeEditValues();
 	bHasDragStartWind = false;
 	if (GraphWidget.IsValid())
 	{
@@ -1798,6 +1855,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	DisplaySamples.Reset();
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
+	CachedLiveEditValues = FKawaiiWindScopeEditValues();
 	bHasDragStartWind = false;
 	if (GraphWidget.IsValid())
 	{
@@ -1923,6 +1981,11 @@ bool SKawaiiPhysicsWindScopeWindow::IsWindEditable() const
 const FKawaiiWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetEditValues() const
 {
 	return &CachedEditValues;
+}
+
+const FKawaiiWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetLiveEditValues() const
+{
+	return CachedLiveEditValues.bValid ? &CachedLiveEditValues : nullptr;
 }
 
 void SKawaiiPhysicsWindScopeWindow::SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries)
@@ -2603,6 +2666,7 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 	{
 		bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
 		UpdateEditValuesFromWind(bHasWindSnapshot ? &WindSnapshot : nullptr);
+		UpdateLiveEditValuesFromRuntime();
 	}
 
 	if (bPaused)
@@ -2716,54 +2780,26 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPreviewSamples(
 void SKawaiiPhysicsWindScopeWindow::UpdateEditValuesFromWind(
 	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind)
 {
-	CachedEditValues = FKawaiiWindScopeEditValues();
-	if (!Wind)
+	FillWindScopeEditValuesFromWind(Wind, CachedEditValues, true);
+}
+
+void SKawaiiPhysicsWindScopeWindow::UpdateLiveEditValuesFromRuntime()
+{
+	CachedLiveEditValues = FKawaiiWindScopeEditValues();
+
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* RuntimeWind = ResolveLiveProceduralWind(
+		GraphNode,
+		RuntimeNode,
+		Args.ExternalForceIndex);
+	if (!RuntimeWind)
 	{
 		return;
 	}
 
-	static const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
-	CachedEditValues.bValid = true;
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
-	{
-		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
-		{
-			FProperty* Property = FindProceduralWindProperty(Param.PropertyName);
-			if (!Property)
-			{
-				continue;
-			}
-
-			if (const FBoolProperty* BoolProperty = CastField<FBoolProperty>(Property))
-			{
-				if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
-				{
-					CachedEditValues.bIsEnabled = BoolProperty->GetPropertyValue_InContainer(Wind);
-				}
-			}
-			else if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
-			{
-				CachedEditValues.FloatValues.Add(Param.PropertyName, FloatProperty->GetPropertyValue_InContainer(Wind));
-			}
-			else if (const FIntProperty* IntProperty = CastField<FIntProperty>(Property))
-			{
-				if (Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed))
-				{
-					CachedEditValues.RandomSeed = IntProperty->GetPropertyValue_InContainer(Wind);
-				}
-			}
-			else if (IsFVectorProperty(Property) &&
-				Param.PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
-			{
-				CachedEditValues.WindDirection = *Property->ContainerPtrToValuePtr<FVector>(Wind);
-			}
-
-			if (IsProceduralWindPropertyModifiedFromDefault(*Wind, DefaultWind, Property))
-			{
-				CachedEditValues.ModifiedFromDefault.Add(Param.PropertyName);
-			}
-		}
-	}
+	// Worker スレッドが DynamicParams 反映で値を書き換える可能性があるが、表示専用の乖離ヒントなので torn-read を許容し Mutex は取得しない。
+	FillWindScopeEditValuesFromWind(RuntimeWind, CachedLiveEditValues, false);
 }
 
 bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -17,6 +17,7 @@
 #include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdUtils.h"
 #include "KawaiiPhysicsEdWindowUtils.h"
+#include "KawaiiPhysicsWindScopeStyle.h"
 #include "Kismet2/BlueprintEditorUtils.h"
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeLock.h"
@@ -96,15 +97,6 @@ namespace
 		return nullptr;
 	}
 
-	struct FKawaiiWindScopeComponentStyle
-	{
-		EKawaiiPhysicsWindScopeComponent Component;
-		FText Label;
-		FLinearColor Color;
-		float Thickness = 1.0f;
-		bool bDashed = false;
-	};
-
 	struct FKawaiiWindScopeRange
 	{
 		float MinTime = 0.0f;
@@ -112,22 +104,6 @@ namespace
 		float MinValue = -1.0f;
 		float MaxValue = 1.0f;
 	};
-
-	// 各波形成分の表示スタイル（色・凡例ラベル・線種）を定義する
-	const TArray<FKawaiiWindScopeComponentStyle>& GetWindScopeComponentStyles()
-	{
-		static const TArray<FKawaiiWindScopeComponentStyle> Styles =
-		{
-			{EKawaiiPhysicsWindScopeComponent::Total, LOCTEXT("TotalLabel", "Total"), FLinearColor::White, 2.0f, false},
-			{EKawaiiPhysicsWindScopeComponent::Steady, LOCTEXT("SteadyLabel", "Steady"), FLinearColor(1.0f, 0.48f, 0.08f), 1.0f, false},
-			{EKawaiiPhysicsWindScopeComponent::Oscillation, LOCTEXT("OscillationLabel", "Oscillation"), FLinearColor(1.0f, 0.86f, 0.05f), 1.0f, false},
-			{EKawaiiPhysicsWindScopeComponent::Wave, LOCTEXT("WaveLabel", "Wave"), FLinearColor(0.0f, 0.85f, 1.0f), 1.0f, false},
-			{EKawaiiPhysicsWindScopeComponent::Envelope, LOCTEXT("EnvelopeLabel", "Envelope"), FLinearColor(0.2f, 0.42f, 1.0f), 1.0f, true},
-			{EKawaiiPhysicsWindScopeComponent::Random, LOCTEXT("RandomLabel", "Random"), FLinearColor(1.0f, 0.25f, 0.78f), 1.0f, false},
-			{EKawaiiPhysicsWindScopeComponent::Gust, LOCTEXT("GustLabel", "Gust"), FLinearColor(1.0f, 0.12f, 0.08f), 1.0f, false},
-		};
-		return Styles;
-	}
 
 	// FKawaiiPhysicsProceduralWindSample から指定成分の値を取り出す
 	float GetWindScopeComponentValue(const FKawaiiPhysicsProceduralWindSample& Sample,
@@ -1131,33 +1107,11 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked(int32 PresetIndex)
 
 FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPreset& Preset)
 {
-	// 対象グラフノードを解決（失敗時は通知して終了）
-	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
-	if (!GraphNode)
-	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetNoNode", "Failed to resolve the KawaiiPhysics graph node."),
-			SNotificationItem::CS_Fail);
-		return FReply::Handled();
-	}
-
-	// ProceduralWind 外力を解決・型チェック
-	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
-	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
-	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetNoWind", "No ProceduralWind external force was found."),
-			SNotificationItem::CS_Fail);
-		return FReply::Handled();
-	}
-
-	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
-		GraphNode->Node.ExternalForces[ResolvedIndex].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
 	if (!Wind)
 	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("ApplyPresetInvalidWind", "The selected external force is not ProceduralWind."),
-			SNotificationItem::CS_Fail);
 		return FReply::Handled();
 	}
 
@@ -1174,7 +1128,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 	Args.ExternalForceIndex = ResolvedIndex;
 	// シミュレーションリセット回避のため PostEditChangeProperty / NotifyGraphNodePropertyChanged は呼ばず、
 	// ライブ側には PendingParams 経由で同じ値を送る
-	const bool bAppliedLive = PushPresetToLiveRuntime(Params);
+	const bool bAppliedLive = PushParamsToLiveRuntime(Params);
 
 	// 外力一覧を更新し、成功通知を表示
 	RefreshExternalForceItems();
@@ -1191,7 +1145,49 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 	return FReply::Handled();
 }
 
-bool SKawaiiPhysicsWindScopeWindow::PushPresetToLiveRuntime(
+FKawaiiPhysics_ExternalForce_ProceduralWind* SKawaiiPhysicsWindScopeWindow::ResolveEditableWind(
+	UAnimGraphNode_KawaiiPhysics*& OutGraphNode,
+	int32& OutResolvedIndex)
+{
+	OutGraphNode = nullptr;
+	OutResolvedIndex = INDEX_NONE;
+
+	// 対象グラフノードを解決（失敗時は通知して終了）
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetNoNode", "Failed to resolve the KawaiiPhysics graph node."),
+			SNotificationItem::CS_Fail);
+		return nullptr;
+	}
+
+	// ProceduralWind 外力を解決・型チェック
+	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
+	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetNoWind", "No ProceduralWind external force was found."),
+			SNotificationItem::CS_Fail);
+		return nullptr;
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		GraphNode->Node.ExternalForces[ResolvedIndex].GetMutablePtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	if (!Wind)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("ApplyPresetInvalidWind", "The selected external force is not ProceduralWind."),
+			SNotificationItem::CS_Fail);
+		return nullptr;
+	}
+
+	OutGraphNode = GraphNode;
+	OutResolvedIndex = ResolvedIndex;
+	return Wind;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::PushParamsToLiveRuntime(
 	const FKawaiiProceduralWindDynamicParams& Params)
 {
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -11,9 +11,11 @@
 #include "Engine/AssetManager.h"
 #include "Engine/StreamableManager.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Docking/TabManager.h"
 #include "Framework/Docking/WorkspaceItem.h"
 #include "HAL/CriticalSection.h"
+#include "HAL/PlatformApplicationMisc.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
 #include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdUtils.h"
@@ -34,6 +36,7 @@
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SComboBox.h"
 #include "Widgets/Input/SSpinBox.h"
 #include "Widgets/Layout/SBorder.h"
@@ -357,6 +360,25 @@ namespace
 		}
 
 		return FText::Format(LOCTEXT("WindPresetFallbackNameFormat", "Preset {0}"), FText::AsNumber(PresetIndex));
+	}
+
+	FKawaiiProceduralWindPreset MakeWindPresetFromCurrentWind(
+		const FKawaiiPhysics_ExternalForce_ProceduralWind& Wind)
+	{
+		FKawaiiProceduralWindPreset Preset;
+		Preset.SteadyForce = Wind.SteadyForce;
+		Preset.OscillationForce = Wind.OscillationForce;
+		Preset.OscillationPeriod = Wind.OscillationPeriod;
+		Preset.WaveAmplitude = Wind.WaveAmplitude;
+		Preset.WavePeriod = Wind.WavePeriod;
+		Preset.WaveSpatialOffset = Wind.WaveSpatialOffset;
+		Preset.EnvelopeMin = Wind.EnvelopeMin;
+		Preset.EnvelopeMax = Wind.EnvelopeMax;
+		Preset.EnvelopeFrequency = Wind.EnvelopeFrequency;
+		Preset.RandomForce = Wind.RandomForce;
+		Preset.RandomPeriod = Wind.RandomPeriod;
+		Preset.DirectionNoiseAngle = Wind.DirectionNoiseAngle;
+		return Preset;
 	}
 
 	// サンプルが無い時の初期表示値。Envelope=1にして Total=0（無風）を表すサンプルにする
@@ -1275,6 +1297,53 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 					return FReply::Handled();
 				})
 			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SComboButton)
+				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+				.ContentPadding(FMargin(6.0f, 2.0f))
+				.ToolTipText(LOCTEXT("SavePresetTooltip", "現在のパラメータをプリセットDataAssetへ保存します / Save current parameters to the preset DataAsset."))
+				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset)
+				.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu)
+				.ButtonContent()
+				[
+					SNew(STextBlock)
+					.Text(LOCTEXT("SavePresetButton", "Save as Preset"))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SButton)
+				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+				.ContentPadding(FMargin(3.0f))
+				.ToolTipText(LOCTEXT("CopyWindParametersTooltip", "現在のProceduralWindパラメータをコピー / Copy current ProceduralWind parameters."))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnCopyWindParametersClicked)
+				[
+					SNew(SImage)
+					.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Copy")))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SButton)
+				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+				.ContentPadding(FMargin(3.0f))
+				.ToolTipText(LOCTEXT("PasteWindParametersTooltip", "クリップボードからProceduralWindパラメータを貼り付け / Paste ProceduralWind parameters from the clipboard."))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked)
+				[
+					SNew(SImage)
+					.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Paste")))
+				]
+			]
 		]
 		// 編集パネル・凡例・波形グラフ本体
 		+ SVerticalBox::Slot()
@@ -1750,6 +1819,205 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 			              ? LOCTEXT("ApplyPresetSucceededLive", "Applied {0} wind preset. (live)")
 			              : LOCTEXT("ApplyPresetSucceededNodeOnly", "Applied {0} wind preset. (node only — no live target)"),
 			ResolveWindPresetDisplayName(Preset, PresetIndex)),
+		SNotificationItem::CS_Success);
+	return FReply::Handled();
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu()
+{
+	FMenuBuilder MenuBuilder(true, nullptr);
+	MenuBuilder.AddMenuEntry(
+		LOCTEXT("SavePresetAddNewMenu", "新規追加 / Add New Preset"),
+		LOCTEXT("SavePresetAddNewTooltip", "現在のパラメータを新しいプリセットとして追加します / Add current parameters as a new preset."),
+		FSlateIcon(),
+		FUIAction(FExecuteAction::CreateLambda([this]()
+		{
+			SaveCurrentWindAsPreset(INDEX_NONE);
+		})));
+
+	MenuBuilder.BeginSection(NAME_None, LOCTEXT("SavePresetOverwriteSection", "既存を上書き / Overwrite:"));
+	for (int32 PresetIndex = 0; PresetIndex < CachedPresets.Num(); ++PresetIndex)
+	{
+		MenuBuilder.AddMenuEntry(
+			ResolveWindPresetDisplayName(CachedPresets[PresetIndex], PresetIndex),
+			LOCTEXT("SavePresetOverwriteTooltip", "現在のパラメータでこのプリセットを上書きします / Overwrite this preset with current parameters."),
+			FSlateIcon(),
+			FUIAction(
+				FExecuteAction::CreateLambda([this, PresetIndex]()
+				{
+					SaveCurrentWindAsPreset(PresetIndex);
+				}),
+				FCanExecuteAction::CreateLambda([this, PresetIndex]()
+				{
+					if (const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset = ResolveWritablePresetDataAsset(false))
+					{
+						return PresetDataAsset->Presets.IsValidIndex(PresetIndex);
+					}
+					return false;
+				})));
+	}
+	MenuBuilder.EndSection();
+
+	return MenuBuilder.MakeWidget();
+}
+
+bool SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset() const
+{
+	const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>();
+	return Settings && !Settings->WindScopePresetDataAsset.IsNull() && IsWindEditable();
+}
+
+UKawaiiPhysicsWindPresetDataAsset* SKawaiiPhysicsWindScopeWindow::ResolveWritablePresetDataAsset(
+	bool bShowNotification) const
+{
+	const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>();
+	if (!Settings || Settings->WindScopePresetDataAsset.IsNull())
+	{
+		if (bShowNotification)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("SavePresetNoDataAsset", "プロジェクト設定で Wind Scope Preset Data Asset を設定してください / Set the Wind Scope Preset Data Asset in Project Settings first."),
+				SNotificationItem::CS_Fail);
+		}
+		return nullptr;
+	}
+
+	UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset = Settings->WindScopePresetDataAsset.LoadSynchronous();
+	if (!PresetDataAsset && bShowNotification)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("SavePresetLoadDataAssetFailed", "Failed to load the Wind Scope Preset Data Asset."),
+			SNotificationItem::CS_Fail);
+	}
+	return PresetDataAsset;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::SaveCurrentWindAsPreset(int32 PresetIndex)
+{
+	UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset = ResolveWritablePresetDataAsset(true);
+	if (!PresetDataAsset)
+	{
+		return false;
+	}
+
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
+	if (!Wind)
+	{
+		return false;
+	}
+
+	const bool bAddNewPreset = PresetIndex == INDEX_NONE;
+	if (!bAddNewPreset && !PresetDataAsset->Presets.IsValidIndex(PresetIndex))
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("SavePresetInvalidOverwriteTarget", "Failed to resolve the wind preset to overwrite."),
+			SNotificationItem::CS_Fail);
+		return false;
+	}
+
+	FKawaiiProceduralWindPreset Preset = MakeWindPresetFromCurrentWind(*Wind);
+	FText SavedPresetName;
+	const FScopedTransaction Transaction(LOCTEXT("SaveWindPresetTransaction", "Save Kawaii Physics Wind Preset"));
+	PresetDataAsset->Modify();
+	if (bAddNewPreset)
+	{
+		Preset.PresetName = FText::Format(
+			LOCTEXT("SavePresetCustomNameFormat", "Custom {0}"),
+			FText::AsNumber(PresetDataAsset->Presets.Num() + 1));
+		SavedPresetName = Preset.PresetName;
+		PresetDataAsset->Presets.Add(Preset);
+	}
+	else
+	{
+		FKawaiiProceduralWindPreset& TargetPreset = PresetDataAsset->Presets[PresetIndex];
+		SavedPresetName = ResolveWindPresetDisplayName(TargetPreset, PresetIndex);
+		Preset.PresetTag = TargetPreset.PresetTag;
+		Preset.PresetName = TargetPreset.PresetName;
+		TargetPreset = Preset;
+	}
+
+	PresetDataAsset->MarkPackageDirty();
+	Args.ExternalForceIndex = ResolvedIndex;
+	RebuildPresetButtons();
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
+		FText::Format(
+			bAddNewPreset
+				? LOCTEXT("SavePresetSucceededAdd", "Saved {0} wind preset.")
+				: LOCTEXT("SavePresetSucceededOverwrite", "Overwrote {0} wind preset."),
+			SavedPresetName),
+		SNotificationItem::CS_Success);
+	return true;
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnCopyWindParametersClicked()
+{
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
+	if (!Wind)
+	{
+		return FReply::Handled();
+	}
+
+	FString ClipboardText;
+	FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct()->ExportText(
+		ClipboardText,
+		Wind,
+		nullptr,
+		nullptr,
+		PPF_None,
+		nullptr);
+	FPlatformApplicationMisc::ClipboardCopy(*ClipboardText);
+	Args.ExternalForceIndex = ResolvedIndex;
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
+		LOCTEXT("CopyWindParametersSucceeded", "Copied ProceduralWind parameters to clipboard."),
+		SNotificationItem::CS_Success);
+	return FReply::Handled();
+}
+
+FReply SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked()
+{
+	FString ClipboardText;
+	FPlatformApplicationMisc::ClipboardPaste(ClipboardText);
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind PastedWind;
+	const UScriptStruct* WindStruct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
+	const TCHAR* ImportResult = WindStruct->ImportText(
+		*ClipboardText,
+		&PastedWind,
+		nullptr,
+		PPF_None,
+		nullptr,
+		WindStruct->GetName());
+	if (!ImportResult)
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("PasteWindParametersInvalidClipboard", "クリップボードに ProceduralWind パラメータがありません / Clipboard does not contain ProceduralWind parameters."),
+			SNotificationItem::CS_Fail);
+		return FReply::Handled();
+	}
+
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
+	if (!Wind)
+	{
+		return FReply::Handled();
+	}
+
+	const FScopedTransaction Transaction(LOCTEXT("PasteWindParametersTransaction", "Paste Kawaii Physics Wind Parameters"));
+	GraphNode->Modify();
+	*Wind = PastedWind;
+	MarkWindScopeGraphNodeModified(GraphNode);
+	Args.ExternalForceIndex = ResolvedIndex;
+	const bool bAppliedLive = PushParamsToLiveRuntime(Wind->BuildDynamicParamsSnapshot());
+	RefreshExternalForceItems();
+	KawaiiPhysicsEdWindowUtils::ShowNotification(
+		bAppliedLive
+			? LOCTEXT("PasteWindParametersSucceededLive", "Pasted ProceduralWind parameters. (live)")
+			: LOCTEXT("PasteWindParametersSucceededNodeOnly", "Pasted ProceduralWind parameters. (node only — no live target)"),
 		SNotificationItem::CS_Success);
 	return FReply::Handled();
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -59,7 +59,9 @@ namespace
 	constexpr float WindScopeDefaultGustStrength = 6.0f;
 	constexpr float WindScopeDefaultGustRiseTime = 0.1f;
 	constexpr float WindScopeDefaultGustDecayTime = 0.5f;
+	constexpr float WindScopePinExposureRefreshInterval = 1.0f;
 	constexpr float WindScopeReconnectTryLoadDelay = 5.0f;
+	const TCHAR* WindScopeClipboardMarker = TEXT("KawaiiPhysicsProceduralWind:");
 	const TCHAR* WindScopeConfigSectionName = TEXT("KawaiiPhysicsEd");
 	const TCHAR* WindScopeLastAnimBlueprintKey = TEXT("WindScopeLastAnimBlueprint");
 	const TCHAR* WindScopeLastNodeGuidKey = TEXT("WindScopeLastNodeGuid");
@@ -520,6 +522,7 @@ namespace
 		const FVector2D& GraphSize)
 	{
 		TArray<FVector2D> Points;
+		Points.Reserve(Samples.Num());
 		const float TimeSpan = FMath::Max(MaxTime - MinTime, KINDA_SMALL_NUMBER);
 		const float ValueSpan = FMath::Max(MaxValue - MinValue, KINDA_SMALL_NUMBER);
 
@@ -551,6 +554,7 @@ namespace
 		const FVector2D& GraphSize)
 	{
 		TArray<FVector2D> Points;
+		Points.Reserve(GhostSamples.Num());
 		const float TimeSpan = FMath::Max(MaxTime - MinTime, KINDA_SMALL_NUMBER);
 		const float ValueSpan = FMath::Max(MaxValue - MinValue, KINDA_SMALL_NUMBER);
 
@@ -596,6 +600,7 @@ namespace
 			{
 				const float DashEndOffset = FMath::Min(Offset + DashLength, SegmentLength);
 				TArray<FVector2D> DashPoints;
+				DashPoints.Reserve(2);
 				DashPoints.Add(Start + Direction * Offset);
 				DashPoints.Add(Start + Direction * DashEndOffset);
 				FSlateDrawElement::MakeLines(
@@ -819,7 +824,7 @@ FReply SKawaiiPhysicsWindScopeGraph::OnMouseMove(const FGeometry& MyGeometry, co
 {
 	HoverMousePosition = MyGeometry.AbsoluteToLocal(MouseEvent.GetScreenSpacePosition());
 	Invalidate(EInvalidateWidgetReason::Paint);
-	return FReply::Handled();
+	return FReply::Unhandled();
 }
 
 void SKawaiiPhysicsWindScopeGraph::OnMouseLeave(const FPointerEvent& MouseEvent)
@@ -868,6 +873,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	{
 		const float X = GraphOrigin.X + GraphSize.X * (static_cast<float>(GridIndex) / 4.0f);
 		TArray<FVector2D> VerticalLine;
+		VerticalLine.Reserve(2);
 		VerticalLine.Add(FVector2D(X, GraphOrigin.Y));
 		VerticalLine.Add(FVector2D(X, GraphOrigin.Y + GraphSize.Y));
 		FSlateDrawElement::MakeLines(
@@ -882,6 +888,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 
 		const float Y = GraphOrigin.Y + GraphSize.Y * (static_cast<float>(GridIndex) / 4.0f);
 		TArray<FVector2D> HorizontalLine;
+		HorizontalLine.Reserve(2);
 		HorizontalLine.Add(FVector2D(GraphOrigin.X, Y));
 		HorizontalLine.Add(FVector2D(GraphOrigin.X + GraphSize.X, Y));
 		FSlateDrawElement::MakeLines(
@@ -900,6 +907,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	{
 		const float ZeroY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((0.0f - Range.MinValue) / (Range.MaxValue - Range.MinValue)));
 		TArray<FVector2D> ZeroLine;
+		ZeroLine.Reserve(2);
 		ZeroLine.Add(FVector2D(GraphOrigin.X, ZeroY));
 		ZeroLine.Add(FVector2D(GraphOrigin.X + GraphSize.X, ZeroY));
 		FSlateDrawElement::MakeLines(
@@ -1025,6 +1033,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			}
 
 			TArray<FVector2D> GuideLine;
+			GuideLine.Reserve(2);
 			GuideLine.Add(FVector2D(X, GraphOrigin.Y));
 			GuideLine.Add(FVector2D(X, GraphBottom));
 			FSlateDrawElement::MakeLines(
@@ -1046,6 +1055,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			}
 
 			TArray<FVector2D> GuideLine;
+			GuideLine.Reserve(2);
 			GuideLine.Add(FVector2D(GraphOrigin.X, Y));
 			GuideLine.Add(FVector2D(GraphRight, Y));
 			FSlateDrawElement::MakeLines(
@@ -1220,6 +1230,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			}
 
 			TArray<FVector2D> CursorLine;
+			CursorLine.Reserve(2);
 			CursorLine.Add(FVector2D(CursorPosition.X, GraphOrigin.Y));
 			CursorLine.Add(FVector2D(CursorPosition.X, GraphBottom));
 			FSlateDrawElement::MakeLines(
@@ -1245,8 +1256,9 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			};
 
 			TArray<FCursorTextLine> CursorTextLines;
+			CursorTextLines.Reserve(1 + GetWindScopeComponentStyles().Num());
 			CursorTextLines.Emplace(
-				FString::Printf(TEXT("t=%.2fs"), Samples[ClosestIndex].Time),
+				FString::Printf(TEXT("t=%.2fs"), Samples[ClosestIndex].Time - Range.MaxTime),
 				FLinearColor(1.0f, 1.0f, 1.0f, 0.92f));
 			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 			{
@@ -1818,6 +1830,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	// 対象引数を差し替え、表示状態をリセットして外力一覧を再構築する
 	ResolvedGraphNodeCache.Reset();
 	Args = MoveTemp(InArgs);
+	ClearWindParamPinExposureCache();
 	DisplaySamples.Reset();
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
@@ -1851,6 +1864,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	(void)SelectInfo;
 	SelectedExternalForceItem = Item;
 	Args.ExternalForceIndex = Item.IsValid() ? *Item : INDEX_NONE;
+	ClearWindParamPinExposureCache();
 	// 選択切替時は別の外力の波形を混在させないよう表示状態を丸ごとリセットする
 	DisplaySamples.Reset();
 	LastLiveSampleCount = 0;
@@ -1964,6 +1978,10 @@ const FSlateBrush* SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon() const
 FReply SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked()
 {
 	bEditPanelExpanded = !bEditPanelExpanded;
+	if (bEditPanelExpanded)
+	{
+		ClearWindParamPinExposureCache();
+	}
 	SaveEditPanelConfig();
 	return FReply::Handled();
 }
@@ -2137,6 +2155,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu()
 		})));
 
 	MenuBuilder.BeginSection(NAME_None, LOCTEXT("SavePresetOverwriteSection", "既存を上書き / Overwrite:"));
+	UKawaiiPhysicsWindPresetDataAsset* WritablePresetDataAsset = ResolveWritablePresetDataAsset(false);
 	for (int32 PresetIndex = 0; PresetIndex < CachedPresets.Num(); ++PresetIndex)
 	{
 		MenuBuilder.AddMenuEntry(
@@ -2148,13 +2167,9 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu()
 				{
 					SaveCurrentWindAsPreset(PresetIndex);
 				}),
-				FCanExecuteAction::CreateLambda([this, PresetIndex]()
+				FCanExecuteAction::CreateLambda([WritablePresetDataAsset, PresetIndex]()
 				{
-					if (const UKawaiiPhysicsWindPresetDataAsset* PresetDataAsset = ResolveWritablePresetDataAsset(false))
-					{
-						return PresetDataAsset->Presets.IsValidIndex(PresetIndex);
-					}
-					return false;
+					return WritablePresetDataAsset && WritablePresetDataAsset->Presets.IsValidIndex(PresetIndex);
 				})));
 	}
 	MenuBuilder.EndSection();
@@ -2217,6 +2232,19 @@ bool SKawaiiPhysicsWindScopeWindow::SaveCurrentWindAsPreset(int32 PresetIndex)
 			SNotificationItem::CS_Fail);
 		return false;
 	}
+	if (!bAddNewPreset)
+	{
+		const FKawaiiProceduralWindPreset& TargetPreset = PresetDataAsset->Presets[PresetIndex];
+		if (!CachedPresets.IsValidIndex(PresetIndex) ||
+			!TargetPreset.PresetName.EqualTo(CachedPresets[PresetIndex].PresetName) ||
+			TargetPreset.PresetTag != CachedPresets[PresetIndex].PresetTag)
+		{
+			KawaiiPhysicsEdWindowUtils::ShowNotification(
+				LOCTEXT("SavePresetListChanged", "プリセット一覧が変更されています。Reload してください / Preset list has changed. Reload first."),
+				SNotificationItem::CS_Fail);
+			return false;
+		}
+	}
 
 	FKawaiiProceduralWindPreset Preset = MakeWindPresetFromCurrentWind(*Wind);
 	FText SavedPresetName;
@@ -2262,14 +2290,15 @@ FReply SKawaiiPhysicsWindScopeWindow::OnCopyWindParametersClicked()
 		return FReply::Handled();
 	}
 
-	FString ClipboardText;
+	FString ExportedText;
 	FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct()->ExportText(
-		ClipboardText,
+		ExportedText,
 		Wind,
 		nullptr,
 		nullptr,
 		PPF_None,
 		nullptr);
+	const FString ClipboardText = FString::Printf(TEXT("%s%s%s"), WindScopeClipboardMarker, LINE_TERMINATOR, *ExportedText);
 	FPlatformApplicationMisc::ClipboardCopy(*ClipboardText);
 	Args.ExternalForceIndex = ResolvedIndex;
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
@@ -2282,11 +2311,20 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked()
 {
 	FString ClipboardText;
 	FPlatformApplicationMisc::ClipboardPaste(ClipboardText);
+	if (!ClipboardText.StartsWith(WindScopeClipboardMarker))
+	{
+		KawaiiPhysicsEdWindowUtils::ShowNotification(
+			LOCTEXT("PasteWindParametersInvalidClipboard", "クリップボードに ProceduralWind パラメータがありません / Clipboard does not contain ProceduralWind parameters."),
+			SNotificationItem::CS_Fail);
+		return FReply::Handled();
+	}
+
+	const FString ImportText = ClipboardText.RightChop(FCString::Strlen(WindScopeClipboardMarker)).TrimStartAndEnd();
 
 	FKawaiiPhysics_ExternalForce_ProceduralWind PastedWind;
 	const UScriptStruct* WindStruct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
 	const TCHAR* ImportResult = WindStruct->ImportText(
-		*ClipboardText,
+		*ImportText,
 		&PastedWind,
 		nullptr,
 		PPF_None,
@@ -2572,6 +2610,33 @@ bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
 
 bool SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed(FName PropertyName) const
 {
+	if (const bool* bPinExposed = WindParamPinExposureCache.Find(PropertyName))
+	{
+		return *bPinExposed;
+	}
+	return false;
+}
+
+void SKawaiiPhysicsWindScopeWindow::ClearWindParamPinExposureCache()
+{
+	WindParamPinExposureCache.Reset();
+	WindParamPinExposureRefreshElapsedTime = WindScopePinExposureRefreshInterval;
+}
+
+void SKawaiiPhysicsWindScopeWindow::RefreshWindParamPinExposureCache()
+{
+	WindParamPinExposureCache.Reset();
+	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	{
+		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		{
+			WindParamPinExposureCache.Add(Param.PropertyName, ComputeWindParamPinExposure(Param.PropertyName));
+		}
+	}
+}
+
+bool SKawaiiPhysicsWindScopeWindow::ComputeWindParamPinExposure(FName PropertyName) const
+{
 	const UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	if (!GraphNode || PropertyName == NAME_None)
 	{
@@ -2601,6 +2666,8 @@ bool SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed(FName PropertyName) co
 	}
 
 	TArray<FString> CandidatePinNames;
+	CandidatePinNames.Reserve(
+		PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection) ? 10 : 4);
 	CandidatePinNames.Add(PropertyNameString);
 	CandidatePinNames.Add(FString::Printf(TEXT("%s_%s"), *ExternalForceElementPinName, *PropertyNameString));
 	CandidatePinNames.Add(FString::Printf(TEXT("%s.%s"), *ExternalForceElementPinName, *PropertyNameString));
@@ -2664,6 +2731,14 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 	bool bHasWindSnapshot = false;
 	if (bEditPanelExpanded)
 	{
+		WindParamPinExposureRefreshElapsedTime += InDeltaTime;
+		if (WindParamPinExposureCache.Num() == 0 ||
+			WindParamPinExposureRefreshElapsedTime >= WindScopePinExposureRefreshInterval)
+		{
+			RefreshWindParamPinExposureCache();
+			WindParamPinExposureRefreshElapsedTime = 0.0f;
+		}
+
 		bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
 		UpdateEditValuesFromWind(bHasWindSnapshot ? &WindSnapshot : nullptr);
 		UpdateLiveEditValuesFromRuntime();
@@ -2952,6 +3027,10 @@ void SKawaiiPhysicsWindScopeWindow::SaveLastTargetArgs(const FKawaiiPhysicsWindS
 
 void SKawaiiPhysicsWindScopeWindow::LoadEditPanelConfig()
 {
+	GustStrength = WindScopeDefaultGustStrength;
+	GustRiseTime = WindScopeDefaultGustRiseTime;
+	GustDecayTime = WindScopeDefaultGustDecayTime;
+
 	if (!GConfig)
 	{
 		return;
@@ -2968,9 +3047,6 @@ void SKawaiiPhysicsWindScopeWindow::LoadEditPanelConfig()
 		EditPanelSplitterFraction,
 		GEditorPerProjectIni);
 	EditPanelSplitterFraction = FMath::Clamp(EditPanelSplitterFraction, 0.2f, 0.8f);
-	GustStrength = WindScopeDefaultGustStrength;
-	GustRiseTime = WindScopeDefaultGustRiseTime;
-	GustDecayTime = WindScopeDefaultGustDecayTime;
 	GConfig->GetFloat(
 		WindScopeConfigSectionName,
 		WindScopeGustStrengthKey,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -17,6 +17,7 @@
 #include "Framework/Docking/WorkspaceItem.h"
 #include "HAL/CriticalSection.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "ISettingsModule.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
 #include "KawaiiPhysicsEdStyle.h"
 #include "KawaiiPhysicsEdUtils.h"
@@ -27,6 +28,7 @@
 #include "Kismet2/KismetEditorUtilities.h"
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeLock.h"
+#include "Modules/ModuleManager.h"
 #include "Rendering/DrawElements.h"
 #include "ScopedTransaction.h"
 #include "Styling/AppStyle.h"
@@ -1557,7 +1559,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				SNew(SComboButton)
 				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
 				.ContentPadding(FMargin(6.0f, 2.0f))
-				.ToolTipText(LOCTEXT("SavePresetTooltip", "現在のパラメータをプリセットDataAssetへ保存します / Save current parameters to the preset DataAsset."))
+				.ToolTipText(this, &SKawaiiPhysicsWindScopeWindow::GetSavePresetToolTipText)
 				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset)
 				.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu)
 				.ButtonContent()
@@ -2151,6 +2153,39 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 
 TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu()
 {
+	const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>();
+	if (!Settings || Settings->WindScopePresetDataAsset.IsNull())
+	{
+		FMenuBuilder MenuBuilder(true, nullptr);
+		const FText NoDataAssetText = LOCTEXT("SavePresetNoDataAssetMenuInfo", "プリセットを保存するにはプロジェクト設定で Wind Scope Preset Data Asset を設定してください / Set the Wind Scope Preset Data Asset in Project Settings to save presets.");
+		MenuBuilder.AddWidget(
+			SNew(SBox)
+			.MaxDesiredWidth(320.0f)
+			.Padding(FMargin(8.0f, 4.0f))
+			[
+				SNew(STextBlock)
+				.Text(NoDataAssetText)
+				.AutoWrapText(true)
+				.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+			],
+			FText::GetEmpty());
+		MenuBuilder.AddMenuEntry(
+			LOCTEXT("OpenProjectSettingsMenu", "プロジェクト設定を開く / Open Project Settings"),
+			LOCTEXT("OpenProjectSettingsTooltip", "Project Settings > Plugins > Kawaii Physics を開きます / Open Project Settings > Plugins > Kawaii Physics."),
+			FSlateIcon(),
+			FUIAction(FExecuteAction::CreateLambda([Settings]()
+			{
+				if (ISettingsModule* SettingsModule = FModuleManager::LoadModulePtr<ISettingsModule>("Settings"))
+				{
+					const FName SettingsSectionName = Settings
+						                                  ? Settings->GetSectionName()
+						                                  : UKawaiiPhysicsDeveloperSettings::StaticClass()->GetFName();
+					SettingsModule->ShowViewer("Project", "Plugins", SettingsSectionName);
+				}
+			})));
+		return MenuBuilder.MakeWidget();
+	}
+
 	FMenuBuilder MenuBuilder(true, nullptr);
 	MenuBuilder.AddMenuEntry(
 		LOCTEXT("SavePresetAddNewMenu", "新規追加 / Add New Preset"),
@@ -2187,7 +2222,18 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu()
 bool SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset() const
 {
 	const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>();
-	return Settings && !Settings->WindScopePresetDataAsset.IsNull() && IsWindEditable();
+	return Settings && IsWindEditable();
+}
+
+FText SKawaiiPhysicsWindScopeWindow::GetSavePresetToolTipText() const
+{
+	const UKawaiiPhysicsDeveloperSettings* Settings = GetDefault<UKawaiiPhysicsDeveloperSettings>();
+	if (!Settings || Settings->WindScopePresetDataAsset.IsNull())
+	{
+		return LOCTEXT("SavePresetNoDataAssetTooltip", "プリセットを保存するにはプロジェクト設定で Wind Scope Preset Data Asset を設定してください / Set the Wind Scope Preset Data Asset in Project Settings to save presets.");
+	}
+
+	return LOCTEXT("SavePresetTooltip", "現在のパラメータをプリセットDataAssetへ保存します / Save current parameters to the preset DataAsset.");
 }
 
 UKawaiiPhysicsWindPresetDataAsset* SKawaiiPhysicsWindScopeWindow::ResolveWritablePresetDataAsset(

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -988,6 +988,11 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			GraphSize);
 		if (GhostPoints.Num() >= 2)
 		{
+			const FPaintGeometry GhostClipGeometry = AllottedGeometry.ToPaintGeometry(
+				GraphSize,
+				FSlateLayoutTransform(GraphOrigin));
+			// ゴーストはYレンジ超過時にプロット矩形外へはみ出しうるためクリップする
+			OutDrawElements.PushClip(FSlateClippingZone(GhostClipGeometry));
 			DrawWindScopeDashedLine(
 				OutDrawElements,
 				LayerId + 4,
@@ -995,6 +1000,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 				GhostPoints,
 				FLinearColor(1.0f, 1.0f, 1.0f, 0.5f),
 				1.5f);
+			OutDrawElements.PopClip();
 		}
 	}
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -11,6 +11,7 @@
 #include "Engine/AssetManager.h"
 #include "Engine/StreamableManager.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "Framework/Application/SlateApplication.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Framework/Docking/TabManager.h"
 #include "Framework/Docking/WorkspaceItem.h"
@@ -2467,11 +2468,14 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		ClearActiveEditGuide();
 		return false;
 	};
+	const bool bHasMatchingDragStart = bHasDragStartWind && DragStartPropertyName == PropertyName;
+	const bool bApplyAsCommitted = Phase == EKawaiiWindEditPhase::Committed ||
+		(Phase == EKawaiiWindEditPhase::Interactive && !bHasMatchingDragStart);
 
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetActiveEditGuide(
-			Phase == EKawaiiWindEditPhase::Committed
+			bApplyAsCommitted
 				? TOptional<FName>()
 				: TOptional<FName>(PropertyName));
 	}
@@ -2481,7 +2485,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(
 		GraphNode,
 		ResolvedIndex,
-		Phase == EKawaiiWindEditPhase::Committed);
+		bApplyAsCommitted);
 	if (!Wind)
 	{
 		return FailEdit();
@@ -2491,7 +2495,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	FProperty* Property = FindProceduralWindProperty(PropertyName);
 	if (!Property)
 	{
-		if (Phase == EKawaiiWindEditPhase::Committed)
+		if (bApplyAsCommitted)
 		{
 			KawaiiPhysicsEdWindowUtils::ShowNotification(
 				LOCTEXT("EditWindParamPropertyMissing", "Failed to resolve the wind parameter property."),
@@ -2508,7 +2512,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		return true;
 	}
 
-	if (Phase == EKawaiiWindEditPhase::Interactive)
+	if (Phase == EKawaiiWindEditPhase::Interactive && bHasMatchingDragStart)
 	{
 		if (!SetProceduralWindPropertyValue(*Wind, Property, NewValue, VectorComponentIndex))
 		{
@@ -2523,7 +2527,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		return true;
 	}
 
-	const bool bUseDragStartValue = bHasDragStartWind && DragStartPropertyName == PropertyName;
+	const bool bUseDragStartValue = bHasMatchingDragStart;
 	const FKawaiiPhysics_ExternalForce_ProceduralWind& CompareWind = bUseDragStartValue ? DragStartWind : *Wind;
 	if (IsProceduralWindPropertyValueEqualToEdit(CompareWind, Property, NewValue, VectorComponentIndex))
 	{
@@ -2566,6 +2570,71 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		PushParamsToLiveRuntime(Params);
 	}
 	return true;
+}
+
+void SKawaiiPhysicsWindScopeWindow::FinalizeAbandonedWindDrag()
+{
+	const auto ClearActiveEditGuide = [this]()
+	{
+		if (GraphWidget.IsValid())
+		{
+			GraphWidget->SetActiveEditGuide(TOptional<FName>());
+		}
+	};
+
+	if (!bHasDragStartWind)
+	{
+		return;
+	}
+
+	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
+	int32 ResolvedIndex = INDEX_NONE;
+	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex, false);
+	if (!Wind)
+	{
+		bHasDragStartWind = false;
+		ClearActiveEditGuide();
+		return;
+	}
+
+	FProperty* Property = FindProceduralWindProperty(DragStartPropertyName);
+	if (!Property)
+	{
+		bHasDragStartWind = false;
+		ClearActiveEditGuide();
+		return;
+	}
+
+	if (Property->Identical_InContainer(Wind, &DragStartWind))
+	{
+		bHasDragStartWind = false;
+		ClearActiveEditGuide();
+		return;
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind DraggedWind = DragStartWind;
+	if (!CopyProceduralWindPropertyValue(DraggedWind, *Wind, Property))
+	{
+		bHasDragStartWind = false;
+		ClearActiveEditGuide();
+		return;
+	}
+
+	CopyProceduralWindPropertyValue(*Wind, DragStartWind, Property);
+
+	const FScopedTransaction Transaction(LOCTEXT("EditWindParameterTransaction", "Edit Kawaii Physics Wind Parameter"));
+	GraphNode->Modify();
+	CopyProceduralWindPropertyValue(*Wind, DraggedWind, Property);
+	MarkWindScopeGraphNodeModified(GraphNode);
+	Args.ExternalForceIndex = ResolvedIndex;
+	bHasDragStartWind = false;
+	ClearActiveEditGuide();
+
+	FKawaiiProceduralWindDynamicParams Params;
+	if (Wind->BuildDynamicParamsForProperty(DragStartPropertyName, Params))
+	{
+		PushParamsToLiveRuntime(Params);
+	}
 }
 
 bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
@@ -2725,6 +2794,11 @@ void SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked()
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)
 {
 	(void)InCurrentTime;
+	if (bHasDragStartWind && !FSlateApplication::Get().HasAnyMouseCaptor())
+	{
+		FinalizeAbandonedWindDrag();
+	}
+
 	TryResolvePendingReconnect(InDeltaTime);
 
 	FKawaiiPhysics_ExternalForce_ProceduralWind WindSnapshot;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -1345,21 +1345,6 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		[
 			SNew(SHorizontalBox)
 			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(0.0f, 0.0f, 6.0f, 0.0f)
-			[
-				SNew(SButton)
-				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
-				.ContentPadding(FMargin(3.0f))
-				.ToolTipText(LOCTEXT("ToggleEditPanelTooltip", "編集パネルの表示切替 / Toggle the parameter edit panel."))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked)
-				[
-					SNew(SImage)
-					.Image(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon)
-				]
-			]
-			+ SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			.VAlign(VAlign_Center)
 			[
@@ -1398,6 +1383,21 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				SNew(STextBlock)
 				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetModeText)
 				.ColorAndOpacity(FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen")))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(8.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SButton)
+				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
+				.ContentPadding(FMargin(3.0f))
+				.ToolTipText(LOCTEXT("ToggleEditPanelTooltip", "編集パネルの表示切替 / Toggle the parameter edit panel."))
+				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked)
+				[
+					SNew(SImage)
+					.Image(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon)
+				]
 			]
 		]
 		// プリセットボタン列
@@ -1599,37 +1599,13 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				]
 			]
 		]
-		// 編集パネル・凡例・波形グラフ本体
+		// 凡例・波形グラフ本体・編集パネル
 		+ SVerticalBox::Slot()
 		.FillHeight(1.0f)
 		.Padding(8.0f, 2.0f, 8.0f, 4.0f)
 		[
 			SAssignNew(EditPanelSplitter, SSplitter)
 			.Orientation(Orient_Horizontal)
-			+ SSplitter::Slot()
-			.Value_Lambda([this]()
-			{
-				return EditPanelSplitterFraction;
-			})
-			.MinSize(220.0f)
-			.OnSlotResized(SSplitter::FOnSlotResized::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnEditPanelSlotResized))
-			[
-				SNew(SBorder)
-				.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
-				.Visibility(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelVisibility)
-				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::IsWindEditable)
-				.Padding(0.0f, 0.0f, 8.0f, 0.0f)
-				[
-					SNew(SKawaiiPhysicsWindScopeEditPanel)
-					.EditValues(this, &SKawaiiPhysicsWindScopeWindow::GetEditValues)
-					.LiveEditValues(this, &SKawaiiPhysicsWindScopeWindow::GetLiveEditValues)
-					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
-					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
-					.IsParamPinExposed(this, &SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed)
-					.OnFocusNode(FSimpleDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked))
-					.OnHighlightSeries(this, &SKawaiiPhysicsWindScopeWindow::SetHighlightSeries)
-				]
-			]
 			+ SSplitter::Slot()
 			.Value_Lambda([this]()
 			{
@@ -1657,6 +1633,30 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.FillHeight(1.0f)
 				[
 					SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+				]
+			]
+			+ SSplitter::Slot()
+			.Value_Lambda([this]()
+			{
+				return EditPanelSplitterFraction;
+			})
+			.MinSize(220.0f)
+			.OnSlotResized(SSplitter::FOnSlotResized::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnEditPanelSlotResized))
+			[
+				SNew(SBorder)
+				.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
+				.Visibility(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelVisibility)
+				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::IsWindEditable)
+				.Padding(8.0f, 0.0f, 0.0f, 0.0f)
+				[
+					SNew(SKawaiiPhysicsWindScopeEditPanel)
+					.EditValues(this, &SKawaiiPhysicsWindScopeWindow::GetEditValues)
+					.LiveEditValues(this, &SKawaiiPhysicsWindScopeWindow::GetLiveEditValues)
+					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
+					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
+					.IsParamPinExposed(this, &SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed)
+					.OnFocusNode(FSimpleDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked))
+					.OnHighlightSeries(this, &SKawaiiPhysicsWindScopeWindow::SetHighlightSeries)
 				]
 			]
 		]
@@ -1981,7 +1981,7 @@ EVisibility SKawaiiPhysicsWindScopeWindow::GetEditPanelVisibility() const
 
 const FSlateBrush* SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon() const
 {
-	return FAppStyle::Get().GetBrush(IsEditPanelExpanded() ? TEXT("Icons.ChevronLeft") : TEXT("Icons.ChevronRight"));
+	return FAppStyle::Get().GetBrush(IsEditPanelExpanded() ? TEXT("Icons.ChevronRight") : TEXT("Icons.ChevronLeft"));
 }
 
 FReply SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -486,6 +486,35 @@ namespace
 		return Points;
 	}
 
+	static TArray<FVector2D> BuildWindScopeGhostPolylinePoints(
+		const TArray<FVector2D>& GhostSamples,
+		float MinTime,
+		float MaxTime,
+		float MinValue,
+		float MaxValue,
+		const FVector2D& GraphOrigin,
+		const FVector2D& GraphSize)
+	{
+		TArray<FVector2D> Points;
+		const float TimeSpan = FMath::Max(MaxTime - MinTime, KINDA_SMALL_NUMBER);
+		const float ValueSpan = FMath::Max(MaxValue - MinValue, KINDA_SMALL_NUMBER);
+
+		for (const FVector2D& SamplePoint : GhostSamples)
+		{
+			if (SamplePoint.X < MinTime || SamplePoint.X > MaxTime)
+			{
+				continue;
+			}
+
+			const float XRate = (SamplePoint.X - MinTime) / TimeSpan;
+			const float YRate = (SamplePoint.Y - MinValue) / ValueSpan;
+			Points.Add(FVector2D(
+				GraphOrigin.X + GraphSize.X * XRate,
+				GraphOrigin.Y + GraphSize.Y * (1.0f - YRate)));
+		}
+		return Points;
+	}
+
 	// セグメントごとに Dash/Gap を繰り返して破線を描画する
 	void DrawWindScopeDashedLine(FSlateWindowElementList& OutDrawElements,
 	                             int32 LayerId,
@@ -725,6 +754,26 @@ void SKawaiiPhysicsWindScopeGraph::SetEditValues(const FKawaiiWindScopeEditValue
 	Invalidate(EInvalidateWidgetReason::Paint);
 }
 
+void SKawaiiPhysicsWindScopeGraph::SetGhostSamples(TArray<FVector2D> InGhostSamples)
+{
+	GhostSamples = MoveTemp(InGhostSamples);
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+FReply SKawaiiPhysicsWindScopeGraph::OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	HoverMousePosition = MyGeometry.AbsoluteToLocal(MouseEvent.GetScreenSpacePosition());
+	Invalidate(EInvalidateWidgetReason::Paint);
+	return FReply::Handled();
+}
+
+void SKawaiiPhysicsWindScopeGraph::OnMouseLeave(const FPointerEvent& MouseEvent)
+{
+	(void)MouseEvent;
+	HoverMousePosition.Reset();
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
 int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
                                             const FGeometry& AllottedGeometry,
                                             const FSlateRect& MyCullingRect,
@@ -860,6 +909,28 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 				DrawColor,
 				true,
 				DrawThickness);
+		}
+	}
+
+	if (GhostSamples.Num() >= 2)
+	{
+		const TArray<FVector2D> GhostPoints = BuildWindScopeGhostPolylinePoints(
+			GhostSamples,
+			Range.MinTime,
+			Range.MaxTime,
+			Range.MinValue,
+			Range.MaxValue,
+			GraphOrigin,
+			GraphSize);
+		if (GhostPoints.Num() >= 2)
+		{
+			DrawWindScopeDashedLine(
+				OutDrawElements,
+				LayerId + 4,
+				AllottedGeometry,
+				GhostPoints,
+				FLinearColor(1.0f, 1.0f, 1.0f, 0.5f),
+				1.5f);
 		}
 	}
 
@@ -1060,7 +1131,114 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	DrawAxisText(FString::Printf(TEXT("-%.0fs"), DisplaySeconds), FVector2D(GraphOrigin.X, GraphOrigin.Y + GraphSize.Y + 4.0f));
 	DrawAxisText(TEXT("0s"), FVector2D(GraphOrigin.X + GraphSize.X - 24.0f, GraphOrigin.Y + GraphSize.Y + 4.0f));
 
-	return LayerId + 7;
+	if (HoverMousePosition.IsSet() && Samples.Num() > 0)
+	{
+		const FVector2D CursorPosition = HoverMousePosition.GetValue();
+		const float GraphRight = GraphOrigin.X + GraphSize.X;
+		const float GraphBottom = GraphOrigin.Y + GraphSize.Y;
+		if (CursorPosition.X >= GraphOrigin.X && CursorPosition.X <= GraphRight &&
+			CursorPosition.Y >= GraphOrigin.Y && CursorPosition.Y <= GraphBottom)
+		{
+			const float TimeSpan = FMath::Max(Range.MaxTime - Range.MinTime, KINDA_SMALL_NUMBER);
+			const float CursorTime = Range.MinTime + TimeSpan * ((CursorPosition.X - GraphOrigin.X) / GraphSize.X);
+
+			int32 LowerIndex = 0;
+			int32 UpperIndex = Samples.Num();
+			while (LowerIndex < UpperIndex)
+			{
+				const int32 MiddleIndex = LowerIndex + (UpperIndex - LowerIndex) / 2;
+				if (Samples[MiddleIndex].Time < CursorTime)
+				{
+					LowerIndex = MiddleIndex + 1;
+				}
+				else
+				{
+					UpperIndex = MiddleIndex;
+				}
+			}
+
+			int32 ClosestIndex = FMath::Clamp(LowerIndex, 0, Samples.Num() - 1);
+			if (ClosestIndex > 0 &&
+				FMath::Abs(Samples[ClosestIndex - 1].Time - CursorTime) < FMath::Abs(Samples[ClosestIndex].Time - CursorTime))
+			{
+				--ClosestIndex;
+			}
+
+			TArray<FVector2D> CursorLine;
+			CursorLine.Add(FVector2D(CursorPosition.X, GraphOrigin.Y));
+			CursorLine.Add(FVector2D(CursorPosition.X, GraphBottom));
+			FSlateDrawElement::MakeLines(
+				OutDrawElements,
+				LayerId + 7,
+				AllottedGeometry.ToPaintGeometry(),
+				CursorLine,
+				ESlateDrawEffect::None,
+				FLinearColor(1.0f, 1.0f, 1.0f, 0.32f),
+				true,
+				1.0f);
+
+			struct FCursorTextLine
+			{
+				FString Text;
+				FLinearColor Color;
+
+				FCursorTextLine(const FString& InText, const FLinearColor& InColor)
+					: Text(InText)
+					, Color(InColor)
+				{
+				}
+			};
+
+			TArray<FCursorTextLine> CursorTextLines;
+			CursorTextLines.Emplace(
+				FString::Printf(TEXT("t=%.2fs"), Samples[ClosestIndex].Time),
+				FLinearColor(1.0f, 1.0f, 1.0f, 0.92f));
+			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+			{
+				if (!Visibility.IsVisible(Style.Component))
+				{
+					continue;
+				}
+
+				FLinearColor TextColor = Style.Color;
+				TextColor.A = FMath::Max(TextColor.A, 0.9f);
+				const FString LabelString = Style.Label.ToString();
+				CursorTextLines.Emplace(
+					FString::Printf(TEXT("%s %.2f"), *LabelString, GetWindScopeComponentValue(Samples[ClosestIndex].Sample, Style.Component)),
+					TextColor);
+			}
+
+			const FSlateFontInfo CursorFont(FCoreStyle::GetDefaultFont(), 9);
+			constexpr float CursorTextWidth = 128.0f;
+			constexpr float CursorTextHeight = 13.0f;
+			const float PreferredTextX = CursorPosition.X + CursorTextWidth + 8.0f > GraphRight
+				                           ? CursorPosition.X - CursorTextWidth - 8.0f
+				                           : CursorPosition.X + 8.0f;
+			const float TextX = FMath::Clamp(
+				PreferredTextX,
+				GraphOrigin.X,
+				FMath::Max(GraphOrigin.X, GraphRight - CursorTextWidth));
+			const float TextY = FMath::Clamp(
+				CursorPosition.Y - CursorTextHeight * CursorTextLines.Num() - 4.0f,
+				GraphOrigin.Y,
+				FMath::Max(GraphOrigin.Y, GraphBottom - CursorTextHeight * CursorTextLines.Num()));
+			for (int32 LineIndex = 0; LineIndex < CursorTextLines.Num(); ++LineIndex)
+			{
+				FSlateDrawElement::MakeText(
+					OutDrawElements,
+					LayerId + 8,
+					AllottedGeometry.ToPaintGeometry(
+						FVector2D(CursorTextWidth, CursorTextHeight),
+						FSlateLayoutTransform(FVector2D(TextX, TextY + CursorTextHeight * LineIndex))),
+					CursorTextLines[LineIndex].Text,
+					CursorFont,
+					ESlateDrawEffect::None,
+					CursorTextLines[LineIndex].Color);
+			}
+		}
+	}
+
+	return LayerId + 9;
 }
 
 FVector2D SKawaiiPhysicsWindScopeGraph::ComputeDesiredSize(float LayoutScaleMultiplier) const
@@ -1591,6 +1769,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetActiveEditGuide(TOptional<FName>());
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
 	}
 	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
 	RefreshExternalForceItems();
@@ -1623,6 +1802,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetActiveEditGuide(TOptional<FName>());
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
 	}
 }
 
@@ -1761,6 +1941,11 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPresetButtons()
 		return;
 	}
 
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
+	}
+
 	PresetButtonBox->ClearChildren();
 	for (int32 PresetIndex = 0; PresetIndex < CachedPresets.Num(); ++PresetIndex)
 	{
@@ -1769,6 +1954,14 @@ void SKawaiiPhysicsWindScopeWindow::RebuildPresetButtons()
 			SNew(SButton)
 			.Text(ResolveWindPresetDisplayName(CachedPresets[PresetIndex], PresetIndex))
 			.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked, PresetIndex)
+			.OnHovered_Lambda([this, PresetIndex]()
+			{
+				OnPresetButtonHovered(PresetIndex);
+			})
+			.OnUnhovered_Lambda([this]()
+			{
+				OnPresetButtonUnhovered();
+			})
 		];
 	}
 }
@@ -1781,6 +1974,51 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked(int32 PresetIndex)
 	}
 
 	return ApplyPreset(CachedPresets[PresetIndex]);
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnPresetButtonHovered(int32 PresetIndex)
+{
+	if (!GraphWidget.IsValid())
+	{
+		return;
+	}
+
+	if (!CachedPresets.IsValidIndex(PresetIndex))
+	{
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
+		return;
+	}
+
+	FKawaiiPhysics_ExternalForce_ProceduralWind PreviewWind;
+	if (!TryGetPreviewForceCopy(PreviewWind))
+	{
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
+		return;
+	}
+
+	PreviewWind.ApplyDynamicParams(CachedPresets[PresetIndex].ToDynamicParams());
+
+	TArray<FVector2D> NewGhostSamples;
+	NewGhostSamples.Reserve(WindScopePreviewSampleCount);
+	const float EndTime = DisplaySamples.Num() > 0 ? DisplaySamples.Last().Time : PreviewTime;
+	const float StartTime = EndTime - DisplaySeconds;
+	const int32 SampleCount = FMath::Max(WindScopePreviewSampleCount, 2);
+	for (int32 SampleIndex = 0; SampleIndex < SampleCount; ++SampleIndex)
+	{
+		const float Alpha = static_cast<float>(SampleIndex) / static_cast<float>(SampleCount - 1);
+		const float SampleTime = FMath::Lerp(StartTime, EndTime, Alpha);
+		NewGhostSamples.Add(FVector2D(SampleTime, PreviewWind.ComputeWindSample(SampleTime, 0.0f).Total));
+	}
+
+	GraphWidget->SetGhostSamples(MoveTemp(NewGhostSamples));
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnPresetButtonUnhovered()
+{
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetGhostSamples(TArray<FVector2D>());
+	}
 }
 
 FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPreset& Preset)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -7,6 +7,7 @@
 #include "Animation/AnimInstance.h"
 #include "EdGraph/EdGraph.h"
 #include "EdGraph/EdGraphNode.h"
+#include "EdGraph/EdGraphPin.h"
 #include "Engine/AssetManager.h"
 #include "Engine/StreamableManager.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
@@ -52,9 +53,9 @@ namespace
 	constexpr float WindScopeGraphPaddingTop = 12.0f;
 	constexpr float WindScopeGraphPaddingRight = 12.0f;
 	constexpr float WindScopeGraphPaddingBottom = 24.0f;
-	constexpr float WindScopeGustStrength = 6.0f;
-	constexpr float WindScopeGustRiseTime = 0.1f;
-	constexpr float WindScopeGustDecayTime = 0.5f;
+	constexpr float WindScopeDefaultGustStrength = 6.0f;
+	constexpr float WindScopeDefaultGustRiseTime = 0.1f;
+	constexpr float WindScopeDefaultGustDecayTime = 0.5f;
 	constexpr float WindScopeReconnectTryLoadDelay = 5.0f;
 	const TCHAR* WindScopeConfigSectionName = TEXT("KawaiiPhysicsEd");
 	const TCHAR* WindScopeLastAnimBlueprintKey = TEXT("WindScopeLastAnimBlueprint");
@@ -62,6 +63,9 @@ namespace
 	const TCHAR* WindScopeLastForceIndexKey = TEXT("WindScopeLastForceIndex");
 	const TCHAR* WindScopeEditPanelExpandedKey = TEXT("WindScopeEditPanelExpanded");
 	const TCHAR* WindScopeEditPanelSplitterFractionKey = TEXT("WindScopeEditPanelSplitterFraction");
+	const TCHAR* WindScopeGustStrengthKey = TEXT("WindScopeGustStrength");
+	const TCHAR* WindScopeGustRiseTimeKey = TEXT("WindScopeGustRiseTime");
+	const TCHAR* WindScopeGustDecayTimeKey = TEXT("WindScopeGustDecayTime");
 
 	TWeakPtr<SDockTab> KawaiiWindScopeTabWeak;
 	TWeakPtr<SKawaiiPhysicsWindScopeWindow> KawaiiWindScopeWidgetWeak;
@@ -687,6 +691,18 @@ void SKawaiiPhysicsWindScopeGraph::SetHighlightSeries(TOptional<EKawaiiPhysicsWi
 	Invalidate(EInvalidateWidgetReason::Paint);
 }
 
+void SKawaiiPhysicsWindScopeGraph::SetActiveEditGuide(TOptional<FName> PropertyName)
+{
+	ActiveEditGuide = PropertyName;
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
+void SKawaiiPhysicsWindScopeGraph::SetEditValues(const FKawaiiWindScopeEditValues* InEditValues)
+{
+	EditValues = InEditValues;
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
 int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
                                             const FGeometry& AllottedGeometry,
                                             const FSlateRect& MyCullingRect,
@@ -825,12 +841,186 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		}
 	}
 
+	if (ActiveEditGuide.IsSet() && EditValues && EditValues->bValid)
+	{
+		const FName PropertyName = ActiveEditGuide.GetValue();
+		const float TimeSpan = FMath::Max(Range.MaxTime - Range.MinTime, KINDA_SMALL_NUMBER);
+		const float ValueSpan = FMath::Max(Range.MaxValue - Range.MinValue, KINDA_SMALL_NUMBER);
+		const float GraphBottom = GraphOrigin.Y + GraphSize.Y;
+		const float GraphRight = GraphOrigin.X + GraphSize.X;
+		const FLinearColor GuideLineColor(1.0f, 0.74f, 0.16f, 0.5f);
+		const FLinearColor GuideBandColor(1.0f, 0.74f, 0.16f, 0.12f);
+
+		const auto GetFloatEditValue = [this](const FName InPropertyName, float& OutValue)
+		{
+			if (const float* Value = EditValues->FloatValues.Find(InPropertyName))
+			{
+				OutValue = *Value;
+				return true;
+			}
+			return false;
+		};
+		const auto TimeToX = [&](const float Time)
+		{
+			return GraphOrigin.X + GraphSize.X * ((Time - Range.MinTime) / TimeSpan);
+		};
+		const auto ValueToY = [&](const float Value)
+		{
+			return GraphOrigin.Y + GraphSize.Y * (1.0f - ((Value - Range.MinValue) / ValueSpan));
+		};
+		const auto DrawVerticalGuideLine = [&](const float Time, const FLinearColor& Color)
+		{
+			const float X = TimeToX(Time);
+			if (X < GraphOrigin.X || X > GraphRight)
+			{
+				return;
+			}
+
+			TArray<FVector2D> GuideLine;
+			GuideLine.Add(FVector2D(X, GraphOrigin.Y));
+			GuideLine.Add(FVector2D(X, GraphBottom));
+			FSlateDrawElement::MakeLines(
+				OutDrawElements,
+				LayerId + 5,
+				AllottedGeometry.ToPaintGeometry(),
+				GuideLine,
+				ESlateDrawEffect::None,
+				Color,
+				true,
+				1.0f);
+		};
+		const auto DrawHorizontalGuideLine = [&](const float Value, const FLinearColor& Color)
+		{
+			const float Y = ValueToY(Value);
+			if (Y < GraphOrigin.Y || Y > GraphBottom)
+			{
+				return;
+			}
+
+			TArray<FVector2D> GuideLine;
+			GuideLine.Add(FVector2D(GraphOrigin.X, Y));
+			GuideLine.Add(FVector2D(GraphRight, Y));
+			FSlateDrawElement::MakeLines(
+				OutDrawElements,
+				LayerId + 5,
+				AllottedGeometry.ToPaintGeometry(),
+				GuideLine,
+				ESlateDrawEffect::None,
+				Color,
+				true,
+				1.0f);
+		};
+		const auto DrawPeriodGuideLines = [&](const float Period)
+		{
+			if (Period <= KINDA_SMALL_NUMBER)
+			{
+				return;
+			}
+
+			const int32 GuideCount = FMath::Min(50, FMath::FloorToInt(TimeSpan / Period) + 1);
+			for (int32 GuideIndex = 0; GuideIndex < GuideCount; ++GuideIndex)
+			{
+				DrawVerticalGuideLine(Range.MinTime + Period * GuideIndex, GuideLineColor);
+			}
+		};
+		const auto DrawPhaseGuideLine = [&](const float PhaseDegrees, const float Period)
+		{
+			if (Period <= KINDA_SMALL_NUMBER)
+			{
+				return;
+			}
+
+			float PhaseTime = FMath::Fmod(PhaseDegrees / 360.0f * Period, Period);
+			if (PhaseTime < 0.0f)
+			{
+				PhaseTime += Period;
+			}
+			DrawVerticalGuideLine(Range.MinTime + PhaseTime, GuideLineColor);
+		};
+
+		if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMax) ||
+			PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMin))
+		{
+			float EnvelopeMax = 0.0f;
+			float EnvelopeMin = 0.0f;
+			if (GetFloatEditValue(GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMax), EnvelopeMax) &&
+				GetFloatEditValue(GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeMin), EnvelopeMin))
+			{
+				const float MaxY = ValueToY(EnvelopeMax);
+				const float MinY = ValueToY(EnvelopeMin);
+				const float BandTop = FMath::Clamp(FMath::Min(MaxY, MinY), GraphOrigin.Y, GraphBottom);
+				const float BandBottom = FMath::Clamp(FMath::Max(MaxY, MinY), GraphOrigin.Y, GraphBottom);
+				if (BandBottom > BandTop)
+				{
+					FSlateDrawElement::MakeBox(
+						OutDrawElements,
+						LayerId + 4,
+						AllottedGeometry.ToPaintGeometry(
+							FVector2D(GraphSize.X, BandBottom - BandTop),
+							FSlateLayoutTransform(FVector2D(GraphOrigin.X, BandTop))),
+						WhiteBrush,
+						ESlateDrawEffect::None,
+						GuideBandColor);
+				}
+				DrawHorizontalGuideLine(EnvelopeMax, GuideLineColor);
+				DrawHorizontalGuideLine(EnvelopeMin, GuideLineColor);
+			}
+		}
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, SteadyForce))
+		{
+			float SteadyForce = 0.0f;
+			if (GetFloatEditValue(PropertyName, SteadyForce))
+			{
+				DrawHorizontalGuideLine(SteadyForce, GuideLineColor);
+			}
+		}
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, OscillationPeriod) ||
+			PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePeriod) ||
+			PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomPeriod) ||
+			PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, DirectionNoisePeriod))
+		{
+			float Period = 0.0f;
+			if (GetFloatEditValue(PropertyName, Period))
+			{
+				DrawPeriodGuideLines(Period);
+			}
+		}
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeFrequency))
+		{
+			float Frequency = 0.0f;
+			if (GetFloatEditValue(PropertyName, Frequency))
+			{
+				DrawPeriodGuideLines(1.0f / FMath::Max(Frequency, KINDA_SMALL_NUMBER));
+			}
+		}
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePhase))
+		{
+			float Phase = 0.0f;
+			float Period = 0.0f;
+			if (GetFloatEditValue(PropertyName, Phase) &&
+				GetFloatEditValue(GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WavePeriod), Period))
+			{
+				DrawPhaseGuideLine(Phase, Period);
+			}
+		}
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopePhase))
+		{
+			float Phase = 0.0f;
+			float Frequency = 0.0f;
+			if (GetFloatEditValue(PropertyName, Phase) &&
+				GetFloatEditValue(GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, EnvelopeFrequency), Frequency))
+			{
+				DrawPhaseGuideLine(Phase, 1.0f / FMath::Max(Frequency, KINDA_SMALL_NUMBER));
+			}
+		}
+	}
+
 	// 軸ラベル（最大値・0・最小値・時間軸）を描画
 	const auto DrawAxisText = [&](const FString& Text, const FVector2D& Position)
 	{
 		FSlateDrawElement::MakeText(
 			OutDrawElements,
-			LayerId + 4,
+			LayerId + 6,
 			AllottedGeometry.ToPaintGeometry(FVector2D(80.0f, 14.0f), FSlateLayoutTransform(Position)),
 			Text,
 			AxisFont,
@@ -848,7 +1038,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	DrawAxisText(FString::Printf(TEXT("-%.0fs"), DisplaySeconds), FVector2D(GraphOrigin.X, GraphOrigin.Y + GraphSize.Y + 4.0f));
 	DrawAxisText(TEXT("0s"), FVector2D(GraphOrigin.X + GraphSize.X - 24.0f, GraphOrigin.Y + GraphSize.Y + 4.0f));
 
-	return LayerId + 5;
+	return LayerId + 7;
 }
 
 FVector2D SKawaiiPhysicsWindScopeGraph::ComputeDesiredSize(float LayoutScaleMultiplier) const
@@ -960,9 +1150,9 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.OnClicked_Lambda([this]()
 				{
 					const bool bAppliedLive = PushGustToLiveRuntime(
-						WindScopeGustStrength,
-						WindScopeGustRiseTime,
-						WindScopeGustDecayTime);
+						GustStrength,
+						GustRiseTime,
+						GustDecayTime);
 					KawaiiPhysicsEdWindowUtils::ShowNotification(
 						bAppliedLive
 							? LOCTEXT("GustSucceededLive", "Triggered wind gust. (live)")
@@ -970,6 +1160,105 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 						bAppliedLive ? SNotificationItem::CS_Success : SNotificationItem::CS_Fail);
 					return FReply::Handled();
 				})
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("GustStrengthShortLabel", "S"))
+				.ToolTipText(LOCTEXT("GustStrengthTooltip", "突風の強さ / Gust strength."))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SNew(SBox)
+				.WidthOverride(60.0f)
+				[
+					SNew(SSpinBox<float>)
+					.MinValue(0.0f)
+					.MaxValue(50.0f)
+					.MinSliderValue(0.0f)
+					.MaxSliderValue(50.0f)
+					.Value_Lambda([this]()
+					{
+						return GustStrength;
+					})
+					.OnValueChanged_Lambda([this](float NewValue)
+					{
+						GustStrength = FMath::Clamp(NewValue, 0.0f, 50.0f);
+					})
+					.ToolTipText(LOCTEXT("GustStrengthSpinTooltip", "突風の強さ / Gust strength."))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("GustRiseShortLabel", "R"))
+				.ToolTipText(LOCTEXT("GustRiseTooltip", "突風の立ち上がり時間 / Gust rise time."))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SNew(SBox)
+				.WidthOverride(60.0f)
+				[
+					SNew(SSpinBox<float>)
+					.MinValue(0.01f)
+					.MaxValue(5.0f)
+					.MinSliderValue(0.01f)
+					.MaxSliderValue(5.0f)
+					.Value_Lambda([this]()
+					{
+						return GustRiseTime;
+					})
+					.OnValueChanged_Lambda([this](float NewValue)
+					{
+						GustRiseTime = FMath::Clamp(NewValue, 0.01f, 5.0f);
+					})
+					.ToolTipText(LOCTEXT("GustRiseSpinTooltip", "突風の立ち上がり時間 / Gust rise time."))
+				]
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("GustDecayShortLabel", "D"))
+				.ToolTipText(LOCTEXT("GustDecayTooltip", "突風の減衰時間 / Gust decay time."))
+				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			[
+				SNew(SBox)
+				.WidthOverride(60.0f)
+				[
+					SNew(SSpinBox<float>)
+					.MinValue(0.01f)
+					.MaxValue(10.0f)
+					.MinSliderValue(0.01f)
+					.MaxSliderValue(10.0f)
+					.Value_Lambda([this]()
+					{
+						return GustDecayTime;
+					})
+					.OnValueChanged_Lambda([this](float NewValue)
+					{
+						GustDecayTime = FMath::Clamp(NewValue, 0.01f, 10.0f);
+					})
+					.ToolTipText(LOCTEXT("GustDecaySpinTooltip", "突風の減衰時間 / Gust decay time."))
+				]
 			]
 			+ SHorizontalBox::Slot()
 			.AutoWidth()
@@ -1012,6 +1301,7 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 					.EditValues(this, &SKawaiiPhysicsWindScopeWindow::GetEditValues)
 					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
 					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
+					.IsParamPinExposed(this, &SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed)
 					.OnFocusNode(FSimpleDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked))
 					.OnHighlightSeries(this, &SKawaiiPhysicsWindScopeWindow::SetHighlightSeries)
 				]
@@ -1103,6 +1393,11 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 			]
 		]
 	];
+
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetEditValues(&CachedEditValues);
+	}
 
 	if (HasTargetArgs())
 	{
@@ -1224,6 +1519,10 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
 	bHasDragStartWind = false;
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetActiveEditGuide(TOptional<FName>());
+	}
 	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
 	RefreshExternalForceItems();
 	if (HasTargetArgs())
@@ -1252,6 +1551,10 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
 	bHasDragStartWind = false;
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetActiveEditGuide(TOptional<FName>());
+	}
 }
 
 FText SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText() const
@@ -1545,6 +1848,27 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	int32 VectorComponentIndex,
 	EKawaiiWindEditPhase Phase)
 {
+	const auto ClearActiveEditGuide = [this]()
+	{
+		if (GraphWidget.IsValid())
+		{
+			GraphWidget->SetActiveEditGuide(TOptional<FName>());
+		}
+	};
+	const auto FailEdit = [&ClearActiveEditGuide]()
+	{
+		ClearActiveEditGuide();
+		return false;
+	};
+
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetActiveEditGuide(
+			Phase == EKawaiiWindEditPhase::Committed
+				? TOptional<FName>()
+				: TOptional<FName>(PropertyName));
+	}
+
 	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
 	int32 ResolvedIndex = INDEX_NONE;
 	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(
@@ -1553,7 +1877,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		Phase == EKawaiiWindEditPhase::Committed);
 	if (!Wind)
 	{
-		return false;
+		return FailEdit();
 	}
 	Args.ExternalForceIndex = ResolvedIndex;
 
@@ -1566,7 +1890,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 				LOCTEXT("EditWindParamPropertyMissing", "Failed to resolve the wind parameter property."),
 				SNotificationItem::CS_Fail);
 		}
-		return false;
+		return FailEdit();
 	}
 
 	if (Phase == EKawaiiWindEditPhase::Begin)
@@ -1581,7 +1905,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	{
 		if (!SetProceduralWindPropertyValue(*Wind, Property, NewValue, VectorComponentIndex))
 		{
-			return false;
+			return FailEdit();
 		}
 
 		FKawaiiProceduralWindDynamicParams Params;
@@ -1622,7 +1946,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("EditWindParamSetFailed", "Failed to update the wind parameter."),
 			SNotificationItem::CS_Fail);
-		return false;
+		return FailEdit();
 	}
 
 	MarkWindScopeGraphNodeModified(GraphNode);
@@ -1639,6 +1963,11 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 
 bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
 {
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetActiveEditGuide(TOptional<FName>());
+	}
+
 	UAnimGraphNode_KawaiiPhysics* GraphNode = nullptr;
 	int32 ResolvedIndex = INDEX_NONE;
 	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = ResolveEditableWind(GraphNode, ResolvedIndex);
@@ -1670,6 +1999,77 @@ bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
 		PushParamsToLiveRuntime(Params);
 	}
 	return true;
+}
+
+bool SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed(FName PropertyName) const
+{
+	const UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	if (!GraphNode || PropertyName == NAME_None)
+	{
+		return false;
+	}
+
+	const int32 ResolvedIndex = ResolveProceduralWindIndex(GraphNode->Node, Args.ExternalForceIndex);
+	if (!GraphNode->Node.ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		return false;
+	}
+
+	const FString PropertyNameString = PropertyName.ToString();
+	const FString ExternalForcesName = GET_MEMBER_NAME_STRING_CHECKED(FAnimNode_KawaiiPhysics, ExternalForces);
+	const FString ExternalForceElementPinName = FString::Printf(TEXT("%s_%d"), *ExternalForcesName, ResolvedIndex);
+
+	const auto IsExactPinDriven = [GraphNode](const FString& PinName)
+	{
+		return GraphNode->IsPinExposedAndLinked(PinName, EGPD_Input) ||
+			GraphNode->IsPinExposedAndBound(PinName, EGPD_Input);
+	};
+
+	// FInstancedStruct配列の要素ピンが接続されている場合、その要素全体がグラフ側の値になる。
+	if (IsExactPinDriven(ExternalForceElementPinName))
+	{
+		return true;
+	}
+
+	TArray<FString> CandidatePinNames;
+	CandidatePinNames.Add(PropertyNameString);
+	CandidatePinNames.Add(FString::Printf(TEXT("%s_%s"), *ExternalForceElementPinName, *PropertyNameString));
+	CandidatePinNames.Add(FString::Printf(TEXT("%s.%s"), *ExternalForceElementPinName, *PropertyNameString));
+	CandidatePinNames.Add(FString::Printf(TEXT("%s[%d].%s"), *ExternalForcesName, ResolvedIndex, *PropertyNameString));
+	if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection))
+	{
+		static const TCHAR* ComponentSuffixes[] = {TEXT("X"), TEXT("Y"), TEXT("Z")};
+		for (const TCHAR* ComponentSuffix : ComponentSuffixes)
+		{
+			CandidatePinNames.Add(FString::Printf(TEXT("%s_%s_%s"), *ExternalForceElementPinName, *PropertyNameString, ComponentSuffix));
+			CandidatePinNames.Add(FString::Printf(TEXT("%s.%s.%s"), *ExternalForceElementPinName, *PropertyNameString, ComponentSuffix));
+		}
+	}
+
+	for (const FString& CandidatePinName : CandidatePinNames)
+	{
+		if (IsExactPinDriven(CandidatePinName))
+		{
+			return true;
+		}
+	}
+
+	const FString InternalPrefix = FString::Printf(TEXT("%s_%s_"), *ExternalForceElementPinName, *PropertyNameString);
+	for (const UEdGraphPin* Pin : GraphNode->Pins)
+	{
+		if (!Pin || Pin->Direction != EGPD_Input || Pin->LinkedTo.Num() == 0)
+		{
+			continue;
+		}
+
+		const FString PinNameString = Pin->PinName.ToString();
+		if (PinNameString.StartsWith(InternalPrefix))
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked()
@@ -2026,6 +2426,27 @@ void SKawaiiPhysicsWindScopeWindow::LoadEditPanelConfig()
 		EditPanelSplitterFraction,
 		GEditorPerProjectIni);
 	EditPanelSplitterFraction = FMath::Clamp(EditPanelSplitterFraction, 0.2f, 0.8f);
+	GustStrength = WindScopeDefaultGustStrength;
+	GustRiseTime = WindScopeDefaultGustRiseTime;
+	GustDecayTime = WindScopeDefaultGustDecayTime;
+	GConfig->GetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustStrengthKey,
+		GustStrength,
+		GEditorPerProjectIni);
+	GConfig->GetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustRiseTimeKey,
+		GustRiseTime,
+		GEditorPerProjectIni);
+	GConfig->GetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustDecayTimeKey,
+		GustDecayTime,
+		GEditorPerProjectIni);
+	GustStrength = FMath::Clamp(GustStrength, 0.0f, 50.0f);
+	GustRiseTime = FMath::Clamp(GustRiseTime, 0.01f, 5.0f);
+	GustDecayTime = FMath::Clamp(GustDecayTime, 0.01f, 10.0f);
 }
 
 void SKawaiiPhysicsWindScopeWindow::SaveEditPanelConfig() const
@@ -2044,6 +2465,21 @@ void SKawaiiPhysicsWindScopeWindow::SaveEditPanelConfig() const
 		WindScopeConfigSectionName,
 		WindScopeEditPanelSplitterFractionKey,
 		EditPanelSplitterFraction,
+		GEditorPerProjectIni);
+	GConfig->SetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustStrengthKey,
+		GustStrength,
+		GEditorPerProjectIni);
+	GConfig->SetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustRiseTimeKey,
+		GustRiseTime,
+		GEditorPerProjectIni);
+	GConfig->SetFloat(
+		WindScopeConfigSectionName,
+		WindScopeGustDecayTimeKey,
+		GustDecayTime,
 		GEditorPerProjectIni);
 	GConfig->Flush(false, GEditorPerProjectIni);
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -98,6 +98,10 @@ public:
 	void SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries);
 	void SetActiveEditGuide(TOptional<FName> PropertyName);
 	void SetEditValues(const FKawaiiWindScopeEditValues* InEditValues);
+	void SetGhostSamples(TArray<FVector2D> InGhostSamples);
+
+	virtual FReply OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
+	virtual void OnMouseLeave(const FPointerEvent& MouseEvent) override;
 
 	// グラフの描画本体 / Slate paint callback for the graph.
 	virtual int32 OnPaint(const FPaintArgs& Args,
@@ -112,9 +116,11 @@ public:
 
 private:
 	TArray<FKawaiiProceduralWindScopeSample> Samples;
+	TArray<FVector2D> GhostSamples;
 	FKawaiiPhysicsWindScopeSeriesVisibility Visibility;
 	TOptional<EKawaiiPhysicsWindScopeComponent> HighlightSeries;
 	TOptional<FName> ActiveEditGuide;
+	TOptional<FVector2D> HoverMousePosition;
 	const FKawaiiWindScopeEditValues* EditValues = nullptr;
 	float DisplaySeconds = 8.0f;
 };
@@ -179,6 +185,8 @@ private:
 
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
+	void OnPresetButtonHovered(int32 PresetIndex);
+	void OnPresetButtonUnhovered();
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
 	TSharedRef<SWidget> GenerateSavePresetMenu();
 	bool CanSaveWindPreset() const;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -204,6 +204,9 @@ private:
 	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiWindEditPhase Phase);
 	bool ResetWindParamToDefault(FName PropertyName);
 	bool IsWindParamPinExposed(FName PropertyName) const;
+	void ClearWindParamPinExposureCache();
+	void RefreshWindParamPinExposureCache();
+	bool ComputeWindParamPinExposure(FName PropertyName) const;
 	void OnFocusWindScopeNodeClicked();
 
 	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.
@@ -243,11 +246,13 @@ private:
 	float DisplaySeconds = 8.0f;
 	FKawaiiWindScopeEditValues CachedEditValues;
 	FKawaiiWindScopeEditValues CachedLiveEditValues;
+	TMap<FName, bool> WindParamPinExposureCache;
 	FKawaiiPhysics_ExternalForce_ProceduralWind DragStartWind;
 	FName DragStartPropertyName;
-	float GustStrength = 6.0f;
-	float GustRiseTime = 0.1f;
-	float GustDecayTime = 0.5f;
+	float GustStrength;
+	float GustRiseTime;
+	float GustDecayTime;
+	float WindParamPinExposureRefreshElapsedTime = 0.0f;
 	bool bHasDragStartWind = false;
 	bool bEditPanelExpanded = false;
 	float EditPanelSplitterFraction = 0.4f;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -146,7 +146,8 @@ private:
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
-	bool PushPresetToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveEditableWind(UAnimGraphNode_KawaiiPhysics*& OutGraphNode, int32& OutResolvedIndex);
+	bool PushParamsToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
 
 	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -202,6 +202,8 @@ private:
 	bool PushParamsToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
 	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiWindEditPhase Phase);
+	// 放棄されたドラッグ編集をトランザクションとして確定する / Finalizes an abandoned drag edit as a transaction.
+	void FinalizeAbandonedWindDrag();
 	bool ResetWindParamToDefault(FName PropertyName);
 	bool IsWindParamPinExposed(FName PropertyName) const;
 	void ClearWindParamPinExposureCache();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -182,6 +182,7 @@ private:
 	void OnEditPanelSlotResized(float NewFraction);
 	bool IsWindEditable() const;
 	const FKawaiiWindScopeEditValues* GetEditValues() const;
+	const FKawaiiWindScopeEditValues* GetLiveEditValues() const;
 
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
@@ -215,6 +216,7 @@ private:
 	// Preview 計算用に ProceduralWind 設定値のコピーを取得する / Gets a ProceduralWind copy for Preview calculation.
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
 	void UpdateEditValuesFromWind(const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind);
+	void UpdateLiveEditValuesFromRuntime();
 	void LoadEditPanelConfig();
 	void SaveEditPanelConfig() const;
 	// 弱参照、または AnimBlueprintPath+NodeGuid から対象ノードを再解決する / Resolves the target node from weak reference or AnimBlueprintPath+NodeGuid.
@@ -240,6 +242,7 @@ private:
 	FText CurrentModeText;
 	float DisplaySeconds = 8.0f;
 	FKawaiiWindScopeEditValues CachedEditValues;
+	FKawaiiWindScopeEditValues CachedLiveEditValues;
 	FKawaiiPhysics_ExternalForce_ProceduralWind DragStartWind;
 	FName DragStartPropertyName;
 	float GustStrength = 6.0f;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -96,6 +96,8 @@ public:
 	void SetDisplaySeconds(float InDisplaySeconds);
 	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
 	void SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries);
+	void SetActiveEditGuide(TOptional<FName> PropertyName);
+	void SetEditValues(const FKawaiiWindScopeEditValues* InEditValues);
 
 	// グラフの描画本体 / Slate paint callback for the graph.
 	virtual int32 OnPaint(const FPaintArgs& Args,
@@ -112,6 +114,8 @@ private:
 	TArray<FKawaiiProceduralWindScopeSample> Samples;
 	FKawaiiPhysicsWindScopeSeriesVisibility Visibility;
 	TOptional<EKawaiiPhysicsWindScopeComponent> HighlightSeries;
+	TOptional<FName> ActiveEditGuide;
+	const FKawaiiWindScopeEditValues* EditValues = nullptr;
 	float DisplaySeconds = 8.0f;
 };
 
@@ -184,6 +188,7 @@ private:
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
 	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiWindEditPhase Phase);
 	bool ResetWindParamToDefault(FName PropertyName);
+	bool IsWindParamPinExposed(FName PropertyName) const;
 	void OnFocusWindScopeNodeClicked();
 
 	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.
@@ -223,6 +228,9 @@ private:
 	FKawaiiWindScopeEditValues CachedEditValues;
 	FKawaiiPhysics_ExternalForce_ProceduralWind DragStartWind;
 	FName DragStartPropertyName;
+	float GustStrength = 6.0f;
+	float GustRiseTime = 0.1f;
+	float GustDecayTime = 0.5f;
 	bool bHasDragStartWind = false;
 	bool bEditPanelExpanded = false;
 	float EditPanelSplitterFraction = 0.4f;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -16,6 +16,7 @@ struct FStreamableHandle;
 class FWorkspaceItem;
 class SDockTab;
 class SComboBoxBase;
+class SSplitter;
 class SWrapBox;
 class UAnimGraphNode_KawaiiPhysics;
 
@@ -61,6 +62,25 @@ struct FKawaiiPhysicsWindScopeSeriesVisibility
 	void SetVisible(EKawaiiPhysicsWindScopeComponent Component, bool bVisible);
 };
 
+// 編集パネルが表示する現在値キャッシュ
+struct FKawaiiWindScopeEditValues
+{
+	bool bValid = false;
+	bool bIsEnabled = true;
+	FVector WindDirection = FVector::ForwardVector;
+	TMap<FName, float> FloatValues;
+	int32 RandomSeed = 0;
+	TSet<FName> ModifiedFromDefault;
+};
+
+// 編集操作のフェーズ
+enum class EKawaiiWindEditPhase : uint8
+{
+	Begin,
+	Interactive,
+	Committed,
+};
+
 // 波形グラフ本体 / Waveform graph widget.
 class SKawaiiPhysicsWindScopeGraph : public SLeafWidget
 {
@@ -75,6 +95,7 @@ public:
 	void SetSamples(TArray<FKawaiiProceduralWindScopeSample> InSamples);
 	void SetDisplaySeconds(float InDisplaySeconds);
 	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
+	void SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries);
 
 	// グラフの描画本体 / Slate paint callback for the graph.
 	virtual int32 OnPaint(const FPaintArgs& Args,
@@ -90,6 +111,7 @@ public:
 private:
 	TArray<FKawaiiProceduralWindScopeSample> Samples;
 	FKawaiiPhysicsWindScopeSeriesVisibility Visibility;
+	TOptional<EKawaiiPhysicsWindScopeComponent> HighlightSeries;
 	float DisplaySeconds = 8.0f;
 };
 
@@ -127,6 +149,7 @@ public:
 
 	ECheckBoxState GetSeriesCheckState(EKawaiiPhysicsWindScopeComponent Component) const;
 	void OnSeriesCheckStateChanged(ECheckBoxState NewState, EKawaiiPhysicsWindScopeComponent Component);
+	void SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries);
 
 private:
 	// ExternalForces 配列のインデックスを保持するコンボボックス項目型 / Combo item type storing an ExternalForces array index.
@@ -142,23 +165,39 @@ private:
 	void OnPauseCheckStateChanged(ECheckBoxState NewState);
 	float GetDisplaySeconds() const;
 	void OnDisplaySecondsChanged(float NewValue);
+	bool IsEditPanelExpanded() const;
+	EVisibility GetEditPanelVisibility() const;
+	const FSlateBrush* GetEditPanelToggleIcon() const;
+	FReply OnToggleEditPanelClicked();
+	void OnEditPanelSlotResized(float NewFraction);
+	bool IsWindEditable() const;
+	const FKawaiiWindScopeEditValues* GetEditValues() const;
 
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
-	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveEditableWind(UAnimGraphNode_KawaiiPhysics*& OutGraphNode, int32& OutResolvedIndex);
+	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveEditableWind(
+		UAnimGraphNode_KawaiiPhysics*& OutGraphNode,
+		int32& OutResolvedIndex,
+		bool bShowNotification = true);
 	bool PushParamsToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
+	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiWindEditPhase Phase);
+	bool ResetWindParamToDefault(FName PropertyName);
+	void OnFocusWindScopeNodeClicked();
 
 	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);
 	void RefreshExternalForceItems();
 	// Live 実行中でない場合の理論波形を再計算する / Rebuilds theoretical Preview samples when Live data is unavailable.
-	void RebuildPreviewSamples(float InDeltaTime);
+	void RebuildPreviewSamples(float InDeltaTime, const FKawaiiPhysics_ExternalForce_ProceduralWind* WindSnapshot = nullptr);
 	// 実行中の RuntimeState からライブ波形を取得する / Reads Live samples from RuntimeState.
 	bool TryUpdateFromLiveRuntime();
 	// Preview 計算用に ProceduralWind 設定値のコピーを取得する / Gets a ProceduralWind copy for Preview calculation.
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
+	void UpdateEditValuesFromWind(const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind);
+	void LoadEditPanelConfig();
+	void SaveEditPanelConfig() const;
 	// 弱参照、または AnimBlueprintPath+NodeGuid から対象ノードを再解決する / Resolves the target node from weak reference or AnimBlueprintPath+NodeGuid.
 	UAnimGraphNode_KawaiiPhysics* ResolveGraphNode() const;
 	bool HasTargetArgs() const;
@@ -181,6 +220,12 @@ private:
 	TArray<FKawaiiProceduralWindScopeSample> DisplaySamples;
 	FText CurrentModeText;
 	float DisplaySeconds = 8.0f;
+	FKawaiiWindScopeEditValues CachedEditValues;
+	FKawaiiPhysics_ExternalForce_ProceduralWind DragStartWind;
+	FName DragStartPropertyName;
+	bool bHasDragStartWind = false;
+	bool bEditPanelExpanded = false;
+	float EditPanelSplitterFraction = 0.4f;
 	// Preview モードでの積算経過時間 / Accumulated elapsed time in Preview mode.
 	float PreviewTime = 0.0f;
 	// 直前に読み取った RuntimeState->ScopeSampleCount / Last RuntimeState->ScopeSampleCount read.
@@ -193,6 +238,7 @@ private:
 
 	TSharedPtr<SComboBox<FExternalForceIndexPtr>> ExternalForceComboBox;
 	TSharedPtr<SKawaiiPhysicsWindScopeGraph> GraphWidget;
+	TSharedPtr<SSplitter> EditPanelSplitter;
 	// ボタンindexとの整合を保つプリセットスナップショット / Preset snapshot aligned with button indices.
 	TArray<FKawaiiProceduralWindPreset> CachedPresets;
 	TSharedPtr<SWrapBox> PresetButtonBox;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -191,6 +191,7 @@ private:
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
 	TSharedRef<SWidget> GenerateSavePresetMenu();
 	bool CanSaveWindPreset() const;
+	FText GetSavePresetToolTipText() const;
 	class UKawaiiPhysicsWindPresetDataAsset* ResolveWritablePresetDataAsset(bool bShowNotification) const;
 	bool SaveCurrentWindAsPreset(int32 PresetIndex);
 	FReply OnCopyWindParametersClicked();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -180,6 +180,12 @@ private:
 	void RebuildPresetButtons();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
+	TSharedRef<SWidget> GenerateSavePresetMenu();
+	bool CanSaveWindPreset() const;
+	class UKawaiiPhysicsWindPresetDataAsset* ResolveWritablePresetDataAsset(bool bShowNotification) const;
+	bool SaveCurrentWindAsPreset(int32 PresetIndex);
+	FReply OnCopyWindParametersClicked();
+	FReply OnPasteWindParametersClicked();
 	FKawaiiPhysics_ExternalForce_ProceduralWind* ResolveEditableWind(
 		UAnimGraphNode_KawaiiPhysics*& OutGraphNode,
 		int32& OutResolvedIndex,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
@@ -1,0 +1,103 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "../SKawaiiPhysicsWindScopeEditPanel.h"
+
+#include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+#include "Misc/AutomationTest.h"
+#include "UObject/UnrealType.h"
+
+namespace
+{
+	FProperty* FindWindScopeTestProperty(const FName PropertyName)
+	{
+		for (UStruct* Struct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct(); Struct; Struct = Struct->GetSuperStruct())
+		{
+			if (FProperty* Property = Struct->FindPropertyByName(PropertyName))
+			{
+				return Property;
+			}
+		}
+		return nullptr;
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsWindScopeEditPanelDefinitionsTest,
+                                 "KawaiiPhysics.Editor.WindScopeEditPanel.Definitions",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Parameters)
+{
+	(void)Parameters;
+
+	bool bOk = true;
+	TSet<FName> TableDynamicParamsSupportedNames;
+	TSet<FName> RuntimeDynamicParamsSupportedNames;
+	const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
+
+	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	{
+		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		{
+			FProperty* Property = FindWindScopeTestProperty(Param.PropertyName);
+			bOk &= TestNotNull(
+				FString::Printf(TEXT("Wind Scope edit property exists: %s"), *Param.PropertyName.ToString()),
+				Property);
+
+			if (Param.bDynamicParamsSupported)
+			{
+				TableDynamicParamsSupportedNames.Add(Param.PropertyName);
+			}
+
+			if (const FFloatProperty* FloatProperty = CastField<FFloatProperty>(Property))
+			{
+				(void)FloatProperty;
+				if (Property->HasMetaData(TEXT("ClampMin")))
+				{
+					float ClampMin = 0.0f;
+					if (LexTryParseString(ClampMin, *Property->GetMetaData(TEXT("ClampMin"))))
+					{
+						bOk &= TestTrue(
+							FString::Printf(TEXT("SliderMin is not below ClampMin: %s"), *Param.PropertyName.ToString()),
+							Param.SliderMin + KINDA_SMALL_NUMBER >= ClampMin);
+					}
+				}
+			}
+		}
+	}
+
+	for (TFieldIterator<FProperty> PropertyIt(FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct(), EFieldIterationFlags::IncludeSuper);
+	     PropertyIt;
+	     ++PropertyIt)
+	{
+		FKawaiiProceduralWindDynamicParams Params;
+		if (DefaultWind.BuildDynamicParamsForProperty(PropertyIt->GetFName(), Params))
+		{
+			RuntimeDynamicParamsSupportedNames.Add(PropertyIt->GetFName());
+		}
+	}
+
+	bOk &= TestEqual(TEXT("DynamicParams supported property count"),
+	                 RuntimeDynamicParamsSupportedNames.Num(),
+	                 TableDynamicParamsSupportedNames.Num());
+	for (const FName& RuntimeName : RuntimeDynamicParamsSupportedNames)
+	{
+		bOk &= TestTrue(
+			FString::Printf(TEXT("DynamicParams supported property is listed as supported: %s"), *RuntimeName.ToString()),
+			TableDynamicParamsSupportedNames.Contains(RuntimeName));
+	}
+	for (const FName& TableName : TableDynamicParamsSupportedNames)
+	{
+		bOk &= TestTrue(
+			FString::Printf(TEXT("Table supported property is supported by DynamicParams: %s"), *TableName.ToString()),
+			RuntimeDynamicParamsSupportedNames.Contains(TableName));
+	}
+	bOk &= TestFalse(TEXT("RandomSeed is not live DynamicParams supported"),
+	                 TableDynamicParamsSupportedNames.Contains(GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomSeed)));
+
+	return bOk;
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -84,8 +84,8 @@ private:
 	/** このノードと対象プリセットとの差分を確認します / Checks the diff between this node and its target preset. */
 	void CheckPresetDiff();
 
-	/** Procedural Windの波形プレビューウィンドウを開きます / Opens the waveform preview window for Procedural Wind. */
-	void OpenWindScopeWindow();
+	/** 指定したProcedural Windの波形プレビューウィンドウを開きます / Opens the waveform preview window for the specified Procedural Wind. */
+	void OpenWindScopeWindow(int32 ExternalForceIndex = INDEX_NONE);
 
 public:
 	/** Enables or disables debug drawing for bones. */


### PR DESCRIPTION
## 概要

Wind ScopeウインドウにProceduralWindのパラメータ編集パネルを追加し、グラフを見ながらその場で調整できるようにしました。パネルはUE標準エディタのDetailsパネルに合わせて右側にドッキングします。

## 主な変更

### 編集パネル本体
- ProceduralWindパラメータの編集パネルを新設（数値編集は常にトランザクション対応、Undo/Redo可）
- ピン公開中パラメータの警告表示、ノードへのフォーカス移動
- Gust操作ボタン・編集ガイドオーバーレイ
- ライブ値と編集値の乖離readout、計算式ヘルプ

### プリセット連携
- Save as Preset / Copy / Paste 対応（Save as PresetからプリセットDataAsset設定へ誘導）
- プリセットhover時のゴーストカーブプレビュー（プロット矩形でクリップ）

### UI/UX
- 外力ごとのWind Scopeコンテキストメニュー
- クロスヘアreadout
- **編集パネルを右側に配置**（UEの各エディタとレイアウトを統一）。折りたたみ・スプリッタ幅はconfigに保存され、既存の保存値と互換

## テスト

- KawaiiPhysicsSampleEditor (UE 5.8) ビルド成功
- ヘッドレス自動テスト 130件 全green