### PR TITLE
[fix] Stop showing a success notification when the Wind Scope test gust fires

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -1612,11 +1612,14 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 						GustStrength,
 						GustRiseTime,
 						GustDecayTime);
-					KawaiiPhysicsEdWindowUtils::ShowNotification(
-						bAppliedLive
-							? LOCTEXT("GustSucceededLive", "Triggered wind gust. (live)")
-							: LOCTEXT("GustNoLiveTarget", "Skipped wind gust. (no live target)"),
-						bAppliedLive ? SNotificationItem::CS_Success : SNotificationItem::CS_Fail);
+					// 成功時は通知を出さない: 連打時に右下ポップアップがエディタを重くし、波形の目視確認を妨げるため。
+					// 失敗時（ライブ対象なし）のみ理由を通知する
+					if (!bAppliedLive)
+					{
+						KawaiiPhysicsEdWindowUtils::ShowNotification(
+							LOCTEXT("GustNoLiveTarget", "Skipped wind gust. (no live target)"),
+							SNotificationItem::CS_Fail);
+					}
 					return FReply::Handled();
 				})
 			]


### PR DESCRIPTION
## 概要
Wind Scope の「Test Gust」ボタン押下時に毎回右下へ成功通知（トースト）を出していたため、連打するとエディタが重くなり動作が不安定になる上、波形グラフの目視確認の邪魔になっていました。成功時の通知を廃止します。

## 変更内容
- `SKawaiiPhysicsWindScopeWindow.cpp`: 突風送信成功時の `ShowNotification` を削除
- ライブ対象が無く突風がスキップされた場合の失敗通知は、押しても何も起きない原因が分かるよう従来どおり維持

## 確認
- エディタ起動中（Live Coding 有効）のためローカルでのビルド検証は未実施。変更は通知呼び出しを `if (!bAppliedLive)` で囲んだのみです。