### PR TITLE
[improve] Move Details category filter chips to a dedicated Category Filter category

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -101,6 +101,7 @@ namespace
 		for (const FName& CategoryName : KawaiiPhysicsEditorCategoryNames::GetCategorySortOrderNames())
 		{
 			if (CategoryName != KawaiiPhysicsEditorCategoryNames::KawaiiPhysicsTools &&
+				CategoryName != KawaiiPhysicsEditorCategoryNames::CategoryFilter &&
 				!FilterGroup->CategoryNames.Contains(CategoryName))
 			{
 				DetailBuilder.HideCategory(CategoryName);
@@ -521,8 +522,11 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetailTools(IDetailLayoutBuilder& De
 	const FName SelectedFilterGroupId = ReadKawaiiPhysicsCategoryFilter();
 	IDetailLayoutBuilder* LayoutBuilder = &DetailBuilder;
 
-	// カテゴリの表示範囲をワンクリックで切り替えるため、ツール行の先頭にフィルタチップを置く。
-	FDetailWidgetRow& FilterWidgetRow = ViewportCategory.AddCustomRow(LOCTEXT("CategoryFilterRow", "Category Filter"));
+	// カテゴリの表示範囲をワンクリックで切り替えるため、独立したカテゴリにフィルタチップを置く。
+	IDetailCategoryBuilder& FilterCategory = DetailBuilder.EditCategory(
+		KawaiiPhysicsEditorCategoryNames::CategoryFilter,
+		LOCTEXT("CategoryFilterRow", "Category Filter"));
+	FDetailWidgetRow& FilterWidgetRow = FilterCategory.AddCustomRow(LOCTEXT("CategoryFilterRow", "Category Filter"));
 	FilterWidgetRow.WholeRowContent()
 	[
 		SNew(SSegmentedControl<FName>)
@@ -874,6 +878,8 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetails(IDetailLayoutBuilder& Detail
 
 		const FCategoryDisplayNameOverride DisplayNameOverrides[] =
 		{
+			{ KawaiiPhysicsEditorCategoryNames::CategoryFilter,
+			  LOCTEXT("CategoryFilterRow", "Category Filter") },
 			{ KawaiiPhysicsEditorCategoryNames::BonesBoneSubdivision,
 			  LOCTEXT("Category_Bones_BoneSubdivision", "Bones > Bone Subdivision") },
 			{ KawaiiPhysicsEditorCategoryNames::PhysicsSettingsCurves,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorCategoryNames.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorCategoryNames.h
@@ -12,6 +12,7 @@ namespace KawaiiPhysicsEditorCategoryNames
 		TArray<FName> CategoryNames;
 	};
 
+	inline const FName CategoryFilter(TEXT("Category Filter"));
 	inline const FName KawaiiPhysicsTools(TEXT("Kawaii Physics Tools"));
 	inline const FName DebugVisualization(TEXT("Debug Visualization"));
 	inline const FName Functions(TEXT("Functions"));
@@ -50,6 +51,7 @@ namespace KawaiiPhysicsEditorCategoryNames
 	{
 		static const TArray<FName> CategoryNames =
 		{
+			CategoryFilter,
 			KawaiiPhysicsTools,
 			DebugVisualization,
 			Functions,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorCategoryTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorCategoryTest.cpp
@@ -39,6 +39,7 @@ bool FKawaiiPhysicsEditorCategoryConsistencyTest::RunTest(const FString& Paramet
 	CollectCategoryMetadata(UAnimGraphNode_KawaiiPhysics::StaticClass(), ExistingCategories);
 	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::KawaiiPhysicsTools);
 	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::DebugVisualization);
+	ExistingCategories.Add(KawaiiPhysicsEditorCategoryNames::CategoryFilter);
 
 	bool bOk = true;
 	for (const FName& CategoryName : KawaiiPhysicsEditorCategoryNames::GetCategorySortOrderNames())


### PR DESCRIPTION
## 概要
Detailsパネルのカテゴリフィルタチップを専用の「Category Filter」カテゴリへ移動する変更（b1dbc11）を master へ取り込みます。

## 背景
この変更は元々 #222 として作成しましたが、base が #221 のブランチ（feature/wind-scope-localization）だったため、#221 が先に master へマージされた後のマージとなり、変更が master に届いていませんでした。本PRはそのコミットを改めて master 向けに提出するものです。

## 変更内容（#222 と同一）
- フィルタチップを Editor カテゴリから専用の Category Filter カテゴリへ移動
- カテゴリ名定数の追加（KawaiiPhysicsEditorCategoryNames.h）
- カテゴリ整合テストの更新