### PR TITLE
[improve] Remove curve guide row from Wind Scope edit panel

### DIFF
--- a/Plugins/KawaiiPhysics/Content/Localization/KawaiiPhysics/ja/KawaiiPhysics.po
+++ b/Plugins/KawaiiPhysics/Content/Localization/KawaiiPhysics/ja/KawaiiPhysics.po
@@ -6152,20 +6152,6 @@ msgctxt "KawaiiPhysicsWindScopeEditPanel,CollapsedGroupModifiedTooltip"
 msgid "This collapsed category has edits that differ from defaults."
 msgstr "この折りたたみ中のカテゴリにデフォルトから変更されたパラメータがあります"
 
-#. Key:	CurveEditGuide
-#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(770)
-#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(770)
-msgctxt "KawaiiPhysicsWindScopeEditPanel,CurveEditGuide"
-msgid "Edit the curve in the Details panel"
-msgstr "カーブ(ForceRateByBoneLengthRate)は詳細パネルで編集"
-
-#. Key:	FocusNodeButton
-#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(780)
-#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(780)
-msgctxt "KawaiiPhysicsWindScopeEditPanel,FocusNodeButton"
-msgid "Focus Node"
-msgstr "ノードへフォーカス"
-
 #. Key:	ResetToDefaultTooltip
 #. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(795)
 #: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp(795)
@@ -6634,13 +6620,6 @@ msgstr "風パラメータの更新に失敗しました"
 msgctxt "KawaiiPhysicsWindScopeWindow,ResetWindParamPropertyMissing"
 msgid "Failed to resolve the wind parameter property."
 msgstr "風パラメータのプロパティを特定できませんでした"
-
-#. Key:	FocusWindScopeNodeFailed
-#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2838)
-#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2838)
-msgctxt "KawaiiPhysicsWindScopeWindow,FocusWindScopeNodeFailed"
-msgid "Failed to resolve the KawaiiPhysics graph node."
-msgstr "KawaiiPhysics グラフノードを特定できませんでした"
 
 #. Key:	PreviewModeTick
 #. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2886)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -305,7 +305,6 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 	OnParamEdit = InArgs._OnParamEdit;
 	OnParamReset = InArgs._OnParamReset;
 	IsParamPinExposed = InArgs._IsParamPinExposed;
-	OnFocusNode = InArgs._OnFocusNode;
 	OnHighlightSeries = InArgs._OnHighlightSeries;
 
 	LoadCollapsedGroupsFromConfig();
@@ -561,17 +560,6 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKaw
 		];
 	}
 
-	if (Group.Params.Num() > 0 &&
-		Group.Params[0].PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
-	{
-		BodyBox->AddSlot()
-		.AutoHeight()
-		.Padding(4.0f, 4.0f, 4.0f, 0.0f)
-		[
-			MakeCurveRow()
-		];
-	}
-
 	TSharedPtr<SExpandableArea> GroupArea;
 	SAssignNew(GroupArea, SExpandableArea)
 		.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
@@ -757,33 +745,6 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakePinWarningIcon(FName P
 		.ColorAndOpacity(FLinearColor(1.0f, 0.72f, 0.18f, 1.0f))
 		.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetPinWarningVisibility, PropertyName)
 		.ToolTipText(GetPinDrivenWarningText());
-}
-
-TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeCurveRow() const
-{
-	return SNew(SHorizontalBox)
-		+ SHorizontalBox::Slot()
-		.FillWidth(1.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(STextBlock)
-			.Text(LOCTEXT("CurveEditGuide", "Edit the curve in the Details panel"))
-			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			.AutoWrapText(true)
-		]
-		+ SHorizontalBox::Slot()
-		.AutoWidth()
-		.VAlign(VAlign_Center)
-		.Padding(6.0f, 0.0f, 0.0f, 0.0f)
-		[
-			SNew(SButton)
-			.Text(LOCTEXT("FocusNodeButton", "Focus Node"))
-			.OnClicked_Lambda([this]()
-			{
-				OnFocusNode.ExecuteIfBound();
-				return FReply::Handled();
-			})
-		];
 }
 
 TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeResetButton(FName PropertyName) const

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -51,7 +51,6 @@ public:
 		SLATE_EVENT(FOnWindParamEdit, OnParamEdit)
 		SLATE_EVENT(FOnWindParamReset, OnParamReset)
 		SLATE_EVENT(FIsWindParamPinExposed, IsParamPinExposed)
-		SLATE_EVENT(FSimpleDelegate, OnFocusNode)
 		SLATE_EVENT(FOnWindScopeHighlightSeries, OnHighlightSeries)
 	SLATE_END_ARGS()
 
@@ -62,7 +61,6 @@ private:
 	TSharedRef<SWidget> MakeFormulaHelpContent() const;
 	TSharedRef<SWidget> MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group);
 	TSharedRef<SWidget> MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef);
-	TSharedRef<SWidget> MakeCurveRow() const;
 	TSharedRef<SWidget> MakeResetButton(FName PropertyName) const;
 	TSharedRef<SWidget> MakePinWarningIcon(FName PropertyName) const;
 	TSharedRef<SWidget> MakeHeaderIconButton(const FName IconName, const FText& ToolTipText, FOnClicked OnClicked) const;
@@ -97,7 +95,6 @@ private:
 	FOnWindParamEdit OnParamEdit;
 	FOnWindParamReset OnParamReset;
 	FIsWindParamPinExposed IsParamPinExposed;
-	FSimpleDelegate OnFocusNode;
 	FOnWindScopeHighlightSeries OnHighlightSeries;
 	TSet<FName> CollapsedGroups;
 	TMap<FName, TArray<FName>> GroupPropertyNames;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -25,7 +25,6 @@
 #include "SKawaiiPhysicsWindScopeEditPanel.h"
 #include "KawaiiPhysicsWindScopeStyle.h"
 #include "Kismet2/BlueprintEditorUtils.h"
-#include "Kismet2/KismetEditorUtilities.h"
 #include "Misc/ConfigCacheIni.h"
 #include "Misc/ScopeLock.h"
 #include "Modules/ModuleManager.h"
@@ -1655,7 +1654,6 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 					.OnParamEdit(this, &SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit)
 					.OnParamReset(this, &SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault)
 					.IsParamPinExposed(this, &SKawaiiPhysicsWindScopeWindow::IsWindParamPinExposed)
-					.OnFocusNode(FSimpleDelegate::CreateSP(this, &SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked))
 					.OnHighlightSeries(this, &SKawaiiPhysicsWindScopeWindow::SetHighlightSeries)
 				]
 			]
@@ -2827,20 +2825,6 @@ bool SKawaiiPhysicsWindScopeWindow::ComputeWindParamPinExposure(FName PropertyNa
 	}
 
 	return false;
-}
-
-void SKawaiiPhysicsWindScopeWindow::OnFocusWindScopeNodeClicked()
-{
-	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
-	if (!GraphNode)
-	{
-		KawaiiPhysicsEdWindowUtils::ShowNotification(
-			LOCTEXT("FocusWindScopeNodeFailed", "Failed to resolve the KawaiiPhysics graph node."),
-			SNotificationItem::CS_Fail);
-		return;
-	}
-
-	FKismetEditorUtilities::BringKismetToFocusAttentionOnObject(GraphNode);
 }
 
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -210,7 +210,6 @@ private:
 	void ClearWindParamPinExposureCache();
 	void RefreshWindParamPinExposureCache();
 	bool ComputeWindParamPinExposure(FName PropertyName) const;
-	void OnFocusWindScopeNodeClicked();
 
 	// 毎フレームの active timer コールバック / Active timer callback that updates Live or Preview samples.
 	EActiveTimerReturnType TickWindScope(double InCurrentTime, float InDeltaTime);


### PR DESCRIPTION
## 概要

Wind Scope 編集パネルから「カーブ(ForceRateByBoneLengthRate)は詳細パネルで編集」の案内行（Focus Node ボタン含む）を削除します。

- 占有領域が広く、パネルは風自体の調整に特化させたいため
- 行削除に伴い不要化したコードを掃除:
  - `MakeCurveRow()` の呼び出し・定義・宣言
  - `OnFocusNode` デリゲート配線（SLATE_EVENT / メンバ / 代入 / バインド）
  - `OnFocusWindScopeNodeClicked()` ハンドラと `Kismet2/KismetEditorUtilities.h` include
  - ja.po の `CurveEditGuide` / `FocusNodeButton` / stale 化した `FocusWindScopeNodeFailed` 訳エントリ

※ `ResolveGraphNode()` は他 10 箇所で使用中のため残置。

## 変更内容

純削除のみ（5 ファイル、80 行削除・追加 0 行）。

## テスト

- [x] KawaiiPhysicsSampleEditor Win64 Development ビルド成功（UE 5.8）
- [x] ヘッドレス自動テスト 132 件全 green（2 回実行で同一結果）
- [ ] エディタ実機での目視確認（パネルから案内行が消えていること）
