### PR TITLE
[perf] Hoist curve pointers and add an all-curves-empty fast path to physics settings update

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -187,38 +187,87 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 	// αはボーンに依存しないためループ前に1回だけ解決する
 	const FKawaiiPhysicsSettingsScale OverrideScale = ComputeEffectivePhysicsSettingsOverrideScale();
 
+	const FRichCurve* DampingCurve = DampingCurveData.GetRichCurveConst();
+	const FRichCurve* WorldDampingLocationCurve = WorldDampingLocationCurveData.GetRichCurveConst();
+	const FRichCurve* WorldDampingRotationCurve = WorldDampingRotationCurveData.GetRichCurveConst();
+	const FRichCurve* StiffnessCurve = StiffnessCurveData.GetRichCurveConst();
+	const FRichCurve* RadiusCurve = RadiusCurveData.GetRichCurveConst();
+	const FRichCurve* LimitAngleCurve = LimitAngleCurveData.GetRichCurveConst();
+
+	if (DampingCurve->IsEmpty() && WorldDampingLocationCurve->IsEmpty() && WorldDampingRotationCurve->IsEmpty() &&
+		StiffnessCurve->IsEmpty() && RadiusCurve->IsEmpty() && LimitAngleCurve->IsEmpty())
+	{
+		// 全カーブが空なら Eval は時刻非依存のため、フレーム内で1回だけ評価する
+		const float DampingCurveScale = DampingCurve->Eval(0.0f, 1.0f);
+		const float WorldDampingLocationCurveScale = WorldDampingLocationCurve->Eval(0.0f, 1.0f);
+		const float WorldDampingRotationCurveScale = WorldDampingRotationCurve->Eval(0.0f, 1.0f);
+		const float StiffnessCurveScale = StiffnessCurve->Eval(0.0f, 1.0f);
+		const float RadiusCurveScale = RadiusCurve->Eval(0.0f, 1.0f);
+		const float LimitAngleCurveScale = LimitAngleCurve->Eval(0.0f, 1.0f);
+
+		const float Damping = FMath::Clamp(
+			PhysicsSettings.Damping * DampingCurveScale * OverrideScale.Damping, 0.0f, 1.0f);
+		const float WorldDampingLocation = FMath::Clamp(
+			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurveScale * OverrideScale.WorldDampingLocation,
+			0.0f, 1.0f);
+		const float WorldDampingRotation = FMath::Clamp(
+			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurveScale * OverrideScale.WorldDampingRotation,
+			0.0f, 1.0f);
+		const float Stiffness = FMath::Clamp(
+			PhysicsSettings.Stiffness * StiffnessCurveScale * OverrideScale.Stiffness, 0.0f, 1.0f);
+		const float Radius = FMath::Max(
+			PhysicsSettings.Radius * RadiusCurveScale * OverrideScale.Radius, 0.0f);
+		const float BaseLimitAngle = FMath::Max(
+			PhysicsSettings.LimitAngle * LimitAngleCurveScale, 0.0f);
+		const float LimitAngle = BaseLimitAngle > 0.0f
+			                         ? FMath::Max(BaseLimitAngle * OverrideScale.LimitAngle, KINDA_SMALL_NUMBER)
+			                         : 0.0f;
+
+		for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
+		{
+			Bone.PhysicsSettings.Damping = Damping;
+			Bone.PhysicsSettings.WorldDampingLocation = WorldDampingLocation;
+			Bone.PhysicsSettings.WorldDampingRotation = WorldDampingRotation;
+			Bone.PhysicsSettings.Stiffness = Stiffness;
+			Bone.PhysicsSettings.Radius = Radius;
+			Bone.PhysicsSettings.LimitAngle = LimitAngle;
+		}
+
+		return;
+	}
+
 	for (FKawaiiPhysicsModifyBone& Bone : ModifyBones)
 	{
 		const float LengthRate = Bone.LengthRateFromRoot;
 
 		// Damping
 		Bone.PhysicsSettings.Damping = FMath::Clamp(
-			PhysicsSettings.Damping * DampingCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Damping * DampingCurve->Eval(
 				LengthRate, 1.0f) * OverrideScale.Damping, 0.0f, 1.0f);
 
 		// WorldLocationDamping
 		Bone.PhysicsSettings.WorldDampingLocation = FMath::Clamp(
-			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.WorldDampingLocation * WorldDampingLocationCurve->Eval(
 				LengthRate, 1.0f) * OverrideScale.WorldDampingLocation, 0.0f, 1.0f);
 
 		// WorldRotationDamping
 		Bone.PhysicsSettings.WorldDampingRotation = FMath::Clamp(
-			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.WorldDampingRotation * WorldDampingRotationCurve->Eval(
 				LengthRate, 1.0f) * OverrideScale.WorldDampingRotation, 0.0f, 1.0f);
 
 		// Stiffness
 		Bone.PhysicsSettings.Stiffness = FMath::Clamp(
-			PhysicsSettings.Stiffness * StiffnessCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Stiffness * StiffnessCurve->Eval(
 				LengthRate, 1.0f) * OverrideScale.Stiffness, 0.0f, 1.0f);
 
 		// Radius
 		Bone.PhysicsSettings.Radius = FMath::Max(
-			PhysicsSettings.Radius * RadiusCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.Radius * RadiusCurve->Eval(
 				LengthRate, 1.0f) * OverrideScale.Radius, 0.0f);
 
 		// LimitAngle
 		const float BaseLimitAngle = FMath::Max(
-			PhysicsSettings.LimitAngle * LimitAngleCurveData.GetRichCurveConst()->Eval(
+			PhysicsSettings.LimitAngle * LimitAngleCurve->Eval(
 				LengthRate, 1.0f), 0.0f);
 		// LimitAngle==0 は「制限なし」を意味するため、制限ありのボーンが倍率で0へ落ちて反転しないよう極小値で止める
 		Bone.PhysicsSettings.LimitAngle = BaseLimitAngle > 0.0f


### PR DESCRIPTION
## 概要

`UpdatePhysicsSettingsOfModifyBones()` のカーブ評価を最適化します。

1. **カーブポインタの hoist** — 6 本の `GetRichCurveConst()` をボーンループ外で 1 回だけ解決（従来は毎ボーン 6 回）
2. **全カーブ空の高速パス** — 6 本すべて空（キーなし）の場合、`Eval` は時刻非依存なので 6 パラメータの最終値をループ前に 1 回だけ算出し、ループ内は代入のみにする

2026-07 に実測済みだった最適化（旧 perf/hotpath-optimization、PR #208/#209 の base 付け替え漏れで master 未到達）の再実装です。当時のパッチは流用せず、現行 master の仕様に合わせて新規実装しています。

## 挙動互換性（ビット等価）

- 高速パスでも `Eval(0.0f, 1.0f)` の実戻り値を使用（1.0f 決め打ちにしない）
- `OverrideScale`（一時 settings override の倍率）は高速パスでも全 6 パラメータに毎フレーム適用。フレーム跨ぎのキャッシュなし
- `LimitAngle == 0` は「制限なし」のセマンティクスを維持（`BaseLimitAngle > 0` のときのみ `KINDA_SMALL_NUMBER` 下限）
- 乗算順序 `Base * CurveEval * Scale`・Clamp/Max の範囲は通常パスと同一

## 性能実測（正規ビルド・各 3 回実行の中央値、ベンチ内部でも 5 試行中央値）

| ベンチ | before | after | 改善 | checksum |
|---|---:|---:|---:|---|
| **Perf.PhysicsSettings.CurvesEmpty** | 0.007921 ms | 0.000357 ms | **-95.5%** (39.6→1.8 ns/bone) | 完全一致 |
| **Perf.PhysicsSettings.CurvesSet** | 0.011586 ms | 0.006699 ms | **-42.2%** | 完全一致 |
| Perf.Collision | 0.049805 ms | 0.045817 ms | -8.0% | 完全一致 |
| Perf.Chain | 0.014271 ms | 0.014408 ms | +1.0%（ノイズ域） | 完全一致 |
| Perf.ChainLegacy | 0.019364 ms | 0.019357 ms | ±0% | 完全一致 |
| Perf.Constraint | 0.019452 ms | 0.019542 ms | +0.5%（ノイズ域） | 完全一致 |
| Perf.ConstraintHeavy | 0.282689 ms | 0.289744 ms | +2.5%（ノイズ域） | 完全一致 |

- カーブ未設定（既定構成）で **-95.5%**、カーブ設定時も hoist で **-42.2%**
- Collision ベンチの -8.0% は 3 回とも範囲が重ならない一貫した改善（フレーム毎の `UpdatePhysicsSettings` 分の副次効果）
- 実行間ブレは ±1〜3% 以内。checksum は全ベンチで before/after 完全一致（数値等価）

## 検証

- 正規フルビルド（Editor ターゲット）成功
- ヘッドレス自動テスト **157 / 157 green**
  - `KawaiiPhysics.Simulation.PhysicsSettingsCurvePaths`（高速パスと per-bone 経路のビット一致）: pass
  - `KawaiiPhysics.Simulation.GoldenPositions`（全ボーン位置 double ビット列完全一致）: pass

## 備考

PR #236（unity ビルド衝突修正）とは独立です（変更ファイルが異なるため競合なし）。ただし本ブランチ単体でのフルビルドには master 側の unity 衝突（#236 が修正）が残っているため、**#236 を先にマージしてください**。