### PR TITLE
[fix] Collapse Kawaii Physics tools into a Window menu submenu

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEd.cpp
@@ -85,7 +85,7 @@ void FKawaiiPhysicsEdModule::ShutdownModule()
 
 		if (KawaiiPhysicsMenuGroup.IsValid())
 		{
-			WorkspaceMenu::GetMenuStructure().GetStructureRoot()->RemoveItem(KawaiiPhysicsMenuGroup.ToSharedRef());
+			WorkspaceMenu::GetMenuStructure().GetLevelEditorCategory()->RemoveItem(KawaiiPhysicsMenuGroup.ToSharedRef());
 			KawaiiPhysicsMenuGroup.Reset();
 		}
 
@@ -115,7 +115,9 @@ void FKawaiiPhysicsEdModule::RegisterTabSpawners()
 	const FSlateIcon KawaiiPhysicsIcon(
 		FKawaiiPhysicsEdStyle::GetStyleSetName(),
 		TEXT("KawaiiPhysics.TabIcon"));
-	KawaiiPhysicsMenuGroup = WorkspaceMenu::GetMenuStructure().GetStructureRoot()->AddGroup(
+	// ルート直下のグループは Window メニュー上で「セクション見出し」として平坦に展開される。
+	// Level Editor カテゴリの子にすることで「Kawaii Physics >」サブメニュー（Viewports と同階層）として畳まれる
+	KawaiiPhysicsMenuGroup = WorkspaceMenu::GetMenuStructure().GetLevelEditorCategory()->AddGroup(
 		LOCTEXT("KawaiiPhysicsMenuGroup", "Kawaii Physics"),
 		KawaiiPhysicsIcon,
 		false);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsNodeAuditWindow.cpp
@@ -231,7 +231,7 @@ void SKawaiiPhysicsNodeAuditWindow::RegisterTabSpawner(const TSharedRef<FWorkspa
 	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
 			NodeAuditTabId,
 			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsNodeAuditWindow::SpawnNodeAuditTab))
-		.SetDisplayName(LOCTEXT("NodeAuditMenuDisplayName", "Kawaii Physics: Node Audit"))
+		.SetDisplayName(LOCTEXT("NodeAuditMenuDisplayName", "Node Audit"))
 		.SetTooltipText(LOCTEXT("NodeAuditMenuTooltip", "KawaiiPhysics のノード監査タブを開きます / Opens the KawaiiPhysics node audit tab."))
 		.SetGroup(InMenuGroup)
 		.SetIcon(KawaiiPhysicsIcon);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
@@ -496,7 +496,7 @@ void SKawaiiPhysicsPresetDiffWindow::RegisterTabSpawner(const TSharedRef<FWorksp
 	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
 			PresetDiffTabId,
 			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsPresetDiffWindow::SpawnPresetDiffTab))
-		.SetDisplayName(LOCTEXT("PresetDiffMenuDisplayName", "Kawaii Physics: Preset Diff"))
+		.SetDisplayName(LOCTEXT("PresetDiffMenuDisplayName", "Preset Diff"))
 		.SetTooltipText(LOCTEXT("PresetDiffMenuTooltip", "KawaiiPhysics のプリセット差分タブを開きます / Opens the KawaiiPhysics preset diff tab."))
 		.SetGroup(InMenuGroup)
 		.SetIcon(KawaiiPhysicsIcon);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -1934,7 +1934,7 @@ void SKawaiiPhysicsWindScopeWindow::RegisterTabSpawner(const TSharedRef<FWorkspa
 	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(
 			WindScopeTabId,
 			FOnSpawnTab::CreateStatic(&SKawaiiPhysicsWindScopeWindow::SpawnWindScopeTab))
-		.SetDisplayName(LOCTEXT("WindScopeMenuDisplayName", "Kawaii Physics: Wind Scope"))
+		.SetDisplayName(LOCTEXT("WindScopeMenuDisplayName", "Wind Scope"))
 		.SetTooltipText(LOCTEXT("WindScopeMenuTooltip", "Opens the KawaiiPhysics wind preview tab."))
 		.SetGroup(InMenuGroup)
 		.SetIcon(KawaiiPhysicsIcon);


### PR DESCRIPTION
## 概要
ウィンドウメニューで KawaiiPhysics の 3 ツール（Wind Scope / Preset Diff / Node Audit）がセクション見出し付きで縦に平坦展開され、メニューの幅・高さを取りすぎていたため、`Kawaii Physics >` サブメニュー 1 項目に畳んで配下に 3 ツールを展開する構成に変更。

## 変更内容
- `KawaiiPhysicsEd.cpp`: メニューグループの親を `GetStructureRoot()` → `GetLevelEditorCategory()` に変更（登録・解除の両方）。
  UE の `FTabManager::PopulateTabSpawnerMenu_Helper` はルート直下のグループを「セクション見出し＋平坦展開」、1 段下のグループを「サブメニュー」として描画するため、「ビューポート >」「コンテンツブラウザ >」と同階層に `Kawaii Physics >` が並ぶ。
- 3 ウィンドウの `RegisterTabSpawner`: サブメニュー配下になるため表示名から `Kawaii Physics: ` 接頭辞を削除（`Wind Scope` / `Preset Diff` / `Node Audit`）。タブ自体のラベルは変更なし。

## ローカライズ
変更した 3 つの表示名は `ja/KawaiiPhysics.po` に未訳（msgstr 空）だったため、翻訳フォールバックへの影響なし。

## 検証状況
- [ ] **未ビルド**（作成時にエディタ起動中で Live Coding によりビルドがブロックされたため）。マージ前に Editor ターゲットのビルドと、ウィンドウメニュー「レベルエディタ」セクション内に `Kawaii Physics >` サブメニューが表示されることの目視確認が必要。
