### PR TITLE
[perf] Cache collision shape derived values per simulation step

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -674,6 +674,36 @@ void FAnimNode_KawaiiPhysics::AdjustBySphereCollision(FKawaiiPhysicsModifyBone& 
 	}
 }
 
+void FAnimNode_KawaiiPhysics::PrepareCollisionShapeCaches()
+{
+	// キャッシュは operator= に意図的に載せていない（フィールド追加漏れで静かに陳腐化するため）。
+	// またコピー構築（Shared 経路の auto Converted = Limit 等）は古いキャッシュ値ごと運ぶため、
+	// AdjustBy* の前に必ず本関数で再計算することが正しさの前提。
+	auto UpdateEnabledCaches = [](auto& Limits)
+	{
+		for (auto& Limit : Limits)
+		{
+			if (Limit.bEnable)
+			{
+				Limit.UpdateRuntimeCache();
+			}
+		}
+	};
+
+	UpdateEnabledCaches(CapsuleLimits);
+	UpdateEnabledCaches(CapsuleLimitsData);
+	UpdateEnabledCaches(SharedCapsuleLimits);
+	UpdateEnabledCaches(TaperedCapsuleLimits);
+	UpdateEnabledCaches(TaperedCapsuleLimitsData);
+	UpdateEnabledCaches(SharedTaperedCapsuleLimits);
+	UpdateEnabledCaches(BoxLimits);
+	UpdateEnabledCaches(BoxLimitsData);
+	UpdateEnabledCaches(SharedBoxLimits);
+	UpdateEnabledCaches(PlanarLimits);
+	UpdateEnabledCaches(PlanarLimitsData);
+	UpdateEnabledCaches(SharedPlanarLimits);
+}
+
 void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FCapsuleLimit>& Limits)
 {
 	for (auto& Capsule : Limits)
@@ -683,8 +713,8 @@ void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone&
 			continue;
 		}
 
-		FVector StartPoint = Capsule.Location + Capsule.Rotation.GetAxisZ() * Capsule.Length * 0.5f;
-		FVector EndPoint = Capsule.Location + Capsule.Rotation.GetAxisZ() * Capsule.Length * -0.5f;
+		FVector StartPoint = Capsule.CachedStartPoint;
+		FVector EndPoint = Capsule.CachedEndPoint;
 		const float DistSquared = FMath::PointDistToSegmentSquared(Bone.Location, StartPoint, EndPoint);
 
 		const float LimitDistance = Bone.PhysicsSettings.Radius + Capsule.Radius;
@@ -695,7 +725,7 @@ void FAnimNode_KawaiiPhysics::AdjustByCapsuleCollision(FKawaiiPhysicsModifyBone&
 			if (PushDir.IsNearlyZero())
 			{
 				// ボーンがカプセル軸上に乗ると押し出し方向が消えるため軸直交方向を代替に使う
-				PushDir = Capsule.Rotation.GetAxisX();
+				PushDir = Capsule.CachedFallbackPushDir;
 			}
 			Bone.Location = ClosestPoint + PushDir * LimitDistance;
 		}
@@ -718,11 +748,9 @@ void FAnimNode_KawaiiPhysics::AdjustByTaperedCapsuleCollision(FKawaiiPhysicsModi
 
 		if (TaperedCapsule.Length > KINDA_SMALL_NUMBER)
 		{
-			const FVector AxisZ = TaperedCapsule.Rotation.GetAxisZ();
-			const FVector StartPoint = TaperedCapsule.Location + AxisZ * TaperedCapsule.Length * 0.5f;
-			const FVector EndPoint = TaperedCapsule.Location - AxisZ * TaperedCapsule.Length * 0.5f;
-			const FVector Segment = EndPoint - StartPoint;
-			const float T = FMath::Clamp(FVector::DotProduct(Bone.Location - StartPoint, Segment) / Segment.SizeSquared(),
+			const FVector StartPoint = TaperedCapsule.CachedStartPoint;
+			const FVector Segment = TaperedCapsule.CachedSegment;
+			const float T = FMath::Clamp(FVector::DotProduct(Bone.Location - StartPoint, Segment) / TaperedCapsule.CachedSegmentSizeSq,
 			                             0.0f, 1.0f);
 			ClosestPoint = StartPoint + Segment * T;
 			// Chaos PhiWithNormal 準拠の近似（厳密な2球凸包SDFではない）
@@ -737,7 +765,7 @@ void FAnimNode_KawaiiPhysics::AdjustByTaperedCapsuleCollision(FKawaiiPhysicsModi
 			if (PushDir.IsNearlyZero())
 			{
 				// ボーンがカプセル軸上に乗ると押し出し方向が消えるため軸直交方向を代替に使う
-				PushDir = TaperedCapsule.Rotation.GetAxisX();
+				PushDir = TaperedCapsule.CachedFallbackPushDir;
 			}
 			Bone.Location = ClosestPoint + PushDir * LimitDistance;
 		}
@@ -753,11 +781,11 @@ void FAnimNode_KawaiiPhysics::AdjustByBoxCollision(FKawaiiPhysicsModifyBone& Bon
 			continue;
 		}
 
-		FTransform BoxTransform(Box.Rotation, Box.Location);
+		FTransform BoxTransform = Box.CachedBoxTransform;
 		float SphereRadius = Bone.PhysicsSettings.Radius;
 
 		FVector LocalSphereCenter = BoxTransform.InverseTransformPosition(Bone.Location);
-		FBox LocalBox(-Box.Extent, Box.Extent);
+		FBox LocalBox = Box.CachedLocalBox;
 		if (FMath::SphereAABBIntersection(FSphere(LocalSphereCenter, SphereRadius), LocalBox))
 		{
 			// Sphere の中心に最も近い Box 上の点を計算
@@ -821,7 +849,7 @@ void FAnimNode_KawaiiPhysics::AdjustByPlanerCollision(FKawaiiPhysicsModifyBone& 
 		if (DistSquared < Bone.PhysicsSettings.Radius * Bone.PhysicsSettings.Radius ||
 			FMath::SegmentPlaneIntersection(Bone.Location, Bone.PrevLocation, Planar.Plane, IntersectionPoint))
 		{
-			Bone.Location = PointOnPlane + Planar.Rotation.GetUpVector() * Bone.PhysicsSettings.Radius;
+			Bone.Location = PointOnPlane + Planar.CachedNormal * Bone.PhysicsSettings.Radius;
 		}
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -763,6 +763,10 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 		}
 	}
 
+	// ExternalForce::PostApply が substep 毎にコリジョン limit を書き換え得るため、
+	// 形状派生値キャッシュは毎ステップ再計算する（コストは形状数オーダーで誤差級）
+	PrepareCollisionShapeCaches();
+
 	// Adjust by Bone Constraints Before Collision
 	if (BoneConstraintIterationCountBeforeCollision > 0)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
@@ -7,6 +7,7 @@
 #include "Templates/Function.h"
 #include "Curves/CurveFloat.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce.h"
+#include "KawaiiPhysicsSharedCollisionSubsystem.h"
 #include "KawaiiPhysicsTestHarness.h"
 
 namespace
@@ -217,6 +218,206 @@ namespace
 			TestName, MedianMsPerCall, NsPerBone, Checksum));
 		return bFinite;
 	}
+
+	// ---------------------------------------------------------------
+	// Shared Collision Copy Perf
+	// ---------------------------------------------------------------
+	// Shared コリジョン経路（Publish→ReadMerged→格納）が丸ごとコピーする limit 構造体の量を計測する。
+	// 非UPROPERTYキャッシュメンバの追加でサイズが増えた分（Capsule/TaperedCapsule/Box/Planar）が
+	// フレーム毎コピーコストとして無視できる規模かどうかを実測するのが目的。
+	// ソースは2つ、各ソースはSphere/Capsule/TaperedCapsule/Box各8個・Planar4個を持つ。
+
+	constexpr int32 GSharedCollisionSphereCount = 8;
+	constexpr int32 GSharedCollisionCapsuleCount = 8;
+	constexpr int32 GSharedCollisionTaperedCapsuleCount = 8;
+	constexpr int32 GSharedCollisionBoxCount = 8;
+	constexpr int32 GSharedCollisionPlanarCount = 4;
+	constexpr int32 GSharedCollisionSourceCount = 2;
+	constexpr int32 GSharedCollisionLimitsPerSource =
+		GSharedCollisionSphereCount + GSharedCollisionCapsuleCount + GSharedCollisionTaperedCapsuleCount +
+		GSharedCollisionBoxCount + GSharedCollisionPlanarCount;
+	constexpr int32 GSharedCollisionLimitsPerFrame = GSharedCollisionLimitsPerSource * GSharedCollisionSourceCount;
+
+	// WriteSharedCollisionToSubsystemが送り出す変換済みデータ相当のテンプレートを1ソース分作る
+	// （空間変換[ConvertSimulationSpaceTransform]は本ベンチの対象外。構造体コピーそのものの帯域を測るのが目的）。
+	FKawaiiPhysicsSharedCollisionData MakeSharedCollisionSourceTemplate(float Base)
+	{
+		FKawaiiPhysicsSharedCollisionData Data;
+
+		for (int32 Index = 0; Index < GSharedCollisionSphereCount; ++Index)
+		{
+			FSphericalLimit Sphere;
+			Sphere.bEnable = true;
+			Sphere.Location = FVector(Base + Index, Base + Index * 2.0f, Base + Index * 3.0f);
+			Sphere.Rotation = FQuat(FVector(0.0, 0.0, 1.0), 0.1f * Index);
+			Sphere.Radius = 10.0f + Index;
+			Sphere.LimitType = ESphericalLimitType::Outer;
+			Data.SphericalLimits.Add(Sphere);
+		}
+
+		for (int32 Index = 0; Index < GSharedCollisionCapsuleCount; ++Index)
+		{
+			FCapsuleLimit Capsule;
+			Capsule.bEnable = true;
+			Capsule.Location = FVector(Base + Index, Base - Index, Base + Index * 2.0f);
+			Capsule.Rotation = FQuat(FVector(1.0, 0.0, 0.0), 0.1f * Index);
+			Capsule.Radius = 5.0f;
+			Capsule.Length = 40.0f + Index;
+			Data.CapsuleLimits.Add(Capsule);
+		}
+
+		for (int32 Index = 0; Index < GSharedCollisionTaperedCapsuleCount; ++Index)
+		{
+			FTaperedCapsuleLimit TaperedCapsule;
+			TaperedCapsule.bEnable = true;
+			TaperedCapsule.Location = FVector(Base - Index, Base + Index, Base + Index * 4.0f);
+			TaperedCapsule.Rotation = FQuat(FVector(0.0, 1.0, 0.0), 0.1f * Index);
+			TaperedCapsule.Radius0 = 6.0f + Index;
+			TaperedCapsule.Radius1 = 4.0f + Index;
+			TaperedCapsule.Length = 50.0f + Index;
+			Data.TaperedCapsuleLimits.Add(TaperedCapsule);
+		}
+
+		for (int32 Index = 0; Index < GSharedCollisionBoxCount; ++Index)
+		{
+			FBoxLimit Box;
+			Box.bEnable = true;
+			Box.Location = FVector(Base + Index * 2.0f, Base, Base - Index);
+			Box.Rotation = FQuat(FVector(0.0, 0.0, 1.0), 0.05f * Index);
+			Box.Extent = FVector(8.0f, 8.0f, 20.0f + Index);
+			Data.BoxLimits.Add(Box);
+		}
+
+		for (int32 Index = 0; Index < GSharedCollisionPlanarCount; ++Index)
+		{
+			FPlanarLimit Planar;
+			Planar.bEnable = true;
+			Planar.Location = FVector(Base, Base + Index * 10.0f, Base - 100.0f - Index * 50.0f);
+			Planar.Rotation = FQuat(FVector(1.0, 0.0, 0.0), 0.05f * Index);
+			Planar.Plane = FPlane(Planar.Location, Planar.Rotation.GetUpVector());
+			Data.PlanarLimits.Add(Planar);
+		}
+
+		return Data;
+	}
+
+	// ConvertAndAppend/ConvertAndStoreが行う「要素毎に一旦ローカル変数へコピーしてAddする」を模した汎用コピー。
+	template <typename TLimitArray>
+	void CopyLimitsElementwise(const TLimitArray& InLimits, TLimitArray& OutLimits)
+	{
+		OutLimits.Reserve(OutLimits.Num() + InLimits.Num());
+		for (const auto& Limit : InLimits)
+		{
+			auto Converted = Limit;
+			OutLimits.Add(Converted);
+		}
+	}
+
+	// WriteSharedCollisionToSubsystemのConvertAndAppendを模す: テンプレートからスクラッチへ要素毎コピーしてPublishする。
+	void PublishSharedCollisionSource(const FKawaiiPhysicsSharedCollisionData& Template,
+	                                  FKawaiiPhysicsSharedCollisionData& Scratch,
+	                                  FKawaiiPhysicsSharedCollisionSourceSlot& Slot)
+	{
+		Scratch.Reset();
+		CopyLimitsElementwise(Template.SphericalLimits, Scratch.SphericalLimits);
+		CopyLimitsElementwise(Template.CapsuleLimits, Scratch.CapsuleLimits);
+		CopyLimitsElementwise(Template.TaperedCapsuleLimits, Scratch.TaperedCapsuleLimits);
+		CopyLimitsElementwise(Template.BoxLimits, Scratch.BoxLimits);
+		CopyLimitsElementwise(Template.PlanarLimits, Scratch.PlanarLimits);
+		Slot.Publish(Scratch);
+	}
+
+	// UpdateSharedCollisionLimitsのConvertAndStoreを模す: ReadMergedで受け取った配列をShared側へ要素毎コピーする。
+	// 本番はSharedSphericalLimits等5本の個別TArrayだが、コピー対象の構造体・要素数は同一なので
+	// FKawaiiPhysicsSharedCollisionDataを使い回して集約する（計測の本質＝要素毎コピー帯域には影響しない）。
+	int32 StoreSharedCollisionLimits(const FKawaiiPhysicsSharedCollisionData& Merged,
+	                                 FKawaiiPhysicsSharedCollisionData& SharedOut)
+	{
+		SharedOut.Reset();
+		CopyLimitsElementwise(Merged.SphericalLimits, SharedOut.SphericalLimits);
+		CopyLimitsElementwise(Merged.CapsuleLimits, SharedOut.CapsuleLimits);
+		CopyLimitsElementwise(Merged.TaperedCapsuleLimits, SharedOut.TaperedCapsuleLimits);
+		CopyLimitsElementwise(Merged.BoxLimits, SharedOut.BoxLimits);
+		CopyLimitsElementwise(Merged.PlanarLimits, SharedOut.PlanarLimits);
+		return SharedOut.SphericalLimits.Num() + SharedOut.CapsuleLimits.Num() +
+			SharedOut.TaperedCapsuleLimits.Num() + SharedOut.BoxLimits.Num() + SharedOut.PlanarLimits.Num();
+	}
+
+	bool RunSharedCollisionCopyPerf(FAutomationTestBase& Test)
+	{
+		FKawaiiPhysicsSharedCollisionData SourceTemplates[GSharedCollisionSourceCount];
+		for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
+		{
+			SourceTemplates[SourceIndex] = MakeSharedCollisionSourceTemplate(10.0f + SourceIndex * 100.0f);
+		}
+
+		TArray<double> MsPerFrameValues;
+		MsPerFrameValues.Reserve(GTrials);
+		int32 LastMergedLimitCount = 0;
+
+		for (int32 Trial = 0; Trial < GTrials; ++Trial)
+		{
+			// 本番のCachedSharedCollisionEntry/CachedSourceSlotに相当するキャッシュを試行毎に作り直す
+			// （Entry/Slotはワールド非依存のプレーン構造体のため、Subsystem/Worldを経由せず直接構築できる）。
+			FKawaiiPhysicsSharedCollisionEntry Entry;
+			TArray<TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>> Slots;
+			for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
+			{
+				Slots.Add(Entry.GetOrCreateSlot(static_cast<uint64>(SourceIndex) + 1));
+			}
+
+			// 本番のSharedCollisionPublishScratchに相当する使い回しスクラッチ
+			// （Publishのswapで前フレームのBufferが戻り、確保済みメモリを再利用できる）。
+			TArray<FKawaiiPhysicsSharedCollisionData> PublishScratches;
+			PublishScratches.SetNum(GSharedCollisionSourceCount);
+
+			// 本番のSharedCollisionMergedData/Shared*Limitsに相当する使い回しバッファ。
+			FKawaiiPhysicsSharedCollisionData MergedData;
+			FKawaiiPhysicsSharedCollisionData SharedStore;
+
+			for (int32 Frame = 0; Frame < GWarmupFrames; ++Frame)
+			{
+				for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
+				{
+					PublishSharedCollisionSource(SourceTemplates[SourceIndex], PublishScratches[SourceIndex],
+						*Slots[SourceIndex]);
+				}
+				Entry.ReadMerged(MergedData);
+				StoreSharedCollisionLimits(MergedData, SharedStore);
+			}
+
+			const double StartSeconds = FPlatformTime::Seconds();
+			for (int32 Frame = 0; Frame < GMeasureFrames; ++Frame)
+			{
+				for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
+				{
+					PublishSharedCollisionSource(SourceTemplates[SourceIndex], PublishScratches[SourceIndex],
+						*Slots[SourceIndex]);
+				}
+				Entry.ReadMerged(MergedData);
+				LastMergedLimitCount = StoreSharedCollisionLimits(MergedData, SharedStore);
+			}
+			const double ElapsedSeconds = FPlatformTime::Seconds() - StartSeconds;
+			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(GMeasureFrames);
+
+			Test.AddInfo(FString::Printf(TEXT("PERF_RAW KawaiiPhysics.Perf.SharedCollisionCopy trial=%d ms=%.6f"),
+				Trial, MsPerFrame));
+			MsPerFrameValues.Add(MsPerFrame);
+		}
+
+		// コピー漏れ/重複がないことを最終フレームのマージ結果件数で検証する（2ソース分の合計件数と一致するはず）。
+		const bool bCountOk = Test.TestEqual(
+			TEXT("Merged limit count matches two sources worth of template limits"),
+			LastMergedLimitCount, GSharedCollisionLimitsPerFrame);
+
+		MsPerFrameValues.Sort();
+		const double MedianMsPerFrame = MsPerFrameValues[GTrials / 2];
+		Test.AddInfo(FString::Printf(
+			TEXT("PERF KawaiiPhysics.Perf.SharedCollisionCopy median_ms_per_frame=%.6f limits_per_frame=%d"),
+			MedianMsPerFrame, GSharedCollisionLimitsPerFrame));
+
+		return bCountOk;
+	}
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfChainTest,
@@ -329,6 +530,18 @@ bool FKawaiiPhysicsPerfPhysicsSettingsTest::RunTest(const FString& Parameters)
 	return bOk;
 }
 
+// Shared コリジョン経路（Publish→ReadMerged→格納）の構造体コピー帯域を計測する。
+// ソース2つ×(Sphere8+Capsule8+TaperedCapsule8+Box8+Planar4) = 72limit/frame を毎フレーム
+// Publish→ReadMerged→要素毎コピーし、その所要時間を中央値で報告する。
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSharedCollisionCopyTest,
+                                 "KawaiiPhysics.Perf.SharedCollisionCopy",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsPerfSharedCollisionCopyTest::RunTest(const FString& Parameters)
+{
+	return RunSharedCollisionCopyPerf(*this);
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSizeofTest,
                                  "KawaiiPhysics.Perf.Sizeof",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -341,6 +554,8 @@ bool FKawaiiPhysicsPerfSizeofTest::RunTest(const FString& Parameters)
 	                        static_cast<int32>(sizeof(FKawaiiPhysicsSettings))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FSphericalLimit = %d"), static_cast<int32>(sizeof(FSphericalLimit))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FCapsuleLimit = %d"), static_cast<int32>(sizeof(FCapsuleLimit))));
+	AddInfo(FString::Printf(TEXT("SIZEOF FTaperedCapsuleLimit = %d"),
+	                        static_cast<int32>(sizeof(FTaperedCapsuleLimit))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FBoxLimit = %d"), static_cast<int32>(sizeof(FBoxLimit))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FPlanarLimit = %d"), static_cast<int32>(sizeof(FPlanarLimit))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FModifyBoneConstraint = %d"),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -303,18 +303,34 @@ struct FKawaiiPhysicsTestAccessor
 	}
 	void CallCapsuleCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FCapsuleLimit>& Limits)
 	{
+		for (FCapsuleLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByCapsuleCollision(Bone, Limits);
 	}
 	void CallTaperedCapsuleCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FTaperedCapsuleLimit>& Limits)
 	{
+		for (FTaperedCapsuleLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByTaperedCapsuleCollision(Bone, Limits);
 	}
 	void CallBoxCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FBoxLimit>& Limits)
 	{
+		for (FBoxLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByBoxCollision(Bone, Limits);
 	}
 	void CallPlanarCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits)
 	{
+		for (FPlanarLimit& Limit : Limits)
+		{
+			Limit.UpdateRuntimeCache();
+		}
 		Node.AdjustByPlanerCollision(Bone, Limits);
 	}
 	void CallAngleLimit(FKawaiiPhysicsModifyBone& Bone, const FKawaiiPhysicsModifyBone& ParentBone)
@@ -535,6 +551,9 @@ private:
 				Node.AdjustByBoneConstraints();
 			}
 		}
+
+		// 本番 SimulateOnce と同様、形状キャッシュはステップ毎に再計算
+		Node.PrepareCollisionShapeCaches();
 
 		// コリジョン（SimulateOnce 413-445、AnimNode 側 limits のみ）
 		for (FKawaiiPhysicsModifyBone& Bone : Node.ModifyBones)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -1430,6 +1430,9 @@ protected:
 	 */
 	void AdjustBySphereCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FSphericalLimit>& Limits);
 
+	// コリジョン形状の派生値キャッシュを再計算 / Recompute derived-value caches of collision shapes
+	void PrepareCollisionShapeCaches();
+
 	/**
 	 * Adjusts the bone position based on capsule collision limits.
 	 *

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
@@ -167,6 +167,18 @@ struct FCapsuleLimit : public FCollisionLimitBase
 	UPROPERTY(EditAnywhere, Category = "Capsule Limit", meta = (ClampMin = "0"))
 	float Length = 10.0f;
 
+	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)
+	FVector CachedStartPoint = FVector::ZeroVector;
+	FVector CachedEndPoint = FVector::ZeroVector;
+	FVector CachedFallbackPushDir = FVector::ZeroVector;
+
+	void UpdateRuntimeCache()
+	{
+		CachedStartPoint = Location + Rotation.GetAxisZ() * Length * 0.5f;
+		CachedEndPoint = Location + Rotation.GetAxisZ() * Length * -0.5f;
+		CachedFallbackPushDir = Rotation.GetAxisX();
+	}
+
 	/** Assignment operator */
 	FCapsuleLimit& operator=(const FCapsuleLimit& Other)
 	{
@@ -207,6 +219,23 @@ struct FTaperedCapsuleLimit : public FCollisionLimitBase
 	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0"))
 	float Length = 10.0f;
 
+	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)
+	FVector CachedStartPoint = FVector::ZeroVector;
+	FVector CachedEndPoint = FVector::ZeroVector;
+	FVector CachedSegment = FVector::ZeroVector;
+	FVector::FReal CachedSegmentSizeSq = 0.0;
+	FVector CachedFallbackPushDir = FVector::ZeroVector;
+
+	void UpdateRuntimeCache()
+	{
+		const FVector AxisZ = Rotation.GetAxisZ();
+		CachedStartPoint = Location + AxisZ * Length * 0.5f;
+		CachedEndPoint = Location - AxisZ * Length * 0.5f;
+		CachedSegment = CachedEndPoint - CachedStartPoint;
+		CachedSegmentSizeSq = CachedSegment.SizeSquared();
+		CachedFallbackPushDir = Rotation.GetAxisX();
+	}
+
 	/** Assignment operator */
 	FTaperedCapsuleLimit& operator=(const FTaperedCapsuleLimit& Other)
 	{
@@ -240,6 +269,17 @@ struct FBoxLimit : public FCollisionLimitBase
 	UPROPERTY(EditAnywhere, Category = "Box Limit")
 	FVector Extent = FVector(5.0f, 5.0f, 5.0f);
 
+	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)
+	FTransform CachedBoxTransform = FTransform::Identity;
+	// FBox は既定構築で Min/Max が未初期化のため ForceInit で明示ゼロ化 / FBox default construction leaves Min/Max uninitialized, so ForceInit explicitly zeroes it
+	FBox CachedLocalBox = FBox(ForceInit);
+
+	void UpdateRuntimeCache()
+	{
+		CachedBoxTransform = FTransform(Rotation, Location);
+		CachedLocalBox = FBox(-Extent, Extent);
+	}
+
 	/** Assignment operator */
 	FBoxLimit& operator=(const FBoxLimit& Other)
 	{
@@ -270,6 +310,14 @@ struct FPlanarLimit : public FCollisionLimitBase
 	/** The plane defining the planar limit */
 	UPROPERTY()
 	FPlane Plane = FPlane(0, 0, 0, 0);
+
+	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)
+	FVector CachedNormal = FVector::ZeroVector;
+
+	void UpdateRuntimeCache()
+	{
+		CachedNormal = Rotation.GetUpVector();
+	}
 
 	/** Assignment operator */
 	FPlanarLimit& operator=(const FPlanarLimit& Other)


### PR DESCRIPTION
## 概要

ボーン毎シミュレーションループ内で毎回計算していたコリジョン形状の派生値を、シミュレーションステップ毎1回の `PrepareCollisionShapeCaches()` に集約するホットパス最適化です（ホットパス最適化テーマ2）。

- Capsule: 線分端点（`GetAxisZ()` からの Start/End）、フォールバック押し出し方向（`GetAxisX()`）
- TaperedCapsule: 線分端点・セグメント・長さ二乗（除算の分母）・フォールバック押し出し方向
- Box: `FTransform(Rotation, Location)`・ローカル AABB `FBox(-Extent, Extent)`
- Planar: 押し出し法線（`Rotation.GetUpVector()`）
- Spherical: 派生値なしのため対象外

## 計測結果（同一マシン・master 新規ベースライン、3回実行 × 各5試行中央値）

| ベンチ | master | 本PR | 差 |
|---|---|---|---|
| Perf.Collision（200ボーン×18コライダー） | 0.0496 ms/frame | 0.0313 ms/frame | **−36.8%** |

- checksum は前後3回すべて `-574346.110571` で完全一致
- `KawaiiPhysics.Simulation.GoldenPositions`（全ボーン位置の double ビット列一致）成功 — 数値挙動は 1 bit も変化なし
- 全157自動テスト成功
- 他ベンチ（Chain / Constraint 等）はノイズ範囲内・checksum 一致（副作用なし）

## 設計ポイント

- キャッシュは**非 UPROPERTY** メンバ（シリアライズ・リフレクション対象外。アセット保存サイズ不変）
- 手書き `operator=` には**意図的に載せない** — 代入でキャッシュを運ぶと将来のフィールド追加漏れで静かに陳腐化するため、毎ステップ再計算で構造的に防止
- 再計算位置は `SimulateOnce()` の衝突処理節冒頭（`ExternalForce::PostApply` の後）。PostApply が substep 毎にコリジョン limit を書き換え得るため、フレーム毎1回ではなく毎ステップ再計算（コストは形状数オーダーで誤差級）
- **ビット一致の維持**: 演算の形を一切変更していない（例: Capsule 終端は `Location + AxisZ * Length * -0.5f` のまま、TaperedCapsule の `/ SizeSquared` を逆数乗算化しない）
- テストハーネス追随: `StepOnce()` の衝突節と `Call*Collision` ヘルパーでキャッシュ再計算を実施

## トレードオフ

構造体サイズ増（ランタイムのみ）: Capsule 160→240B / TaperedCapsule 192→272B / Box 176→336B / Planar 192→224B。

Shared コリジョン経路（Publish→ReadMerged→格納）は構造体を丸ごとコピーするため帯域が増えますが、新設の `KawaiiPhysics.Perf.SharedCollisionCopy` ベンチで **72 limits/frame のコピー経路全体が 1.8μs/frame** と実測済みで、増分はその一部に留まります（削減幅 −18μs/frame の 2桁下）。コピーされた古いキャッシュ値は `PrepareCollisionShapeCaches` が `AdjustBy*` の前に必ず走るため消費されません。

## テスト

- [x] `KawaiiPhysics.Simulation.GoldenPositions` ビット一致
- [x] 全 KawaiiPhysics 自動テスト（157件）成功
- [x] `Perf.Collision` 前後実測（−36.8%・checksum 一致）
- [x] `Perf.SharedCollisionCopy` 新設・実測（1.8μs/frame @ 72 limits）
- [x] `Perf.Sizeof` に `FTaperedCapsuleLimit` 追加
- [ ] PIE 目視確認（Golden ビット一致のためマージ前必須とせず、手動確認台帳で管理）
