### PR TITLE
[fix] Wind Scope edit panel: typed values not applied on first commit

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -703,7 +703,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 	else if (KawaiiPhysicsWindScopeEditPanelPrivate::IsEditPanelParameterModeProperty(Property))
 	{
 		ValueWidget =
-			SNew(SComboBox<TSharedPtr<EKawaiiProceduralWindParameterMode>>)
+			SAssignNew(ParameterModeComboBox, SComboBox<TSharedPtr<EKawaiiProceduralWindParameterMode>>)
 			.OptionsSource(&KawaiiPhysicsWindScopeEditPanelPrivate::GetParameterModeItems())
 			.InitiallySelectedItem(KawaiiPhysicsWindScopeEditPanelPrivate::GetParameterModeItems()[0])
 			.OnGenerateWidget_Lambda([](TSharedPtr<EKawaiiProceduralWindParameterMode> Item)
@@ -712,9 +712,20 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 					.Text(Item.IsValid() ? KawaiiPhysicsWindScopeEditPanelPrivate::FormatParameterMode(*Item) : FText::GetEmpty())
 					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9));
 			})
+			// SComboBox は内部 SelectedItem と異なる項目を選んだときしか OnSelectionChanged を発火しない。
+			// 内部状態はここでしか更新されないため、開く直前にノードの実値へ合わせておかないと
+			// 「1回目の選択が無視される」「ドロップダウンのハイライトが実値とずれる」が起きる
+			.OnComboBoxOpening_Lambda([this]()
+			{
+				SyncParameterModeComboSelection();
+			})
 			.OnSelectionChanged_Lambda([this, PropertyName = ParamDef.PropertyName](TSharedPtr<EKawaiiProceduralWindParameterMode> Item, ESelectInfo::Type SelectInfo)
 			{
 				(void)SelectInfo;
+				if (bSyncingParameterModeCombo)
+				{
+					return;
+				}
 				if (Item.IsValid() && OnParamEdit.IsBound())
 				{
 					OnParamEdit.Execute(PropertyName, static_cast<double>(static_cast<uint8>(*Item)), INDEX_NONE, EKawaiiWindEditPhase::Committed);
@@ -977,6 +988,37 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeResetButton(FName Prop
 			SNew(SImage)
 			.Image(FAppStyle::Get().GetBrush(TEXT("PropertyWindow.DiffersFromDefault")))
 		];
+}
+
+// SetSelectedItem は SListView 経由で OnSelectionChanged を誘発するため、
+// ガードを立てて自前ハンドラ（＝不要な編集イベント）を抑止してから同期する
+void SKawaiiPhysicsWindScopeEditPanel::SyncParameterModeComboSelection()
+{
+	if (!ParameterModeComboBox.IsValid())
+	{
+		return;
+	}
+
+	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	if (!Values || !Values->bValid)
+	{
+		return;
+	}
+
+	const TArray<TSharedPtr<EKawaiiProceduralWindParameterMode>>& Items =
+		KawaiiPhysicsWindScopeEditPanelPrivate::GetParameterModeItems();
+	const TSharedPtr<EKawaiiProceduralWindParameterMode>* MatchedItem = Items.FindByPredicate(
+		[Mode = Values->ParameterMode](const TSharedPtr<EKawaiiProceduralWindParameterMode>& Item)
+		{
+			return Item.IsValid() && *Item == Mode;
+		});
+	if (!MatchedItem || *MatchedItem == ParameterModeComboBox->GetSelectedItem())
+	{
+		return;
+	}
+
+	TGuardValue<bool> SyncGuard(bSyncingParameterModeCombo, true);
+	ParameterModeComboBox->SetSelectedItem(*MatchedItem);
 }
 
 void SKawaiiPhysicsWindScopeEditPanel::LoadCollapsedGroupsFromConfig()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -712,13 +712,6 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 					.Text(Item.IsValid() ? KawaiiPhysicsWindScopeEditPanelPrivate::FormatParameterMode(*Item) : FText::GetEmpty())
 					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9));
 			})
-			// SComboBox は内部 SelectedItem と異なる項目を選んだときしか OnSelectionChanged を発火しない。
-			// 内部状態はここでしか更新されないため、開く直前にノードの実値へ合わせておかないと
-			// 「1回目の選択が無視される」「ドロップダウンのハイライトが実値とずれる」が起きる
-			.OnComboBoxOpening_Lambda([this]()
-			{
-				SyncParameterModeComboSelection();
-			})
 			.OnSelectionChanged_Lambda([this, PropertyName = ParamDef.PropertyName](TSharedPtr<EKawaiiProceduralWindParameterMode> Item, ESelectInfo::Type SelectInfo)
 			{
 				(void)SelectInfo;
@@ -990,11 +983,26 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeResetButton(FName Prop
 		];
 }
 
-// SetSelectedItem は SListView 経由で OnSelectionChanged を誘発するため、
-// ガードを立てて自前ハンドラ（＝不要な編集イベント）を抑止してから同期する
+// SComboBox は内部 SelectedItem と異なる項目を選んだときしか OnSelectionChanged を発火せず、
+// さらにキーボードの Up/Down はメニューを開かずにその内部 SelectedItem を起点に隣の項目を選ぶ
+// （SComboBox::OnKeyDown）。開いた瞬間だけ同期してもキーボード・ゲームパッド経路を取りこぼすため、
+// 毎フレーム実値へ寄せる。未生成・展開中・既に一致のいずれかで即 return するので、
+// 親ウィンドウが毎フレーム行っている CachedEditValues の再構築に比べれば無視できるコスト
+void SKawaiiPhysicsWindScopeEditPanel::Tick(
+	const FGeometry& AllottedGeometry,
+	const double InCurrentTime,
+	const float InDeltaTime)
+{
+	SCompoundWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
+	SyncParameterModeComboSelection();
+}
+
+// SetSelectedItem は SListView 経由で OnSelectionChanged を誘発するため、ガードを立てて
+// 自前ハンドラ（＝不要な編集イベント）を抑止してから同期する。展開中に呼ぶと
+// OnSelectionChanged_Internal の SetIsOpen(false) でドロップダウンが閉じてしまうので触らない
 void SKawaiiPhysicsWindScopeEditPanel::SyncParameterModeComboSelection()
 {
-	if (!ParameterModeComboBox.IsValid())
+	if (!ParameterModeComboBox.IsValid() || ParameterModeComboBox->IsOpen())
 	{
 		return;
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -90,6 +90,9 @@ private:
 	int32 CountHiddenAdvancedParams() const;
 	FLinearColor ResolveSeriesDisplayColor(TOptional<EKawaiiPhysicsWindScopeComponent> LinkedSeries) const;
 
+	// ParameterMode コンボの内部選択状態をノードの実値へ合わせる / Syncs the ParameterMode combo's internal selection with the node value.
+	void SyncParameterModeComboSelection();
+
 	void LoadCollapsedGroupsFromConfig();
 	void SaveCollapsedGroupsToConfig() const;
 	void HandleGroupExpansionChanged(bool bExpanded, FName GroupId);
@@ -112,5 +115,8 @@ private:
 	TSet<FName> CollapsedGroups;
 	TMap<FName, TArray<FName>> GroupPropertyNames;
 	TArray<TSharedPtr<SExpandableArea>> GroupAreas;
+	TSharedPtr<SComboBox<TSharedPtr<EKawaiiProceduralWindParameterMode>>> ParameterModeComboBox;
 	bool bApplyingGroupExpansionBatch = false;
+	// SetSelectedItem が誘発する OnSelectionChanged を自前ハンドラで無視するためのガード / Guards against the OnSelectionChanged triggered by SetSelectedItem.
+	bool bSyncingParameterModeCombo = false;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -57,6 +57,8 @@ public:
 
 	void Construct(const FArguments& InArgs);
 
+	virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
+
 private:
 	TSharedRef<SWidget> MakeFormulaHelpButton() const;
 	TSharedRef<SWidget> MakeFormulaHelpContent() const;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -2338,6 +2338,7 @@ FReply SKawaiiPhysicsWindScopeWindow::ApplyPreset(const FKawaiiProceduralWindPre
 	// シミュレーションリセット回避のため PostEditChangeProperty / NotifyGraphNodePropertyChanged は呼ばず、
 	// ライブ側には PendingParams 経由で同じ値を送る
 	const bool bAppliedLive = PushParamsToLiveRuntime(Params);
+	SyncEditValuesAfterWrite(Wind);
 
 	// 外力一覧を更新し、成功通知を表示
 	RefreshExternalForceItems();
@@ -2608,6 +2609,7 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked()
 	KawaiiPhysicsWindScopeWindowPrivate::MarkWindScopeGraphNodeModified(GraphNode);
 	Args.ExternalForceIndex = ResolvedIndex;
 	const bool bAppliedLive = PushParamsToLiveRuntime(Wind->BuildDynamicParamsSnapshot());
+	SyncEditValuesAfterWrite(Wind);
 	RefreshExternalForceItems();
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		bAppliedLive
@@ -2779,6 +2781,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		{
 			PushParamsToLiveRuntime(Params);
 		}
+		SyncEditValuesAfterWrite(Wind);
 		return true;
 	}
 
@@ -2796,6 +2799,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 			}
 		}
 		bHasDragStartWind = false;
+		SyncEditValuesAfterWrite(Wind);
 		return true;
 	}
 
@@ -2812,6 +2816,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		KawaiiPhysicsEdWindowUtils::ShowNotification(
 			LOCTEXT("EditWindParamSetFailed", "Failed to update the wind parameter."),
 			SNotificationItem::CS_Fail);
+		SyncEditValuesAfterWrite(Wind);
 		return FailEdit();
 	}
 
@@ -2824,6 +2829,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	{
 		PushParamsToLiveRuntime(Params);
 	}
+	SyncEditValuesAfterWrite(Wind);
 	return true;
 }
 
@@ -2890,6 +2896,7 @@ void SKawaiiPhysicsWindScopeWindow::FinalizeAbandonedWindDrag()
 	{
 		PushParamsToLiveRuntime(Params);
 	}
+	SyncEditValuesAfterWrite(Wind);
 }
 
 bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
@@ -2929,6 +2936,7 @@ bool SKawaiiPhysicsWindScopeWindow::ResetWindParamToDefault(FName PropertyName)
 	{
 		PushParamsToLiveRuntime(Params);
 	}
+	SyncEditValuesAfterWrite(Wind);
 	return true;
 }
 
@@ -3170,6 +3178,17 @@ void SKawaiiPhysicsWindScopeWindow::UpdateEditValuesFromWind(
 	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind)
 {
 	KawaiiPhysicsWindScopeWindowPrivate::FillWindScopeEditValuesFromWind(Wind, CachedEditValues, true);
+}
+
+// ノード実体を書き換えた経路は必ずここを通す。編集パネルの SSpinBox は Value を CachedEditValues に
+// バインドしており、Slate のテキスト確定は OnTextCommitted の直後、同一コールスタック内で
+// バインド値を読み直す（FSlateEditableTextLayout::LoadText）。TickWindScope による次フレームの更新を
+// 待つと、そこで旧値が読まれて入力欄が巻き戻り、さらにフォーカスを外した際にその旧値が
+// ノードへ書き戻されてしまう
+void SKawaiiPhysicsWindScopeWindow::SyncEditValuesAfterWrite(
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind)
+{
+	UpdateEditValuesFromWind(Wind);
 }
 
 void SKawaiiPhysicsWindScopeWindow::UpdateLiveEditValuesFromRuntime()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -225,6 +225,8 @@ private:
 	// Preview 計算用に ProceduralWind 設定値のコピーを取得する / Gets a ProceduralWind copy for Preview calculation.
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
 	void UpdateEditValuesFromWind(const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind);
+	// ノードへ書いた直後に表示キャッシュを同期する / Syncs the display cache immediately after writing to the node.
+	void SyncEditValuesAfterWrite(const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind);
 	void UpdateLiveEditValuesFromRuntime();
 	void LoadEditPanelConfig();
 	void SaveEditPanelConfig() const;


### PR DESCRIPTION
## 何が起きていたか（症状）

Wind Scope タブの編集パネルで、数値パラメータをキーボードで打ち込んで Enter しても:

- **1回目は反映されず**、入力欄の表示が元の値に戻る
- そのまま別の場所をクリックすると**旧値がノードへ書き戻されて編集が失われる**（余計な Undo も1段積まれる）
- 同じ操作を2回目に行うと反映される

編集パネル導入時（`135b1db`）からある初期バグで、回帰ではありません。

## なぜ起きるか（要点）

入力欄（SpinBox）の表示は、**1/60 秒ごとにしか更新されないキャッシュ**（`CachedEditValues`）にバインドされていました。一方、値を書き込む処理はノード本体だけを更新し、このキャッシュを同期していませんでした。

Slate は Enter 確定の**直後・同一コールスタック内で**バインド値を読み戻すため、そこで「まだ古いキャッシュ」が読まれて入力欄が旧値で上書きされます。フォーカスが残ったまま外すと、その旧値が確定値としてノードへ書き戻されます。2回目で通るのは、その間にキャッシュ更新の Tick が走っているためです。

## 何をどう直したか

### 1. 書き込みと同一コールスタックでキャッシュを同期

`SyncEditValuesAfterWrite()` を追加し、ノード実体を書き換える**全 8 経路**（`ApplyWindParamEdit` の 4 分岐、`FinalizeAbandonedWindDrag`、`ResetWindParamToDefault`、`ApplyPreset`、Paste）から呼ぶようにしました。

副次効果として、ドラッグ中に SpinBox が「外部要因で値が変わった」と誤検知して差分を破棄する問題（＝ドラッグのもたつき）も解消しています。

### 2. ParameterMode コンボの「1回目の選択が無視される」問題（同種の独立バグ）

コンボボックスの内部選択状態が実値と同期されておらず、ノードが Advanced のときに Simple を選んでも 1 回目は無視されていました。パネルの `Tick()` で毎フレーム実値へ寄せる方式で修正しています（キーボード Up/Down はメニューを開かずに内部選択起点で動くため、「開いた瞬間だけ同期」ではキーボード経路を取りこぼします）。未生成・展開中・既に一致の場合は即 return します。

<details>
<summary>エンジン内部の詳細（技術的裏付け）</summary>

**数値入力（修正1）:**

- `FSlateEditableTextLayout::HandleCarriageReturn` が `OnTextCommitted` の直後に `LoadText()` を呼ぶ（`SlateEditableTextLayout.cpp:1719`、コメント: "Reload underlying value now it is committed"）
- `LoadText()` は `bForceBoundTextReview` を立てるため、フォーカス中の上書きを防ぐガード（同 `:4343`）を素通りし、古いスナップショットで入力欄が上書きされる
- `SSpinBox` は Enter では `ExitTextMode()` を呼ばず（`SSpinBox.cpp:979`）、`_ClearKeyboardFocusOnCommit` も既定 false のためフォーカスが残る。その状態でフォーカスを外すと `HandleFocusLost` → `OnTextCommitted(旧値)` で旧値がノードへ書き戻される
- ドラッグのもたつきは `SSpinBox::CommitValue`（`SSpinBox.cpp:1019-1028`）の外部変更誤検知による差分破棄

**ParameterMode コンボ（修正2）:**

- `SComboBox` の内部 `SelectedItem` が `InitiallySelectedItem`（常に Simple）に固定されたままで、`OnSelectionChanged_Internal`（`SComboBox.h:627`）は「内部選択と違う項目を選んだとき」しかデリゲートを発火しない
- `SComboBox::OnKeyDown` はメニューを開かずに Up/Down を処理する（内部 `SelectedItem` 起点で `SetSelectedItem`）
- 展開中に `SetSelectedItem` しないのは、誘発される `OnSelectionChanged_Internal` の `SetIsOpen(false)` でドロップダウンが閉じてしまうため

</details>

## 検証

- `KawaiiPhysicsSampleEditor` Win64 Development ビルド成功
- ヘッドレス自動テスト **158/158 パス**
  - レビューで「キーボード Up/Down 経路の同期漏れ」の指摘を受けて `Tick()` 同期へ変更

### 既知の制限（low・許容済み）

ParameterMode コンボのプログラム同期時（タブを開いた直後・Undo/Redo・Details 側での外部変更）に選択音が 1 回鳴ることがあります（`SComboBox::SetSelectedItem` がデリゲート抑止より前に `PlaySelectionChangeSound()` を実行するため）。連続再生はなく cosmetic のため既知制限として許容しています。

### 残りの手動確認（`WindScopeEditPanel_PIE_Checklist.md` に追加済み）

本件の失敗点は Slate の編集テキストレイアウトとの相互作用のため、ヘッドレスでは踏めません。エディタでの確認が必要です。

- 4-3a. 数値を打ち込んで Enter した瞬間に入力欄が旧値へ巻き戻らない（1回目で反映される）
- 4-3b. その直後に別ウィジェットへフォーカスを移しても値が旧値へ戻らず、Undo 履歴も 1 段だけ
- 3-5. ノードを Advanced にした状態でパネルを開き、ParameterMode で Simple を選ぶと 1 回目で切り替わる
