### PR TITLE
[add] Add security policy (SECURITY.md)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy / セキュリティポリシー
+
+## Supported Versions / サポート対象バージョン
+
+Security fixes are provided only for the latest release.
+セキュリティ修正は最新リリースのみを対象とします。
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release (v1.21.x) | :white_check_mark: |
+| Older releases | :x: |
+
+## Reporting a Vulnerability / 脆弱性の報告方法
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+**脆弱性の内容を public な Issue に書き込まないでください。**
+
+Instead, please use GitHub's private vulnerability reporting:
+代わりに、GitHub の Private vulnerability reporting（非公開報告フォーム）をご利用ください:
+
+https://github.com/pafuhana1213/KawaiiPhysics/security/advisories/new
+
+When reporting, please include the following if possible:
+報告の際は、可能であれば以下の情報を含めてください:
+
+- Steps to reproduce / 再現手順
+- Affected plugin version(s) / 影響を受けるプラグインのバージョン
+- Unreal Engine version(s) / Unreal Engine のバージョン
+- Potential impact / 想定される影響
+
+## Response / 対応について
+
+This plugin is maintained by an individual developer as an open-source project.
+Reports will be reviewed, but response times and fixes cannot be guaranteed.
+本プラグインは個人開発の OSS のため、報告内容は確認しますが、対応時期や修正を保証するものではありません。


### PR DESCRIPTION
## 概要
GitHub の Security タブで「Security policy: Disabled」と表示されていたため、`.github/SECURITY.md` を追加します。

## 内容
- 日英併記（既存 Issue テンプレートのスタイルに合わせる）
- サポート対象: 最新リリース（v1.21.x）のみ
- 脆弱性は public Issue ではなく Private vulnerability reporting（有効化済み）で報告するよう明記
- 個人開発 OSS として、対応時期・修正を保証しない旨を明記

## 検証
- マージ後、Security タブの Policy が Enabled になり本ファイルへリンクされることを確認する