### PR TITLE
[improve] Move Details category filter chips to a dedicated Category Filter category

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -101,6 +101,7 @@ namespace
 		for (const FName& CategoryName : KawaiiPhysicsEditorCategoryNames::GetCategorySortOrderNames())
 		{
 			if (CategoryName != KawaiiPhysicsEditorCategoryNames::KawaiiPhysicsTools &&
+				CategoryName != KawaiiPhysicsEditorCategoryNames::CategoryFilter &&
 				!FilterGroup->CategoryNames.Contains(CategoryName))
 			{
 				DetailBuilder.HideCategory(CategoryName);
@@ -521,8 +522,11 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetailTools(IDetailLayoutBuilder& De
 	const FName SelectedFilterGroupId = ReadKawaiiPhysicsCategoryFilter();
 	IDetailLayoutBuilder* LayoutBuilder = &DetailBuilder;
 
-	// カテゴリの表示範囲をワンクリックで切り替えるため、ツール行の先頭にフィルタチップを置く。
-	FDetailWidgetRow& FilterWidgetRow = ViewportCategory.AddCustomRow(LOCTEXT("CategoryFilterRow", "Category Filter"));
+	// カテゴリの表示範囲をワンクリックで切り替えるため、独立したカテゴリにフィルタチップを置く。
+	IDetailCategoryBuilder& FilterCategory = DetailBuilder.EditCategory(
+		KawaiiPhysicsEditorCategoryNames::CategoryFilter,
+		LOCTEXT("CategoryFilterRow", "Category Filter"));
+	FDetailWidgetRow& FilterWidgetRow = FilterCategory.AddCustomRow(LOCTEXT("CategoryFilterRow", "Category Filter"));
 	FilterWidgetRow.WholeRowContent()
 	[
 		SNew(SSegmentedControl<FName>)
@@ -874,6 +878,8 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 
 		const FCategoryDisplayNameOverride DisplayNameOverrides[] =
 		{
+			{ KawaiiPhysicsEditorCategoryNames::CategoryFilter,
+			  LOCTEXT("CategoryFilterRow", "Category Filter") },
 			{ KawaiiPhysicsEditorCategoryNames::BonesBoneSubdivision,
 			  LOCTEXT("Category_Bones_BoneSubdivision", "Bones > Bone Subdivision") },
 			{ KawaiiPhysicsEditorCategoryNames::PhysicsSettingsCurves,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorCategoryNames.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorCategoryNames.h
@@ -12,6 +12,7 @@ namespace KawaiiPhysicsEditorCategoryNames
 		TArray<FName> CategoryNames;
 	};
 
+	inline const FName CategoryFilter(TEXT("Category Filter"));
 	inline const FName KawaiiPhysicsTools(TEXT("Kawaii Physics Tools"));
 	inline const FName DebugVisualization(TEXT("Debug Visualization"));
 	inline const FName Functions(TEXT("Functions"));
@@ -50,6 +51,7 @@ namespace KawaiiPhysicsEditorCategoryNames
 	{
 		static const TArray<FName> CategoryNames =
 		{
+			CategoryFilter,
 			KawaiiPhysicsTools,
 			DebugVisualization,
 			Functions,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorCategoryTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorCategoryTest.cpp
@@ -39,6 +39,7 @@ bool FKawaiiPhysicsEditorCategoryConsistencyTest::RunTest(const FString& Paramet
 	CollectCategoryMetadata(UAnimGraphNode_KawaiiPhysics::StaticClass(), ExistingCategories);
 	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::KawaiiPhysicsTools);
 	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::DebugVisualization);
+	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::CategoryFilter);
 
 	bool bOk = true;
 	for (const FName& CategoryName : KawaiiPhysicsEditorCategoryNames::GetCategorySortOrderNames())


### PR DESCRIPTION
## 概要
ノード Details のカテゴリフィルタチップ（All / Bones / Physics / Collision / Force）を「Kawaii Physics Tools」カテゴリから独立した新カテゴリ「Category Filter」へ移動しました。Export 系などの他ボタンとの混同を防ぎます。

## 変更内容
- 新カテゴリ名 `Category Filter` を追加し、ソート順の先頭（Kawaii Physics Tools の上）に配置
- フィルタ適用中もチップカテゴリが非表示にならないよう `HideCategoriesOutsideFilter` の除外条件に追加
- エンジン側の表示名リセット対策として `SortCategories` 内の `DisplayNameOverrides` に登録（既存パターン踏襲）
- カテゴリ整合テストにカスタム行カテゴリとして登録

## ローカライズ
既存キー `CategoryFilterRow`（訳: カテゴリフィルタ）を再利用したため、新規キー追加・GatherText 再実行・ja.po 更新は不要です。

## テスト
- KawaiiPhysicsSampleEditor Win64 Development ビルド成功
- KawaiiPhysics 自動テスト 132 件すべて green（`KawaiiPhysics.Editor.CategoryConsistency` 含む）
- エディタ実機で Details パネルの表示を目視確認済み

## 備考
チップ機能を導入した feature/wind-scope-localization（#221）上のコミットに依存するため、ベースを同ブランチにしています。#221 マージ後は自動的に master 向けに付け替わります。