### PR TITLE
[improve] Add explicit read-only permissions to version consistency workflow

### DIFF
--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -22,6 +22,9 @@ on:
       - Tools/check_version_consistency.py
       - .github/workflows/version-consistency.yml
 
+permissions:
+  contents: read
+
 jobs:
   version-consistency:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL (code scanning) alert fix: the Version Consistency workflow did not declare permissions, so it ran with the default token scope. Adds an explicit workflow-level `permissions: contents: read` (least privilege). No functional change to the check itself.