### PR TITLE
[improve] Rework Wind Scope tab UI into a slim toolbar layout

### DIFF
--- a/Plugins/KawaiiPhysics/Content/Localization/KawaiiPhysics/ja/KawaiiPhysics.po
+++ b/Plugins/KawaiiPhysics/Content/Localization/KawaiiPhysics/ja/KawaiiPhysics.po
@@ -6845,3 +6845,66 @@ msgctxt "KawaiiPhysicsWindScopeWindow,FormulaHeaderGust"
 msgid "Gust"
 msgstr ""
 
+#. Key:	PresetToolbarButton
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1711)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1711)
+msgctxt "KawaiiPhysicsWindScopeWindow,PresetToolbarButton"
+msgid "Presets"
+msgstr "プリセット"
+
+#. Key:	GustSettingsTooltip
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1749)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1749)
+msgctxt "KawaiiPhysicsWindScopeWindow,GustSettingsTooltip"
+msgid "Adjust the test gust settings."
+msgstr "テスト突風の設定を調整します"
+
+#. Key:	CopyWindParametersButton
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1789)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1789)
+msgctxt "KawaiiPhysicsWindScopeWindow,CopyWindParametersButton"
+msgid "Copy"
+msgstr "コピー"
+
+#. Key:	PasteWindParametersButton
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1819)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1819)
+msgctxt "KawaiiPhysicsWindScopeWindow,PasteWindParametersButton"
+msgid "Paste"
+msgstr "貼り付け"
+
+#. Key:	NoPresetsMenuInfo
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2361)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2361)
+msgctxt "KawaiiPhysicsWindScopeWindow,NoPresetsMenuInfo"
+msgid "No wind presets found."
+msgstr "風プリセットが見つかりません"
+
+#. Key:	GustStrengthLabel
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2444)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2444)
+msgctxt "KawaiiPhysicsWindScopeWindow,GustStrengthLabel"
+msgid "Strength"
+msgstr "強さ"
+
+#. Key:	GustRiseLabel
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2483)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2483)
+msgctxt "KawaiiPhysicsWindScopeWindow,GustRiseLabel"
+msgid "Rise"
+msgstr "立ち上がり"
+
+#. Key:	GustDecayLabel
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2521)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(2521)
+msgctxt "KawaiiPhysicsWindScopeWindow,GustDecayLabel"
+msgid "Decay"
+msgstr "減衰"
+
+#. Key:	DisplayWindowLabel
+#. SourceLocation:	Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1963)
+#: Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp(1963)
+msgctxt "KawaiiPhysicsWindScopeWindow,DisplayWindowLabel"
+msgid "Window"
+msgstr "表示幅"
+

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -29,7 +29,7 @@
 
 namespace KawaiiPhysicsWindScopeEditPanelPrivate
 {
-	constexpr float LabelColumnWidth = 150.0f;
+	constexpr float LabelColumnWidth = 190.0f;
 	constexpr float LiveValueTolerance = 0.01f;
 	const TCHAR* const EditPanelConfigSectionName = TEXT("KawaiiPhysicsEd");
 	const TCHAR* const WindScopeCollapsedGroupsKey = TEXT("WindScopeEditPanelCollapsedGroups");
@@ -208,6 +208,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 			{
 				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, ParameterMode), 0.0f, 1.0f, false},
 				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled), 0.0f, 1.0f, true},
+				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, TimeScale), 0.0f, 3.0f, true, true},
 			},
 			true
 		},
@@ -274,15 +275,6 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomForce), 0.0f, 50.0f, true},
 				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomForcePeriod), 0.01f, 5.0f, true},
 				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, Seed), 0.0f, 10000.0f, false, true},
-			}
-		},
-		{
-			LOCTEXT("TimeGroupLabel", "Time"),
-			FName(TEXT("Time")),
-			GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, TimeScale),
-			TOptional<EKawaiiPhysicsWindScopeComponent>(),
-			{
-				{GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, TimeScale), 0.0f, 3.0f, true, true},
 			}
 		},
 	};
@@ -419,6 +411,25 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 		.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
 		.AutoWrapText(true)
 		.ColorAndOpacity(FLinearColor(0.78f, 0.78f, 0.72f, 1.0f))
+		.Visibility_Lambda([this]()
+		{
+			if (!IsParamPinExposed.IsBound())
+			{
+				return EVisibility::Collapsed;
+			}
+
+			for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+			{
+				for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+				{
+					if (IsParamPinExposed.Execute(Param.PropertyName))
+					{
+						return EVisibility::Visible;
+					}
+				}
+			}
+			return EVisibility::Collapsed;
+		})
 	];
 
 	ChildSlot
@@ -781,6 +792,8 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 			.ToolTipText(ToolTipText);
 	}
 
+	// 値ウィジェットはパネル幅に追従させるため FillWidth + HAlign_Fill で伸縮させる
+	// （固定幅の SBox で包まない。CheckBox もこの扱いで問題ない）
 	return SNew(SHorizontalBox)
 		.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetParamRowVisibility, ParamDef.PropertyName)
 		+ SHorizontalBox::Slot()
@@ -799,6 +812,8 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 					.Text(Label)
 					.ToolTipText(ToolTipText)
 					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+					// ラベル列を広げたので折り返しは不要。クリップ（省略記号）も付けず全文表示する
+					.AutoWrapText(false)
 				]
 				+ SHorizontalBox::Slot()
 				.AutoWidth()
@@ -811,6 +826,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 		]
 		+ SHorizontalBox::Slot()
 		.FillWidth(1.0f)
+		.HAlign(HAlign_Fill)
 		.VAlign(VAlign_Center)
 		[
 			ValueWidget.ToSharedRef()
@@ -818,20 +834,33 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 		+ SHorizontalBox::Slot()
 		.AutoWidth()
 		.VAlign(VAlign_Center)
-		.Padding(6.0f, 0.0f, 0.0f, 0.0f)
+		.Padding(8.0f, 0.0f, 0.0f, 0.0f)
 		[
 			SNew(STextBlock)
 			.Text(this, &SKawaiiPhysicsWindScopeEditPanel::GetLiveValueText, ParamDef.PropertyName)
-			.Visibility(this, &SKawaiiPhysicsWindScopeEditPanel::GetLiveValueVisibility, ParamDef.PropertyName)
+			.Visibility_Lambda([this, PropertyName = ParamDef.PropertyName]()
+			{
+				// Hidden ではなく Collapsed で幅を消し、値ウィジェットの右端の位置が揺れないようにする
+				return GetLiveValueVisibility(PropertyName) == EVisibility::Visible
+					       ? EVisibility::Visible
+					       : EVisibility::Collapsed;
+			})
 			.ColorAndOpacity(KawaiiPhysicsWindScopeEditPanelPrivate::ResolveLiveWarningColor())
 			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+			.Justification(ETextJustify::Left)
 		]
+		// リセットボタンは非表示時も Hidden（Collapsed ではない）で 24px 分の幅を確保し、
+		// 行ごとに右端の位置がずれないようにする
 		+ SHorizontalBox::Slot()
 		.AutoWidth()
 		.VAlign(VAlign_Center)
 		.Padding(4.0f, 0.0f, 0.0f, 0.0f)
 		[
-			MakeResetButton(ParamDef.PropertyName)
+			SNew(SBox)
+			.WidthOverride(24.0f)
+			[
+				MakeResetButton(ParamDef.PropertyName)
+			]
 		];
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -29,16 +29,18 @@
 #include "ScopedTransaction.h"
 #include "Styling/AppStyle.h"
 #include "Styling/CoreStyle.h"
+#include "Styling/ToolBarStyle.h"
 #include "UObject/UnrealType.h"
-#include "Widgets/Colors/SColorBlock.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/Images/SImage.h"
+#include "Widgets/SNullWidget.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SComboBox.h"
 #include "Widgets/Input/SSpinBox.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
+#include "Widgets/SOverlay.h"
 #include "Widgets/Layout/SSeparator.h"
 #include "Widgets/Layout/SSplitter.h"
 #include "Widgets/Layout/SWrapBox.h"
@@ -58,9 +60,9 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 {
 	constexpr int32 WindScopePreviewSampleCount = 240;
 	constexpr float WindScopeGraphPaddingLeft = 42.0f;
-	constexpr float WindScopeGraphPaddingTop = 12.0f;
-	constexpr float WindScopeGraphPaddingRight = 12.0f;
-	constexpr float WindScopeGraphPaddingBottom = 24.0f;
+	constexpr float WindScopeGraphPaddingTop = 14.0f;
+	constexpr float WindScopeGraphPaddingRight = 36.0f;
+	constexpr float WindScopeGraphPaddingBottom = 34.0f;
 	constexpr float WindScopeDefaultGustStrength = 6.0f;
 	constexpr float WindScopeDefaultGustRiseTime = 0.1f;
 	constexpr float WindScopeDefaultGustDecayTime = 0.5f;
@@ -461,14 +463,6 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		return Preset;
 	}
 
-	// サンプルが無い時の初期表示値。StrengthCycle=1にして Total=0（無風）を表すサンプルにする
-	FKawaiiPhysicsProceduralWindSample MakeZeroWindSample()
-	{
-		FKawaiiPhysicsProceduralWindSample Sample;
-		Sample.StrengthCycle = 1.0f;
-		return Sample;
-	}
-
 	void FillWindScopeEditValuesFromWind(
 		const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind,
 		FKawaiiWindScopeEditValues& OutValues,
@@ -537,18 +531,10 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		}
 	}
 
-	FText FormatFloat2(float Value)
-	{
-		FNumberFormattingOptions Options;
-		Options.MinimumFractionalDigits = 2;
-		Options.MaximumFractionalDigits = 2;
-		return FText::AsNumber(Value, &Options);
-	}
-
 	FLinearColor MakeInactiveSeriesColor(FLinearColor Color)
 	{
-		Color = Color.Desaturate(0.65f);
-		Color.A *= 0.38f;
+		Color = Color.Desaturate(0.5f);
+		Color.A *= 0.6f;
 		return Color;
 	}
 
@@ -630,7 +616,8 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 			{
-				if (!Visibility.IsVisible(Style.Component))
+				if (!Visibility.IsVisible(Style.Component) ||
+					Style.Component == EKawaiiPhysicsWindScopeComponent::StrengthCycle)
 				{
 					continue;
 				}
@@ -663,6 +650,51 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		Range.MinValue -= Padding;
 		Range.MaxValue += Padding;
 		return Range;
+	}
+
+	float ComputeStrengthCycleAxisMax(
+		const TArray<FKawaiiProceduralWindScopeSample>& Samples,
+		float MinTime,
+		const FKawaiiWindScopeEditValues* EditValues)
+	{
+		float MaxValue = 0.0f;
+		bool bHasValue = false;
+		if (EditValues && EditValues->bValid)
+		{
+			if (const FFloatInterval* StrengthCycleRange = EditValues->IntervalValues.Find(
+				GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, StrengthCycleRange)))
+			{
+				MaxValue = FMath::Max(StrengthCycleRange->Min, StrengthCycleRange->Max);
+				bHasValue = true;
+			}
+		}
+
+		for (const FKawaiiProceduralWindScopeSample& Point : Samples)
+		{
+			if (Point.Time < MinTime)
+			{
+				continue;
+			}
+
+			MaxValue = bHasValue ? FMath::Max(MaxValue, Point.Sample.StrengthCycle) : Point.Sample.StrengthCycle;
+			bHasValue = true;
+		}
+
+		return FMath::Max(2.0f, FMath::CeilToFloat(FMath::Max(MaxValue, 0.0f)));
+	}
+
+	FString FormatWindScopeAxisNumber(float Value)
+	{
+		return FMath::IsNearlyEqual(Value, FMath::RoundToFloat(Value), 0.01f)
+			       ? FString::Printf(TEXT("%.0f"), Value)
+			       : FString::Printf(TEXT("%.1f"), Value);
+	}
+
+	FString FormatWindScopeSecondsLabel(float Seconds)
+	{
+		// 浮動小数演算による -0.0 などの微小な負値を 0 に丸めてから整形する（"-0s" 表記を防ぐため）
+		const float ClampedSeconds = FMath::IsNearlyZero(Seconds, 0.01f) ? 0.0f : Seconds;
+		return FString::Printf(TEXT("%ss"), *FormatWindScopeAxisNumber(ClampedSeconds));
 	}
 
 	// 契約: Slate 型に依存せず、時刻順サンプル列をグラフローカル座標のポリラインへ変換する。
@@ -814,7 +846,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		FSimpleDelegate OnUnhovered;
 	};
 
-	// 凡例1項目（色スウォッチ＋表示切替チェックボックス＋ラベル）を生成する
+	// 凡例1項目（表示切替チェックボックス＋ラベル）を生成する
 	TSharedRef<SWidget> MakeWindScopeLegendItem(SKawaiiPhysicsWindScopeWindow* Owner,
 	                                            const FKawaiiWindScopeComponentStyle& Style)
 	{
@@ -834,32 +866,15 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 				.IsChecked(Owner, &SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState, Style.Component)
 				.OnCheckStateChanged(Owner, &SKawaiiPhysicsWindScopeWindow::OnSeriesCheckStateChanged, Style.Component)
 				.ToolTipText(Style.Label)
+				.Padding(FMargin(2.0f, 0.0f, 0.0f, 0.0f))
 				[
-					SNew(SHorizontalBox)
-					+ SHorizontalBox::Slot()
-					.AutoWidth()
-					.VAlign(VAlign_Center)
-					.Padding(0.0f, 0.0f, 4.0f, 0.0f)
-					[
-						SNew(SColorBlock)
-						.Color_Lambda([Owner, Component = Style.Component]()
-						{
-							return Owner->ResolveSeriesDisplayColor(Component);
-						})
-						.Size(FVector2D(12.0f, 8.0f))
-					]
-					+ SHorizontalBox::Slot()
-					.AutoWidth()
-					.VAlign(VAlign_Center)
-					[
-						SNew(STextBlock)
-						.Text(Style.Label)
-						.ColorAndOpacity_Lambda([Owner, Component = Style.Component]()
-						{
-							return FSlateColor(Owner->ResolveSeriesDisplayColor(Component));
-						})
-						.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-					]
+					SNew(STextBlock)
+					.Text(Style.Label)
+					.ColorAndOpacity_Lambda([Owner, Component = Style.Component]()
+					{
+						return FSlateColor(Owner->ResolveSeriesDisplayColor(Component));
+					})
+					.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
 				]
 			];
 	}
@@ -872,38 +887,50 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 10, TEXT("Bold")));
 	}
 
-	TSharedRef<STextBlock> MakeFormulaHeaderSeriesText(
-		SKawaiiPhysicsWindScopeWindow* Owner,
-		EKawaiiPhysicsWindScopeComponent Component,
-		const FText& Text)
+	TSharedRef<SWidget> MakeWindScopeFormulaLegend(SKawaiiPhysicsWindScopeWindow* Owner)
 	{
-		return SNew(STextBlock)
-			.Text(Text)
-			.ColorAndOpacity_Lambda([Owner, Component]()
-			{
-				return FSlateColor(Owner->ResolveSeriesDisplayColor(Component));
-			})
-			.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 10, TEXT("Bold")));
-	}
-
-	TSharedRef<SWidget> MakeWindScopeFormulaHeader(SKawaiiPhysicsWindScopeWindow* Owner)
-	{
-		return SNew(SWrapBox)
+		// グラフ直上の専用行に配置するため、幅が狭い場合は折り返す
+		TSharedRef<SWrapBox> FormulaLegend = SNew(SWrapBox)
 			.UseAllottedSize(true)
-			.InnerSlotPadding(FVector2D(1.0f, 1.0f))
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Total, LOCTEXT("FormulaHeaderTotal", "Total"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderEquals", " = ("))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Constant, LOCTEXT("FormulaHeaderConstant", "Constant"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderPlusSway", " + "))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Sway, LOCTEXT("FormulaHeaderSway", "Sway"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderPlusRipple", " + "))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Ripple, LOCTEXT("FormulaHeaderRipple", "Ripple"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderStrengthCyclePrefix", ") × "))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::StrengthCycle, LOCTEXT("FormulaHeaderStrengthCycle", "StrengthCycle"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderPlusRandom", " + "))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Random, LOCTEXT("FormulaHeaderRandom", "Random"))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderStaticText(LOCTEXT("FormulaHeaderPlusGust", " + "))]
-			+ SWrapBox::Slot()[MakeFormulaHeaderSeriesText(Owner, EKawaiiPhysicsWindScopeComponent::Gust, LOCTEXT("FormulaHeaderGust", "Gust"))];
+			.InnerSlotPadding(FVector2D(2.0f, 2.0f));
+
+		const auto AddSeries = [&FormulaLegend, Owner](EKawaiiPhysicsWindScopeComponent Component)
+		{
+			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+			{
+				if (Style.Component == Component)
+				{
+					FormulaLegend->AddSlot()
+						.VAlign(VAlign_Center)
+						.Padding(1.0f, 0.0f)
+						[MakeWindScopeLegendItem(Owner, Style)];
+					return;
+				}
+			}
+		};
+		const auto AddText = [&FormulaLegend](const FText& Text)
+		{
+			FormulaLegend->AddSlot()
+				.VAlign(VAlign_Center)
+				.Padding(1.0f, 0.0f)
+				[MakeFormulaHeaderStaticText(Text)];
+		};
+
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Total);
+		AddText(LOCTEXT("FormulaHeaderEquals", " = ("));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Constant);
+		AddText(LOCTEXT("FormulaHeaderPlusSway", " + "));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Sway);
+		AddText(LOCTEXT("FormulaHeaderPlusRipple", " + "));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Ripple);
+		AddText(LOCTEXT("FormulaHeaderStrengthCyclePrefix", ") × "));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::StrengthCycle);
+		AddText(LOCTEXT("FormulaHeaderPlusRandom", " + "));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Random);
+		AddText(LOCTEXT("FormulaHeaderPlusGust", " + "));
+		AddSeries(EKawaiiPhysicsWindScopeComponent::Gust);
+
+		return FormulaLegend;
 	}
 
 	// 所属 AnimBlueprint を変更済みとしてマークする（プリセット適用の Undo/Redo・保存ダーティ化用）
@@ -1025,6 +1052,12 @@ void SKawaiiPhysicsWindScopeGraph::SetGhostSamples(TArray<FVector2D> InGhostSamp
 	Invalidate(EInvalidateWidgetReason::Paint);
 }
 
+void SKawaiiPhysicsWindScopeGraph::SetPaused(bool bInPaused)
+{
+	bPaused = bInPaused;
+	Invalidate(EInvalidateWidgetReason::Paint);
+}
+
 FReply SKawaiiPhysicsWindScopeGraph::OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
 {
 	HoverMousePosition = MyGeometry.AbsoluteToLocal(MouseEvent.GetScreenSpacePosition());
@@ -1069,6 +1102,8 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		FMath::Max(LocalSize.X - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingLeft - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingRight, 1.0f),
 		FMath::Max(LocalSize.Y - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingTop - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingBottom, 1.0f));
 	const KawaiiPhysicsWindScopeWindowPrivate::FKawaiiWindScopeRange Range = KawaiiPhysicsWindScopeWindowPrivate::ComputeWindScopeRange(Samples, DisplaySeconds, Visibility);
+	const float StrengthCycleAxisMin = 0.0f;
+	const float StrengthCycleAxisMax = KawaiiPhysicsWindScopeWindowPrivate::ComputeStrengthCycleAxisMax(Samples, Range.MinTime, EditValues);
 	const FLinearColor GridColor(0.22f, 0.24f, 0.28f, 0.55f);
 	const FLinearColor AxisColor(0.52f, 0.56f, 0.62f, 0.9f);
 	const FSlateFontInfo AxisFont(FCoreStyle::GetDefaultFont(), 9);
@@ -1134,13 +1169,14 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			continue;
 		}
 
+		const bool bStrengthCycleSeries = Style.Component == EKawaiiPhysicsWindScopeComponent::StrengthCycle;
 		const TArray<FVector2D> Points = KawaiiPhysicsWindScopeWindowPrivate::BuildWindScopePolylinePoints(
 			Samples,
 			Style.Component,
 			Range.MinTime,
 			Range.MaxTime,
-			Range.MinValue,
-			Range.MaxValue,
+			bStrengthCycleSeries ? StrengthCycleAxisMin : Range.MinValue,
+			bStrengthCycleSeries ? StrengthCycleAxisMax : Range.MaxValue,
 			GraphOrigin,
 			GraphSize);
 		if (Points.Num() < 2)
@@ -1213,6 +1249,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		const FName PropertyName = ActiveEditGuide.GetValue();
 		const float TimeSpan = FMath::Max(Range.MaxTime - Range.MinTime, KINDA_SMALL_NUMBER);
 		const float ValueSpan = FMath::Max(Range.MaxValue - Range.MinValue, KINDA_SMALL_NUMBER);
+		const float StrengthCycleValueSpan = FMath::Max(StrengthCycleAxisMax - StrengthCycleAxisMin, KINDA_SMALL_NUMBER);
 		const float GraphBottom = GraphOrigin.Y + GraphSize.Y;
 		const float GraphRight = GraphOrigin.X + GraphSize.X;
 		const FLinearColor GuideLineColor(1.0f, 0.74f, 0.16f, 0.5f);
@@ -1244,6 +1281,10 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		{
 			return GraphOrigin.Y + GraphSize.Y * (1.0f - ((Value - Range.MinValue) / ValueSpan));
 		};
+		const auto StrengthCycleValueToY = [&](const float Value)
+		{
+			return GraphOrigin.Y + GraphSize.Y * (1.0f - ((Value - StrengthCycleAxisMin) / StrengthCycleValueSpan));
+		};
 		const auto DrawVerticalGuideLine = [&](const float Time, const FLinearColor& Color)
 		{
 			const float X = TimeToX(Time);
@@ -1269,6 +1310,28 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		const auto DrawHorizontalGuideLine = [&](const float Value, const FLinearColor& Color)
 		{
 			const float Y = ValueToY(Value);
+			if (Y < GraphOrigin.Y || Y > GraphBottom)
+			{
+				return;
+			}
+
+			TArray<FVector2D> GuideLine;
+			GuideLine.Reserve(2);
+			GuideLine.Add(FVector2D(GraphOrigin.X, Y));
+			GuideLine.Add(FVector2D(GraphRight, Y));
+			FSlateDrawElement::MakeLines(
+				OutDrawElements,
+				LayerId + 5,
+				AllottedGeometry.ToPaintGeometry(),
+				GuideLine,
+				ESlateDrawEffect::None,
+				Color,
+				true,
+				1.0f);
+		};
+		const auto DrawStrengthCycleHorizontalGuideLine = [&](const float Value, const FLinearColor& Color)
+		{
+			const float Y = StrengthCycleValueToY(Value);
 			if (Y < GraphOrigin.Y || Y > GraphBottom)
 			{
 				return;
@@ -1321,8 +1384,8 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			FFloatInterval StrengthCycleRange;
 			if (GetIntervalEditValue(PropertyName, StrengthCycleRange))
 			{
-				const float MaxY = ValueToY(StrengthCycleRange.Max);
-				const float MinY = ValueToY(StrengthCycleRange.Min);
+				const float MaxY = StrengthCycleValueToY(StrengthCycleRange.Max);
+				const float MinY = StrengthCycleValueToY(StrengthCycleRange.Min);
 				const float BandTop = FMath::Clamp(FMath::Min(MaxY, MinY), GraphOrigin.Y, GraphBottom);
 				const float BandBottom = FMath::Clamp(FMath::Max(MaxY, MinY), GraphOrigin.Y, GraphBottom);
 				if (BandBottom > BandTop)
@@ -1337,8 +1400,8 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 					ESlateDrawEffect::None,
 					GuideBandColor);
 				}
-				DrawHorizontalGuideLine(StrengthCycleRange.Max, GuideLineColor);
-				DrawHorizontalGuideLine(StrengthCycleRange.Min, GuideLineColor);
+				DrawStrengthCycleHorizontalGuideLine(StrengthCycleRange.Max, GuideLineColor);
+				DrawStrengthCycleHorizontalGuideLine(StrengthCycleRange.Min, GuideLineColor);
 			}
 		}
 		else if (PropertyName == GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, ConstantForce))
@@ -1383,8 +1446,8 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		}
 	}
 
-	// 軸ラベル（最大値・0・最小値・時間軸）を描画
-	const auto DrawAxisText = [&](const FString& Text, const FVector2D& Position)
+	// 軸ラベル（左=Force、右=StrengthCycle、下=時間）を描画
+	const auto DrawAxisText = [&](const FString& Text, const FVector2D& Position, const FLinearColor& TextColor)
 	{
 		FSlateDrawElement::MakeText(
 			OutDrawElements,
@@ -1393,27 +1456,138 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 			Text,
 			AxisFont,
 			ESlateDrawEffect::None,
-			AxisColor);
+			TextColor);
+	};
+	const auto DrawLeftAxisText = [&](const FString& Text, const FVector2D& Position)
+	{
+		DrawAxisText(Text, Position, AxisColor);
 	};
 
-	DrawAxisText(FString::Printf(TEXT("%.2f"), Range.MaxValue), FVector2D(2.0f, GraphOrigin.Y - 2.0f));
+	DrawLeftAxisText(FString::Printf(TEXT("%.2f"), Range.MaxValue), FVector2D(2.0f, GraphOrigin.Y - 2.0f));
 	if (Range.MinValue <= 0.0f && Range.MaxValue >= 0.0f)
 	{
 		const float ZeroLabelY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((0.0f - Range.MinValue) / (Range.MaxValue - Range.MinValue)));
-		DrawAxisText(TEXT("0.00"), FVector2D(2.0f, ZeroLabelY - 7.0f));
+		DrawLeftAxisText(TEXT("0.00"), FVector2D(2.0f, ZeroLabelY - 7.0f));
 	}
-	DrawAxisText(FString::Printf(TEXT("%.2f"), Range.MinValue), FVector2D(2.0f, GraphOrigin.Y + GraphSize.Y - 14.0f));
-	DrawAxisText(FString::Printf(TEXT("-%.0fs"), DisplaySeconds), FVector2D(GraphOrigin.X, GraphOrigin.Y + GraphSize.Y + 4.0f));
-	DrawAxisText(TEXT("0s"), FVector2D(GraphOrigin.X + GraphSize.X - 24.0f, GraphOrigin.Y + GraphSize.Y + 4.0f));
+	DrawLeftAxisText(FString::Printf(TEXT("%.2f"), Range.MinValue), FVector2D(2.0f, GraphOrigin.Y + GraphSize.Y - 14.0f));
+
+	for (int32 LabelIndex = 0; LabelIndex <= 4; ++LabelIndex)
+	{
+		const float LabelAlpha = static_cast<float>(LabelIndex) / 4.0f;
+		const float X = GraphOrigin.X + GraphSize.X * LabelAlpha;
+		// 右端＝現在時刻(0s)となる相対時間表記（例: -8s, -6s, -4s, -2s, 0s）
+		const float Seconds = -DisplaySeconds * (1.0f - LabelAlpha);
+		const float LabelWidth = 44.0f;
+		const float TextX = FMath::Clamp(X - LabelWidth * 0.5f, GraphOrigin.X, GraphOrigin.X + GraphSize.X - LabelWidth);
+		DrawLeftAxisText(
+			KawaiiPhysicsWindScopeWindowPrivate::FormatWindScopeSecondsLabel(Seconds),
+			FVector2D(TextX, GraphOrigin.Y + GraphSize.Y + 6.0f));
+	}
+
+	// 右軸は StrengthCycle（倍率）専用なので系列色で描き、目盛は「×N」表記で倍率であることを示す
+	FLinearColor StrengthCycleAxisColor = KawaiiPhysicsWindScopeWindowPrivate::ResolveBaseComponentColor(EKawaiiPhysicsWindScopeComponent::StrengthCycle);
+	const bool bStrengthCycleHighlighted = HighlightSeries.IsSet() && HighlightSeries.GetValue() == EKawaiiPhysicsWindScopeComponent::StrengthCycle;
+	StrengthCycleAxisColor.A *= bStrengthCycleHighlighted ? 1.0f : 0.75f;
+	const auto DrawStrengthCycleAxisText = [&](float Value)
+	{
+		const float ValueSpan = FMath::Max(StrengthCycleAxisMax - StrengthCycleAxisMin, KINDA_SMALL_NUMBER);
+		const float Y = GraphOrigin.Y + GraphSize.Y * (1.0f - ((Value - StrengthCycleAxisMin) / ValueSpan));
+		DrawAxisText(
+			TEXT("×") + KawaiiPhysicsWindScopeWindowPrivate::FormatWindScopeAxisNumber(Value),
+			FVector2D(GraphOrigin.X + GraphSize.X + 4.0f, Y - 7.0f),
+			StrengthCycleAxisColor);
+	};
+	if (StrengthCycleAxisMax <= 5.0f)
+	{
+		for (int32 Tick = 0; Tick <= FMath::RoundToInt(StrengthCycleAxisMax); ++Tick)
+		{
+			DrawStrengthCycleAxisText(static_cast<float>(Tick));
+		}
+	}
+	else
+	{
+		DrawStrengthCycleAxisText(0.0f);
+		DrawStrengthCycleAxisText(StrengthCycleAxisMax * 0.5f);
+		DrawStrengthCycleAxisText(StrengthCycleAxisMax);
+	}
+
+	struct FCursorTextLine
+	{
+		FString Text;
+		FLinearColor Color;
+
+		FCursorTextLine(const FString& InText, const FLinearColor& InColor)
+			: Text(InText)
+			, Color(InColor)
+		{
+		}
+	};
+
+	const float GraphRight = GraphOrigin.X + GraphSize.X;
+	const float GraphBottom = GraphOrigin.Y + GraphSize.Y;
+	bool bHoveringGraphPlot = false;
+	const auto BuildCursorTextLines = [&](const int32 SampleIndex)
+	{
+		TArray<FCursorTextLine> CursorTextLines;
+		CursorTextLines.Reserve(1 + GetWindScopeComponentStyles().Num());
+		CursorTextLines.Emplace(
+			FString::Printf(TEXT("t=%.2fs"), Samples[SampleIndex].Time - Range.MaxTime),
+			FLinearColor(1.0f, 1.0f, 1.0f, 0.92f));
+		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		{
+			if (!Visibility.IsVisible(Style.Component))
+			{
+				continue;
+			}
+
+			FLinearColor TextColor = Style.Color;
+			TextColor.A = FMath::Max(TextColor.A, 0.9f);
+			const FString LabelString = Style.Label.ToString();
+			CursorTextLines.Emplace(
+				FString::Printf(TEXT("%s %.2f"), *LabelString, KawaiiPhysicsWindScopeWindowPrivate::GetWindScopeComponentValue(Samples[SampleIndex].Sample, Style.Component)),
+				TextColor);
+		}
+		return CursorTextLines;
+	};
+	const auto DrawSampleReadout = [&](const FVector2D& AnchorPosition, const int32 SampleIndex)
+	{
+		const TArray<FCursorTextLine> CursorTextLines = BuildCursorTextLines(SampleIndex);
+		const FSlateFontInfo CursorFont(FCoreStyle::GetDefaultFont(), 9);
+		constexpr float CursorTextWidth = 128.0f;
+		constexpr float CursorTextHeight = 13.0f;
+		const float PreferredTextX = AnchorPosition.X + CursorTextWidth + 8.0f > GraphRight
+			                           ? AnchorPosition.X - CursorTextWidth - 8.0f
+			                           : AnchorPosition.X + 8.0f;
+		const float TextX = FMath::Clamp(
+			PreferredTextX,
+			GraphOrigin.X,
+			FMath::Max(GraphOrigin.X, GraphRight - CursorTextWidth));
+		const float TextY = FMath::Clamp(
+			AnchorPosition.Y - CursorTextHeight * CursorTextLines.Num() - 4.0f,
+			GraphOrigin.Y,
+			FMath::Max(GraphOrigin.Y, GraphBottom - CursorTextHeight * CursorTextLines.Num()));
+		for (int32 LineIndex = 0; LineIndex < CursorTextLines.Num(); ++LineIndex)
+		{
+			FSlateDrawElement::MakeText(
+				OutDrawElements,
+				LayerId + 8,
+				AllottedGeometry.ToPaintGeometry(
+					FVector2D(CursorTextWidth, CursorTextHeight),
+					FSlateLayoutTransform(FVector2D(TextX, TextY + CursorTextHeight * LineIndex))),
+				CursorTextLines[LineIndex].Text,
+				CursorFont,
+				ESlateDrawEffect::None,
+				CursorTextLines[LineIndex].Color);
+		}
+	};
 
 	if (HoverMousePosition.IsSet() && Samples.Num() > 0)
 	{
 		const FVector2D CursorPosition = HoverMousePosition.GetValue();
-		const float GraphRight = GraphOrigin.X + GraphSize.X;
-		const float GraphBottom = GraphOrigin.Y + GraphSize.Y;
 		if (CursorPosition.X >= GraphOrigin.X && CursorPosition.X <= GraphRight &&
 			CursorPosition.Y >= GraphOrigin.Y && CursorPosition.Y <= GraphBottom)
 		{
+			bHoveringGraphPlot = true;
 			const float TimeSpan = FMath::Max(Range.MaxTime - Range.MinTime, KINDA_SMALL_NUMBER);
 			const float CursorTime = Range.MinTime + TimeSpan * ((CursorPosition.X - GraphOrigin.X) / GraphSize.X);
 
@@ -1453,66 +1627,16 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 				true,
 				1.0f);
 
-			struct FCursorTextLine
-			{
-				FString Text;
-				FLinearColor Color;
-
-				FCursorTextLine(const FString& InText, const FLinearColor& InColor)
-					: Text(InText)
-					, Color(InColor)
-				{
-				}
-			};
-
-			TArray<FCursorTextLine> CursorTextLines;
-			CursorTextLines.Reserve(1 + GetWindScopeComponentStyles().Num());
-			CursorTextLines.Emplace(
-				FString::Printf(TEXT("t=%.2fs"), Samples[ClosestIndex].Time - Range.MaxTime),
-				FLinearColor(1.0f, 1.0f, 1.0f, 0.92f));
-			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
-			{
-				if (!Visibility.IsVisible(Style.Component))
-				{
-					continue;
-				}
-
-				FLinearColor TextColor = Style.Color;
-				TextColor.A = FMath::Max(TextColor.A, 0.9f);
-				const FString LabelString = Style.Label.ToString();
-				CursorTextLines.Emplace(
-					FString::Printf(TEXT("%s %.2f"), *LabelString, KawaiiPhysicsWindScopeWindowPrivate::GetWindScopeComponentValue(Samples[ClosestIndex].Sample, Style.Component)),
-					TextColor);
-			}
-
-			const FSlateFontInfo CursorFont(FCoreStyle::GetDefaultFont(), 9);
-			constexpr float CursorTextWidth = 128.0f;
-			constexpr float CursorTextHeight = 13.0f;
-			const float PreferredTextX = CursorPosition.X + CursorTextWidth + 8.0f > GraphRight
-				                           ? CursorPosition.X - CursorTextWidth - 8.0f
-				                           : CursorPosition.X + 8.0f;
-			const float TextX = FMath::Clamp(
-				PreferredTextX,
-				GraphOrigin.X,
-				FMath::Max(GraphOrigin.X, GraphRight - CursorTextWidth));
-			const float TextY = FMath::Clamp(
-				CursorPosition.Y - CursorTextHeight * CursorTextLines.Num() - 4.0f,
-				GraphOrigin.Y,
-				FMath::Max(GraphOrigin.Y, GraphBottom - CursorTextHeight * CursorTextLines.Num()));
-			for (int32 LineIndex = 0; LineIndex < CursorTextLines.Num(); ++LineIndex)
-			{
-				FSlateDrawElement::MakeText(
-					OutDrawElements,
-					LayerId + 8,
-					AllottedGeometry.ToPaintGeometry(
-						FVector2D(CursorTextWidth, CursorTextHeight),
-						FSlateLayoutTransform(FVector2D(TextX, TextY + CursorTextHeight * LineIndex))),
-					CursorTextLines[LineIndex].Text,
-					CursorFont,
-					ESlateDrawEffect::None,
-					CursorTextLines[LineIndex].Color);
-			}
+			DrawSampleReadout(CursorPosition, ClosestIndex);
 		}
+	}
+
+	if (bPaused && Samples.Num() > 0 && !bHoveringGraphPlot)
+	{
+		const int32 LatestIndex = Samples.Num() - 1;
+		const float ValueSpan = FMath::Max(Range.MaxValue - Range.MinValue, KINDA_SMALL_NUMBER);
+		const float TotalY = GraphOrigin.Y + GraphSize.Y * (1.0f - ((Samples[LatestIndex].Sample.Total - Range.MinValue) / ValueSpan));
+		DrawSampleReadout(FVector2D(GraphRight, FMath::Clamp(TotalY, GraphOrigin.Y, GraphBottom)), LatestIndex);
 	}
 
 	return LayerId + 9;
@@ -1536,295 +1660,256 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 		SetArgs(MoveTemp(InitArgs));
 	}
 
+	const FToolBarStyle& SlimToolBarStyle = FAppStyle::Get().GetWidgetStyle<FToolBarStyle>(TEXT("SlimToolbar"));
+
 	ChildSlot
 	[
 		SNew(SVerticalBox)
-		// 上段: 対象ノード名・外力選択コンボ・現在モード表示
+		// 上段: Wind Scope 操作用のスリムツールバー
 		+ SVerticalBox::Slot()
 		.AutoHeight()
-		.Padding(8.0f, 8.0f, 8.0f, 4.0f)
+		.Padding(0.0f)
 		[
-			SNew(SHorizontalBox)
-			+ SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			.VAlign(VAlign_Center)
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot()
+			.AutoHeight()
 			[
-				SNew(STextBlock)
-				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetTargetNodeText)
-				.Clipping(EWidgetClipping::OnDemand)
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(8.0f, 0.0f, 4.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("ExternalForceLabel", "Force"))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SAssignNew(ExternalForceComboBox, SComboBox<FExternalForceIndexPtr>)
-				.OptionsSource(&ExternalForceItems)
-				.InitiallySelectedItem(SelectedExternalForceItem)
-				.OnGenerateWidget(this, &SKawaiiPhysicsWindScopeWindow::GenerateExternalForceComboWidget)
-				.OnSelectionChanged(this, &SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged)
+				SNew(SBorder)
+				.BorderImage(FAppStyle::Get().GetBrush("Brushes.Panel"))
+				.Padding(FMargin(8.0f, 4.0f))
 				[
-					SNew(STextBlock)
-					.Text(this, &SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText)
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SAssignNew(PresetComboButton, SComboButton)
+						.ComboButtonStyle(&SlimToolBarStyle.ComboButtonStyle)
+						.ContentPadding(FMargin(6.0f, 2.0f))
+						.ToolTipText(LOCTEXT("PresetRowLabelTooltip", "Click a preset to apply it to the current wind parameters. Hover to preview it on the graph."))
+						.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GeneratePresetMenu)
+						.OnMenuOpenChanged(this, &SKawaiiPhysicsWindScopeWindow::OnPresetMenuOpenChanged)
+						.ButtonContent()
+						[
+							SNew(SHorizontalBox)
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							[
+								SNew(SImage)
+								.Image(FAppStyle::Get().GetBrush(TEXT("Icons.Settings")))
+								.ColorAndOpacity(FSlateColor::UseForeground())
+							]
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+							[
+								SNew(STextBlock)
+								.Text(LOCTEXT("PresetToolbarButton", "Presets"))
+							]
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+					[
+						SNew(SButton)
+						.ButtonStyle(&SlimToolBarStyle.ButtonStyle)
+						.ContentPadding(FMargin(6.0f, 2.0f))
+						.Text(LOCTEXT("GustButton", "Test Gust"))
+						.ToolTipText(LOCTEXT("GustButtonTooltip", "Sends a one-shot test gust to the live target. Does not change any parameters."))
+						.OnClicked_Lambda([this]()
+						{
+							const bool bAppliedLive = PushGustToLiveRuntime(
+								GustStrength,
+								GustRiseTime,
+								GustDecayTime);
+							// 成功時は通知を出さない: 連打時に右下ポップアップがエディタを重くし、波形の目視確認を妨げるため。
+							// 失敗時（ライブ対象なし）のみ理由を通知する
+							if (!bAppliedLive)
+							{
+								KawaiiPhysicsEdWindowUtils::ShowNotification(
+									LOCTEXT("GustNoLiveTarget", "Skipped wind gust. (no live target)"),
+									SNotificationItem::CS_Fail);
+							}
+							return FReply::Handled();
+						})
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SNew(SComboButton)
+						.ComboButtonStyle(&SlimToolBarStyle.ComboButtonStyle)
+						.ContentPadding(FMargin(2.0f, 2.0f))
+						.ToolTipText(LOCTEXT("GustSettingsTooltip", "Adjust the test gust settings."))
+						.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GenerateGustMenu)
+						.ButtonContent()
+						[
+							SNew(STextBlock)
+							.Text(FText::GetEmpty())
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.Padding(8.0f, 0.0f)
+					[
+						SNew(SSeparator)
+						.Orientation(Orient_Vertical)
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SNew(SButton)
+						.ButtonStyle(&SlimToolBarStyle.ButtonStyle)
+						.ContentPadding(FMargin(6.0f, 2.0f))
+						.ToolTipText(LOCTEXT("CopyWindParametersTooltip", "Copy current ProceduralWind parameters."))
+						.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnCopyWindParametersClicked)
+						[
+							SNew(SHorizontalBox)
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							[
+								SNew(SImage)
+								.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Copy")))
+								.ColorAndOpacity(FSlateColor::UseForeground())
+							]
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+							[
+								SNew(STextBlock)
+								.Text(LOCTEXT("CopyWindParametersButton", "Copy"))
+							]
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(2.0f, 0.0f, 0.0f, 0.0f)
+					[
+						SNew(SButton)
+						.ButtonStyle(&SlimToolBarStyle.ButtonStyle)
+						.ContentPadding(FMargin(6.0f, 2.0f))
+						.ToolTipText(LOCTEXT("PasteWindParametersTooltip", "Paste ProceduralWind parameters from the clipboard."))
+						.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked)
+						[
+							SNew(SHorizontalBox)
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							[
+								SNew(SImage)
+								.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Paste")))
+								.ColorAndOpacity(FSlateColor::UseForeground())
+							]
+							+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
+							.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+							[
+								SNew(STextBlock)
+								.Text(LOCTEXT("PasteWindParametersButton", "Paste"))
+							]
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					[
+						SNullWidget::NullWidget
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(8.0f, 0.0f, 4.0f, 0.0f)
+					[
+						SNew(STextBlock)
+						.Text(LOCTEXT("ExternalForceLabel", "Force"))
+						.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SAssignNew(ExternalForceComboBox, SComboBox<FExternalForceIndexPtr>)
+						.OptionsSource(&ExternalForceItems)
+						.InitiallySelectedItem(SelectedExternalForceItem)
+						.ToolTipText(this, &SKawaiiPhysicsWindScopeWindow::GetTargetNodeText)
+						.OnGenerateWidget(this, &SKawaiiPhysicsWindScopeWindow::GenerateExternalForceComboWidget)
+						.OnSelectionChanged(this, &SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged)
+						[
+							SNew(STextBlock)
+							.Text(this, &SKawaiiPhysicsWindScopeWindow::GetSelectedExternalForceText)
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(12.0f, 0.0f, 0.0f, 0.0f)
+					[
+						SNew(SHorizontalBox)
+						+ SHorizontalBox::Slot()
+						.AutoWidth()
+						.VAlign(VAlign_Center)
+						[
+							SNew(SBox)
+							.WidthOverride(8.0f)
+							.HeightOverride(8.0f)
+							[
+								SNew(SImage)
+								.Image(FAppStyle::Get().GetBrush(TEXT("Icons.FilledCircle")))
+								.ColorAndOpacity(this, &SKawaiiPhysicsWindScopeWindow::GetModeBadgeColor)
+							]
+						]
+						+ SHorizontalBox::Slot()
+						.AutoWidth()
+						.VAlign(VAlign_Center)
+						.Padding(4.0f, 0.0f, 0.0f, 0.0f)
+						[
+							SNew(STextBlock)
+							.Text(this, &SKawaiiPhysicsWindScopeWindow::GetModeText)
+							.ColorAndOpacity(this, &SKawaiiPhysicsWindScopeWindow::GetModeBadgeColor)
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(8.0f, 0.0f, 0.0f, 0.0f)
+					[
+						SNew(SButton)
+						.ButtonStyle(&SlimToolBarStyle.ButtonStyle)
+						.ContentPadding(FMargin(3.0f))
+						.ToolTipText(LOCTEXT("ToggleEditPanelTooltip", "Toggle the parameter edit panel."))
+						.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked)
+						[
+							SNew(SImage)
+							.Image(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon)
+							.ColorAndOpacity(FSlateColor::UseForeground())
+						]
+					]
 				]
 			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(12.0f, 0.0f, 0.0f, 0.0f)
+			+ SVerticalBox::Slot()
+			.AutoHeight()
 			[
-				SNew(STextBlock)
-				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetModeText)
-				.ColorAndOpacity(FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen")))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(8.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SButton)
-				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
-				.ContentPadding(FMargin(3.0f))
-				.ToolTipText(LOCTEXT("ToggleEditPanelTooltip", "Toggle the parameter edit panel."))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnToggleEditPanelClicked)
+				SNew(SBorder)
+				.BorderImage(FAppStyle::Get().GetBrush("Brushes.Recessed"))
+				.Padding(0.0f)
 				[
-					SNew(SImage)
-					.Image(this, &SKawaiiPhysicsWindScopeWindow::GetEditPanelToggleIcon)
-				]
-			]
-		]
-		// プリセットボタン列
-		+ SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(8.0f, 2.0f)
-		[
-			SNew(SHorizontalBox)
-			// プリセット群: 見出しを付けて「適用ボタン」であることを明示する（右側の Gust テスト群との混同防止）
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(0.0f, 0.0f, 4.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("PresetRowLabel", "Presets:"))
-				.ToolTipText(LOCTEXT("PresetRowLabelTooltip", "Click a preset to apply it to the current wind parameters. Hover to preview it on the graph."))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			.VAlign(VAlign_Center)
-			[
-				SAssignNew(PresetButtonBox, SWrapBox)
-				.UseAllottedSize(true)
-				.InnerSlotPadding(FVector2D(4.0f, 2.0f))
-			]
-			// Gust テスト群: セパレータで区切り、ボタン名でもテスト用であることを示す
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.Padding(8.0f, 0.0f)
-			[
-				SNew(SSeparator)
-				.Orientation(Orient_Vertical)
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("GustButton", "Test Gust"))
-				.ContentPadding(FMargin(6.0f, 2.0f))
-				.ToolTipText(LOCTEXT("GustButtonTooltip", "Sends a one-shot test gust to the live target. Does not change any parameters."))
-				.OnClicked_Lambda([this]()
-				{
-					const bool bAppliedLive = PushGustToLiveRuntime(
-						GustStrength,
-						GustRiseTime,
-						GustDecayTime);
-					// 成功時は通知を出さない: 連打時に右下ポップアップがエディタを重くし、波形の目視確認を妨げるため。
-					// 失敗時（ライブ対象なし）のみ理由を通知する
-					if (!bAppliedLive)
-					{
-						KawaiiPhysicsEdWindowUtils::ShowNotification(
-							LOCTEXT("GustNoLiveTarget", "Skipped wind gust. (no live target)"),
-							SNotificationItem::CS_Fail);
-					}
-					return FReply::Handled();
-				})
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("GustStrengthShortLabel", "S"))
-				.ToolTipText(LOCTEXT("GustStrengthTooltip", "Gust strength."))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SNew(SBox)
-				.WidthOverride(60.0f)
-				[
-					SNew(SSpinBox<float>)
-					.MinValue(0.0f)
-					.MaxValue(50.0f)
-					.MinSliderValue(0.0f)
-					.MaxSliderValue(50.0f)
-					.Value_Lambda([this]()
-					{
-						return GustStrength;
-					})
-					.OnValueChanged_Lambda([this](float NewValue)
-					{
-						GustStrength = FMath::Clamp(NewValue, 0.0f, 50.0f);
-					})
-					.ToolTipText(LOCTEXT("GustStrengthSpinTooltip", "Gust strength."))
-				]
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("GustRiseShortLabel", "R"))
-				.ToolTipText(LOCTEXT("GustRiseTooltip", "Gust rise time."))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SNew(SBox)
-				.WidthOverride(60.0f)
-				[
-					SNew(SSpinBox<float>)
-					.MinValue(0.01f)
-					.MaxValue(5.0f)
-					.MinSliderValue(0.01f)
-					.MaxSliderValue(5.0f)
-					.Value_Lambda([this]()
-					{
-						return GustRiseTime;
-					})
-					.OnValueChanged_Lambda([this](float NewValue)
-					{
-						GustRiseTime = FMath::Clamp(NewValue, 0.01f, 5.0f);
-					})
-					.ToolTipText(LOCTEXT("GustRiseSpinTooltip", "Gust rise time."))
-				]
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 2.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("GustDecayShortLabel", "D"))
-				.ToolTipText(LOCTEXT("GustDecayTooltip", "Gust decay time."))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SNew(SBox)
-				.WidthOverride(60.0f)
-				[
-					SNew(SSpinBox<float>)
-					.MinValue(0.01f)
-					.MaxValue(10.0f)
-					.MinSliderValue(0.01f)
-					.MaxSliderValue(10.0f)
-					.Value_Lambda([this]()
-					{
-						return GustDecayTime;
-					})
-					.OnValueChanged_Lambda([this](float NewValue)
-					{
-						GustDecayTime = FMath::Clamp(NewValue, 0.01f, 10.0f);
-					})
-					.ToolTipText(LOCTEXT("GustDecaySpinTooltip", "Gust decay time."))
-				]
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("ReloadPresetsButton", "Reload"))
-				.ContentPadding(FMargin(6.0f, 2.0f))
-				.ToolTipText(LOCTEXT("ReloadPresetsTooltip", "Reload the preset DataAsset."))
-				.OnClicked_Lambda([this]()
-				{
-					RebuildPresetButtons();
-					return FReply::Handled();
-				})
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SComboButton)
-				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
-				.ContentPadding(FMargin(6.0f, 2.0f))
-				.ToolTipText(this, &SKawaiiPhysicsWindScopeWindow::GetSavePresetToolTipText)
-				.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset)
-				.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu)
-				.ButtonContent()
-				[
-					SNew(STextBlock)
-					.Text(LOCTEXT("SavePresetButton", "Save as Preset"))
-				]
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(6.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SButton)
-				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
-				.ContentPadding(FMargin(3.0f))
-				.ToolTipText(LOCTEXT("CopyWindParametersTooltip", "Copy current ProceduralWind parameters."))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnCopyWindParametersClicked)
-				[
-					SNew(SImage)
-					.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Copy")))
-				]
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SButton)
-				.ButtonStyle(FAppStyle::Get(), TEXT("SimpleButton"))
-				.ContentPadding(FMargin(3.0f))
-				.ToolTipText(LOCTEXT("PasteWindParametersTooltip", "Paste ProceduralWind parameters from the clipboard."))
-				.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked)
-				[
-					SNew(SImage)
-					.Image(FAppStyle::Get().GetBrush(TEXT("GenericCommands.Paste")))
+					SNew(SBox)
+					.HeightOverride(2.0f)
 				]
 			]
 		]
 		// 凡例・波形グラフ本体・編集パネル
 		+ SVerticalBox::Slot()
 		.FillHeight(1.0f)
-		.Padding(8.0f, 2.0f, 8.0f, 4.0f)
+		.Padding(8.0f, 10.0f, 8.0f, 4.0f)
 		[
 			SAssignNew(EditPanelSplitter, SSplitter)
 			.Orientation(Orient_Horizontal)
@@ -1840,27 +1925,72 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				.AutoHeight()
 				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
 				[
-					KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeFormulaHeader(this)
-				]
-				+ SVerticalBox::Slot()
-				.AutoHeight()
-				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
-				[
-					SNew(SWrapBox)
-					.UseAllottedSize(true)
-					.InnerSlotPadding(FVector2D(6.0f, 2.0f))
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[0])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[1])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[2])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[3])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[4])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[5])]
-					+ SWrapBox::Slot()[KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeLegendItem(this, GetWindScopeComponentStyles()[6])]
+					KawaiiPhysicsWindScopeWindowPrivate::MakeWindScopeFormulaLegend(this)
 				]
 				+ SVerticalBox::Slot()
 				.FillHeight(1.0f)
 				[
-					SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+					SNew(SOverlay)
+					+ SOverlay::Slot()
+					[
+						SAssignNew(GraphWidget, SKawaiiPhysicsWindScopeGraph)
+					]
+					+ SOverlay::Slot()
+					.HAlign(HAlign_Center)
+					.VAlign(VAlign_Center)
+					[
+						SNew(STextBlock)
+						.Text(this, &SKawaiiPhysicsWindScopeWindow::GetTargetNodeText)
+						.Visibility(this, &SKawaiiPhysicsWindScopeWindow::GetTargetNodeEmptyStateVisibility)
+						.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+						.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 12))
+						.Justification(ETextJustify::Center)
+					]
+				]
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.0f, 4.0f, 0.0f, 0.0f)
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					[
+						SNullWidget::NullWidget
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(8.0f, 0.0f, 4.0f, 0.0f)
+					[
+						SNew(STextBlock)
+						.Text(LOCTEXT("DisplayWindowLabel", "Window"))
+						.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					[
+						SNew(SSpinBox<float>)
+						.MinValue(2.0f)
+						.MaxValue(30.0f)
+						.MinSliderValue(2.0f)
+						.MaxSliderValue(30.0f)
+						.Value(this, &SKawaiiPhysicsWindScopeWindow::GetDisplaySeconds)
+						.OnValueChanged(this, &SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged)
+					]
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(8.0f, 0.0f, 12.0f, 0.0f)
+					[
+						SNew(SCheckBox)
+						.IsChecked(this, &SKawaiiPhysicsWindScopeWindow::GetPauseCheckState)
+						.OnCheckStateChanged(this, &SKawaiiPhysicsWindScopeWindow::OnPauseCheckStateChanged)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("PauseLabel", "Pause"))
+						]
+					]
 				]
 			]
 			+ SSplitter::Slot()
@@ -1887,67 +2017,12 @@ void SKawaiiPhysicsWindScopeWindow::Construct(
 				]
 			]
 		]
-		+ SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(8.0f, 0.0f, 8.0f, 4.0f)
-		[
-			SNew(SSeparator)
-		]
-		// 下段: 現在値テキスト・表示秒数スピンボックス・一時停止チェックボックス
-		+ SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(8.0f, 2.0f, 8.0f, 8.0f)
-		[
-			SNew(SHorizontalBox)
-			+ SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			.VAlign(VAlign_Center)
-			[
-				SNew(STextBlock)
-				.Text(this, &SKawaiiPhysicsWindScopeWindow::GetCurrentValuesText)
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-				.Clipping(EWidgetClipping::OnDemand)
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(8.0f, 0.0f, 4.0f, 0.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("DisplaySecondsLabel", "Seconds"))
-				.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			[
-				SNew(SSpinBox<float>)
-				.MinValue(2.0f)
-				.MaxValue(30.0f)
-				.MinSliderValue(2.0f)
-				.MaxSliderValue(30.0f)
-				.Value(this, &SKawaiiPhysicsWindScopeWindow::GetDisplaySeconds)
-				.OnValueChanged(this, &SKawaiiPhysicsWindScopeWindow::OnDisplaySecondsChanged)
-			]
-			+ SHorizontalBox::Slot()
-			.AutoWidth()
-			.VAlign(VAlign_Center)
-			.Padding(8.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SCheckBox)
-				.IsChecked(this, &SKawaiiPhysicsWindScopeWindow::GetPauseCheckState)
-				.OnCheckStateChanged(this, &SKawaiiPhysicsWindScopeWindow::OnPauseCheckStateChanged)
-				[
-					SNew(STextBlock)
-					.Text(LOCTEXT("PauseLabel", "Pause"))
-				]
-			]
-		]
 	];
 
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetEditValues(&CachedEditValues);
+		GraphWidget->SetPaused(bPaused);
 	}
 
 	if (HasTargetArgs())
@@ -2037,6 +2112,11 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	Args = MoveTemp(InArgs);
 	ClearWindParamPinExposureCache();
 	DisplaySamples.Reset();
+	// Pause 中でも旧波形を残さないため即時反映
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetSamples(DisplaySamples);
+	}
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
 	CachedLiveEditValues = FKawaiiWindScopeEditValues();
@@ -2047,6 +2127,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 		GraphWidget->SetGhostSamples(TArray<FVector2D>());
 	}
 	CurrentModeText = LOCTEXT("PreviewMode", "Preview");
+	bIsLiveMode = false;
 	RefreshExternalForceItems();
 	if (HasTargetArgs())
 	{
@@ -2072,6 +2153,11 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	ClearWindParamPinExposureCache();
 	// 選択切替時は別の外力の波形を混在させないよう表示状態を丸ごとリセットする
 	DisplaySamples.Reset();
+	// Pause 中でも旧波形を残さないため即時反映
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetSamples(DisplaySamples);
+	}
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
 	CachedLiveEditValues = FKawaiiWindScopeEditValues();
@@ -2109,21 +2195,6 @@ FText SKawaiiPhysicsWindScopeWindow::GetModeText() const
 	return CurrentModeText;
 }
 
-FText SKawaiiPhysicsWindScopeWindow::GetCurrentValuesText() const
-{
-	const FKawaiiPhysicsProceduralWindSample Sample =
-		DisplaySamples.Num() > 0 ? DisplaySamples.Last().Sample : KawaiiPhysicsWindScopeWindowPrivate::MakeZeroWindSample();
-	return FText::Format(
-		LOCTEXT("CurrentValuesFormat", "Total {0}  Constant {1}  Sway {2}  Ripple {3}  StrCycle {4}  Rand {5}  Gust {6}"),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Total),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Constant),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Sway),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Ripple),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.StrengthCycle),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Random),
-		KawaiiPhysicsWindScopeWindowPrivate::FormatFloat2(Sample.Gust));
-}
-
 ECheckBoxState SKawaiiPhysicsWindScopeWindow::GetSeriesCheckState(
 	EKawaiiPhysicsWindScopeComponent Component) const
 {
@@ -2149,6 +2220,10 @@ ECheckBoxState SKawaiiPhysicsWindScopeWindow::GetPauseCheckState() const
 void SKawaiiPhysicsWindScopeWindow::OnPauseCheckStateChanged(ECheckBoxState NewState)
 {
 	bPaused = NewState == ECheckBoxState::Checked;
+	if (GraphWidget.IsValid())
+	{
+		GraphWidget->SetPaused(bPaused);
+	}
 }
 
 float SKawaiiPhysicsWindScopeWindow::GetDisplaySeconds() const
@@ -2196,6 +2271,21 @@ void SKawaiiPhysicsWindScopeWindow::OnEditPanelSlotResized(float NewFraction)
 	EditPanelSplitterFraction = FMath::Clamp(NewFraction, 0.2f, 0.8f);
 }
 
+FSlateColor SKawaiiPhysicsWindScopeWindow::GetModeBadgeColor() const
+{
+	if (bIsLiveMode)
+	{
+		return FAppStyle::Get().GetSlateColor(TEXT("Colors.AccentGreen"));
+	}
+
+	return FSlateColor(FLinearColor(0.72f, 0.72f, 0.72f, 0.5f));
+}
+
+EVisibility SKawaiiPhysicsWindScopeWindow::GetTargetNodeEmptyStateVisibility() const
+{
+	return ResolveGraphNode() ? EVisibility::Collapsed : EVisibility::HitTestInvisible;
+}
+
 bool SKawaiiPhysicsWindScopeWindow::IsWindEditable() const
 {
 	return ResolveGraphNode() != nullptr;
@@ -2237,39 +2327,273 @@ FLinearColor SKawaiiPhysicsWindScopeWindow::ResolveSeriesDisplayColor(
 void SKawaiiPhysicsWindScopeWindow::RebuildPresetButtons()
 {
 	CachedPresets = KawaiiPhysicsWindScopeWindowPrivate::ResolveWindScopePresets();
-	if (!PresetButtonBox.IsValid())
-	{
-		return;
-	}
 
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetGhostSamples(TArray<FVector2D>());
 	}
+}
 
-	PresetButtonBox->ClearChildren();
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GeneratePresetMenu()
+{
+	RebuildPresetButtons();
+
+	// ポップアップはタブ破棄後も生存しうるため弱参照で捕捉
+	const TWeakPtr<SKawaiiPhysicsWindScopeWindow> WeakSelf = SharedThis(this);
+
+	TSharedRef<SVerticalBox> PresetMenuBox = SNew(SVerticalBox);
 	for (int32 PresetIndex = 0; PresetIndex < CachedPresets.Num(); ++PresetIndex)
 	{
 		const FText PresetDisplayName =
 			KawaiiPhysicsWindScopeWindowPrivate::ResolveWindPresetDisplayName(CachedPresets[PresetIndex], PresetIndex);
-		PresetButtonBox->AddSlot()
+		PresetMenuBox->AddSlot()
+		.AutoHeight()
 		[
 			SNew(SButton)
 			.Text(PresetDisplayName)
+			.HAlign(HAlign_Left)
 			.ToolTipText(FText::Format(
 				LOCTEXT("PresetButtonTooltipFormat", "Apply the \"{0}\" wind preset to the current parameters.\nHover to preview it on the graph."),
 				PresetDisplayName))
 			.OnClicked(this, &SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked, PresetIndex)
-			.OnHovered_Lambda([this, PresetIndex]()
+			.OnHovered_Lambda([WeakSelf, PresetIndex]()
 			{
-				OnPresetButtonHovered(PresetIndex);
+				if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+				{
+					Self->OnPresetButtonHovered(PresetIndex);
+				}
 			})
-			.OnUnhovered_Lambda([this]()
+			.OnUnhovered_Lambda([WeakSelf]()
 			{
-				OnPresetButtonUnhovered();
+				if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+				{
+					Self->OnPresetButtonUnhovered();
+				}
 			})
 		];
 	}
+
+	if (CachedPresets.Num() == 0)
+	{
+		PresetMenuBox->AddSlot()
+		.AutoHeight()
+		.Padding(FMargin(8.0f, 4.0f))
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("NoPresetsMenuInfo", "No wind presets found."))
+			.ColorAndOpacity(FSlateColor::UseSubduedForeground())
+		];
+	}
+
+	PresetMenuBox->AddSlot()
+	.AutoHeight()
+	.Padding(FMargin(0.0f, 4.0f))
+	[
+		SNew(SSeparator)
+	];
+
+	PresetMenuBox->AddSlot()
+	.AutoHeight()
+	[
+		SNew(SComboButton)
+		.ContentPadding(FMargin(8.0f, 3.0f))
+		.ToolTipText(this, &SKawaiiPhysicsWindScopeWindow::GetSavePresetToolTipText)
+		.IsEnabled(this, &SKawaiiPhysicsWindScopeWindow::CanSaveWindPreset)
+		.OnGetMenuContent(this, &SKawaiiPhysicsWindScopeWindow::GenerateSavePresetMenu)
+		.ButtonContent()
+		[
+			SNew(STextBlock)
+			.Text(LOCTEXT("SavePresetButton", "Save as Preset"))
+		]
+	];
+
+	PresetMenuBox->AddSlot()
+	.AutoHeight()
+	.Padding(FMargin(0.0f, 2.0f, 0.0f, 0.0f))
+	[
+		SNew(SButton)
+		.Text(LOCTEXT("ReloadPresetsButton", "Reload"))
+		.HAlign(HAlign_Left)
+		.ContentPadding(FMargin(8.0f, 3.0f))
+		.ToolTipText(LOCTEXT("ReloadPresetsTooltip", "Reload the preset DataAsset."))
+		.OnClicked_Lambda([WeakSelf]()
+		{
+			if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+			{
+				Self->RebuildPresetButtons();
+				if (Self->PresetComboButton.IsValid())
+				{
+					Self->PresetComboButton->SetIsOpen(false);
+				}
+			}
+			return FReply::Handled();
+		})
+	];
+
+	return SNew(SBox)
+		.MinDesiredWidth(220.0f)
+		[
+			SNew(SBorder)
+			.BorderImage(FAppStyle::Get().GetBrush(TEXT("Menu.Background")))
+			.Padding(2.0f)
+			[
+				PresetMenuBox
+			]
+		];
+}
+
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeWindow::GenerateGustMenu()
+{
+	// ポップアップはタブ破棄後も生存しうるため弱参照で捕捉
+	const TWeakPtr<SKawaiiPhysicsWindScopeWindow> WeakSelf = SharedThis(this);
+
+	return SNew(SBox)
+		.MinDesiredWidth(220.0f)
+		[
+			SNew(SBorder)
+			.BorderImage(FAppStyle::Get().GetBrush(TEXT("Menu.Background")))
+			.Padding(8.0f)
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+					[
+						SNew(SBox)
+						.WidthOverride(56.0f)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("GustStrengthLabel", "Strength"))
+							.ToolTipText(LOCTEXT("GustStrengthTooltip", "Gust strength."))
+							.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SSpinBox<float>)
+						.MinValue(0.0f)
+						.MaxValue(50.0f)
+						.MinSliderValue(0.0f)
+						.MaxSliderValue(50.0f)
+						.Value_Lambda([WeakSelf]()
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								return Self->GustStrength;
+							}
+							return 0.0f;
+						})
+						.OnValueChanged_Lambda([WeakSelf](float NewValue)
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								Self->GustStrength = FMath::Clamp(NewValue, 0.0f, 50.0f);
+							}
+						})
+						.ToolTipText(LOCTEXT("GustStrengthSpinTooltip", "Gust strength."))
+					]
+				]
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.0f, 0.0f, 0.0f, 4.0f)
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+					[
+						SNew(SBox)
+						.WidthOverride(56.0f)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("GustRiseLabel", "Rise"))
+							.ToolTipText(LOCTEXT("GustRiseTooltip", "Gust rise time."))
+							.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SSpinBox<float>)
+						.MinValue(0.01f)
+						.MaxValue(5.0f)
+						.MinSliderValue(0.01f)
+						.MaxSliderValue(5.0f)
+						.Value_Lambda([WeakSelf]()
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								return Self->GustRiseTime;
+							}
+							return 0.0f;
+						})
+						.OnValueChanged_Lambda([WeakSelf](float NewValue)
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								Self->GustRiseTime = FMath::Clamp(NewValue, 0.01f, 5.0f);
+							}
+						})
+						.ToolTipText(LOCTEXT("GustRiseSpinTooltip", "Gust rise time."))
+					]
+				]
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.AutoWidth()
+					.VAlign(VAlign_Center)
+					.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+					[
+						SNew(SBox)
+						.WidthOverride(56.0f)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("GustDecayLabel", "Decay"))
+							.ToolTipText(LOCTEXT("GustDecayTooltip", "Gust decay time."))
+							.Font(FSlateFontInfo(FCoreStyle::GetDefaultFont(), 9))
+						]
+					]
+					+ SHorizontalBox::Slot()
+					.FillWidth(1.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SSpinBox<float>)
+						.MinValue(0.01f)
+						.MaxValue(10.0f)
+						.MinSliderValue(0.01f)
+						.MaxSliderValue(10.0f)
+						.Value_Lambda([WeakSelf]()
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								return Self->GustDecayTime;
+							}
+							return 0.0f;
+						})
+						.OnValueChanged_Lambda([WeakSelf](float NewValue)
+						{
+							if (TSharedPtr<SKawaiiPhysicsWindScopeWindow> Self = WeakSelf.Pin())
+							{
+								Self->GustDecayTime = FMath::Clamp(NewValue, 0.01f, 10.0f);
+							}
+						})
+						.ToolTipText(LOCTEXT("GustDecaySpinTooltip", "Gust decay time."))
+					]
+				]
+			]
+		];
 }
 
 FReply SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked(int32 PresetIndex)
@@ -2279,7 +2603,13 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPresetButtonClicked(int32 PresetIndex)
 		return FReply::Handled();
 	}
 
-	return ApplyPreset(CachedPresets[PresetIndex]);
+	FReply Reply = ApplyPreset(CachedPresets[PresetIndex]);
+	OnPresetButtonUnhovered();
+	if (PresetComboButton.IsValid())
+	{
+		PresetComboButton->SetIsOpen(false);
+	}
+	return Reply;
 }
 
 void SKawaiiPhysicsWindScopeWindow::OnPresetButtonHovered(int32 PresetIndex)
@@ -2324,6 +2654,15 @@ void SKawaiiPhysicsWindScopeWindow::OnPresetButtonUnhovered()
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetGhostSamples(TArray<FVector2D>());
+	}
+}
+
+void SKawaiiPhysicsWindScopeWindow::OnPresetMenuOpenChanged(bool bIsOpen)
+{
+	// メニューを閉じた際、ホバー中のプレビュー波形（ゴースト）を消し忘れないようにする
+	if (!bIsOpen)
+	{
+		OnPresetButtonUnhovered();
 	}
 }
 
@@ -3053,6 +3392,29 @@ bool SKawaiiPhysicsWindScopeWindow::ComputeWindParamPinExposure(FName PropertyNa
 	return false;
 }
 
+bool SKawaiiPhysicsWindScopeWindow::IsLiveTargetResolved() const
+{
+	// Editor側ノードからLive実行中のランタイムノードを解決し、対象ProceduralWindの
+	// RuntimeStateが有効かどうかだけを判定する（サンプル取得は行わない）
+	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
+	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);
+	if (!RuntimeNode)
+	{
+		return false;
+	}
+
+	const int32 ResolvedIndex =
+		KawaiiPhysicsWindScopeWindowPrivate::ResolveProceduralWindIndex(*RuntimeNode, Args.ExternalForceIndex);
+	if (!RuntimeNode->ExternalForces.IsValidIndex(ResolvedIndex))
+	{
+		return false;
+	}
+
+	const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind =
+		RuntimeNode->ExternalForces[ResolvedIndex].GetPtr<FKawaiiPhysics_ExternalForce_ProceduralWind>();
+	return Wind && Wind->RuntimeState.IsValid();
+}
+
 EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCurrentTime, float InDeltaTime)
 {
 	(void)InCurrentTime;
@@ -3076,30 +3438,57 @@ EActiveTimerReturnType SKawaiiPhysicsWindScopeWindow::TickWindScope(double InCur
 		}
 	}
 	bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
+	if (!bHasWindSnapshot)
+	{
+		// Editor側ノード（GraphNode->Node）で対象を解決できなかった場合でも、Live実行中は
+		// ランタイム側の別ノードを参照して独立に解決されることがある（BP未再コンパイルの編集で
+		// Editor側だけ対象を失っている等）。両方とも解決できないと確認できたときだけ、
+		// Pause中に旧波形を残さないようクリアする
+		if (!IsLiveTargetResolved())
+		{
+			DisplaySamples.Reset();
+			LastLiveSampleCount = 0;
+		}
+	}
 	UpdateEditValuesFromWind(bHasWindSnapshot ? &WindSnapshot : nullptr);
 	UpdateLiveEditValuesFromRuntime();
 
-	if (bPaused)
+	if (!bPaused)
 	{
-		return EActiveTimerReturnType::Continue;
-	}
-
-	// Live 取得に失敗したら（PIE/デバッグ対象なし等）Preview 波形を計算する
-	if (!TryUpdateFromLiveRuntime())
-	{
-		if (!bHasWindSnapshot)
+		// Live 取得に失敗したら（PIE/デバッグ対象なし等）Preview 波形を計算する
+		bool bLiveTargetResolved = false;
+		const bool bLiveUpdated = TryUpdateFromLiveRuntime(bLiveTargetResolved);
+		if (bLiveUpdated)
 		{
-			bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
+			CurrentModeText = LOCTEXT("LiveModeTick", "Live");
+			bIsLiveMode = true;
 		}
-		RebuildPreviewSamples(InDeltaTime, bHasWindSnapshot ? &WindSnapshot : nullptr);
-		CurrentModeText = LOCTEXT("PreviewModeTick", "Preview");
+		else if (bLiveTargetResolved)
+		{
+			// Live対象が有効で新規サンプルが無いだけの tick は Preview に落とさず現状維持する
+			// （DisplaySamples はそのまま。CurrentModeText/bIsLiveMode も Live 表示を継続する）
+			CurrentModeText = LOCTEXT("LiveModeTick", "Live");
+			bIsLiveMode = true;
+		}
+		else
+		{
+			if (!bHasWindSnapshot)
+			{
+				bHasWindSnapshot = TryGetPreviewForceCopy(WindSnapshot);
+			}
+			RebuildPreviewSamples(InDeltaTime, bHasWindSnapshot ? &WindSnapshot : nullptr);
+			CurrentModeText = LOCTEXT("PreviewModeTick", "Preview");
+			bIsLiveMode = false;
+		}
 	}
 	else
 	{
-		CurrentModeText = LOCTEXT("LiveModeTick", "Live");
+		// Pause中もバッジ表示だけは対象の生死に追従させる（サンプルは凍結）
+		bIsLiveMode = IsLiveTargetResolved();
+		CurrentModeText = bIsLiveMode ? LOCTEXT("LiveModeTick", "Live") : LOCTEXT("PreviewModeTick", "Preview");
 	}
 
-	// グラフウィジェットへ最新サンプル・表示設定を反映
+	// グラフウィジェットへ最新サンプル・表示設定を反映（Pause中もクリア直後の状態を反映するため実行する）
 	if (GraphWidget.IsValid())
 	{
 		GraphWidget->SetDisplaySeconds(DisplaySeconds);
@@ -3223,8 +3612,10 @@ void SKawaiiPhysicsWindScopeWindow::UpdateLiveEditValuesFromRuntime()
 	KawaiiPhysicsWindScopeWindowPrivate::FillWindScopeEditValuesFromWind(RuntimeWind, CachedLiveEditValues, false);
 }
 
-bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
+bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime(bool& bOutLiveTargetResolved)
 {
+	bOutLiveTargetResolved = false;
+
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	if (!GraphNode)
 	{
@@ -3250,6 +3641,9 @@ bool SKawaiiPhysicsWindScopeWindow::TryUpdateFromLiveRuntime()
 	{
 		return false;
 	}
+
+	// Live対象（ProceduralWind + RuntimeState）自体は解決できた。以降は新規サンプルの有無だけを判定する
+	bOutLiveTargetResolved = true;
 
 	// ScopeBuffer は PreApply（アニメーションワーカースレッド）が Mutex 下で書き込むリングバッファなので、
 	// ロック区間はコピーのみに留め、Game Thread 側にスナップショットを持ち出してから解放する

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -13,9 +13,9 @@
 
 struct FStreamableHandle;
 class SDockTab;
+class SComboButton;
 class SComboBoxBase;
 class SSplitter;
-class SWrapBox;
 class UAnimGraphNode_KawaiiPhysics;
 
 struct FKawaiiPhysicsWindScopeWindowArgs
@@ -99,6 +99,7 @@ public:
 	void SetActiveEditGuide(TOptional<FName> PropertyName);
 	void SetEditValues(const FKawaiiWindScopeEditValues* InEditValues);
 	void SetGhostSamples(TArray<FVector2D> InGhostSamples);
+	void SetPaused(bool bInPaused);
 
 	virtual FReply OnMouseMove(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
 	virtual void OnMouseLeave(const FPointerEvent& MouseEvent) override;
@@ -123,6 +124,7 @@ private:
 	TOptional<FVector2D> HoverMousePosition;
 	const FKawaiiWindScopeEditValues* EditValues = nullptr;
 	float DisplaySeconds = 8.0f;
+	bool bPaused = false;
 };
 
 // Wind Scope タブ本体 / Wind Scope tab content widget.
@@ -171,7 +173,6 @@ private:
 	FText GetSelectedExternalForceText() const;
 	FText GetTargetNodeText() const;
 	FText GetModeText() const;
-	FText GetCurrentValuesText() const;
 	ECheckBoxState GetPauseCheckState() const;
 	void OnPauseCheckStateChanged(ECheckBoxState NewState);
 	float GetDisplaySeconds() const;
@@ -181,14 +182,19 @@ private:
 	const FSlateBrush* GetEditPanelToggleIcon() const;
 	FReply OnToggleEditPanelClicked();
 	void OnEditPanelSlotResized(float NewFraction);
+	FSlateColor GetModeBadgeColor() const;
+	EVisibility GetTargetNodeEmptyStateVisibility() const;
 	bool IsWindEditable() const;
 	const FKawaiiWindScopeEditValues* GetEditValues() const;
 	const FKawaiiWindScopeEditValues* GetLiveEditValues() const;
 
 	void RebuildPresetButtons();
+	TSharedRef<SWidget> GeneratePresetMenu();
+	TSharedRef<SWidget> GenerateGustMenu();
 	FReply OnPresetButtonClicked(int32 PresetIndex);
 	void OnPresetButtonHovered(int32 PresetIndex);
 	void OnPresetButtonUnhovered();
+	void OnPresetMenuOpenChanged(bool bIsOpen);
 	FReply ApplyPreset(const FKawaiiProceduralWindPreset& Preset);
 	TSharedRef<SWidget> GenerateSavePresetMenu();
 	bool CanSaveWindPreset() const;
@@ -218,7 +224,10 @@ private:
 	// Live 実行中でない場合の理論波形を再計算する / Rebuilds theoretical Preview samples when Live data is unavailable.
 	void RebuildPreviewSamples(float InDeltaTime, const FKawaiiPhysics_ExternalForce_ProceduralWind* WindSnapshot = nullptr);
 	// 実行中の RuntimeState からライブ波形を取得する / Reads Live samples from RuntimeState.
-	bool TryUpdateFromLiveRuntime();
+	bool TryUpdateFromLiveRuntime(bool& bOutLiveTargetResolved);
+	// Live対象（ProceduralWind + RuntimeState）が現在解決可能かだけを判定する（サンプル取得は行わない）
+	// Checks only whether a Live target currently resolves (does not fetch samples).
+	bool IsLiveTargetResolved() const;
 	// Preview 計算用に ProceduralWind 設定値のコピーを取得する / Gets a ProceduralWind copy for Preview calculation.
 	bool TryGetPreviewForceCopy(struct FKawaiiPhysics_ExternalForce_ProceduralWind& OutForce) const;
 	void UpdateEditValuesFromWind(const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind);
@@ -257,6 +266,7 @@ private:
 	float GustDecayTime;
 	float WindParamPinExposureRefreshElapsedTime = 0.0f;
 	bool bHasDragStartWind = false;
+	bool bIsLiveMode = false;
 	bool bEditPanelExpanded = false;
 	float EditPanelSplitterFraction = 0.4f;
 	// Preview モードでの積算経過時間 / Accumulated elapsed time in Preview mode.
@@ -270,10 +280,10 @@ private:
 	TSharedPtr<FStreamableHandle> PendingReconnectAsyncLoadHandle;
 
 	TWeakPtr<SDockTab> OwnerTabWeak;
+	TSharedPtr<SComboButton> PresetComboButton;
 	TSharedPtr<SComboBox<FExternalForceIndexPtr>> ExternalForceComboBox;
 	TSharedPtr<SKawaiiPhysicsWindScopeGraph> GraphWidget;
 	TSharedPtr<SSplitter> EditPanelSplitter;
 	// ボタンindexとの整合を保つプリセットスナップショット / Preset snapshot aligned with button indices.
 	TArray<FKawaiiProceduralWindPreset> CachedPresets;
-	TSharedPtr<SWrapBox> PresetButtonBox;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
@@ -140,9 +140,10 @@ bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Par
 			CollapsedGroupRoundTripOutput.Contains(GroupId));
 	}
 
-	const TSet<FName> ParsedWithUnknown = ParseWindScopeCollapsedGroups(FString(TEXT("Constant,UnknownGroup,Ripple")));
+	const TSet<FName> ParsedWithUnknown = ParseWindScopeCollapsedGroups(FString(TEXT("Constant,Time,UnknownGroup,Ripple")));
 	bOk &= TestTrue(TEXT("Known collapsed group is parsed"), ParsedWithUnknown.Contains(FName(TEXT("Constant"))));
 	bOk &= TestTrue(TEXT("Known collapsed group after unknown is parsed"), ParsedWithUnknown.Contains(FName(TEXT("Ripple"))));
+	bOk &= TestFalse(TEXT("Removed Time collapsed group is discarded"), ParsedWithUnknown.Contains(FName(TEXT("Time"))));
 	bOk &= TestFalse(TEXT("Unknown collapsed group is discarded"), ParsedWithUnknown.Contains(FName(TEXT("UnknownGroup"))));
 
 	return bOk;


### PR DESCRIPTION
## 概要
Wind Scope タブの UI/UX を再編しました。「計算式と凡例の重複・近接」「役割の異なる操作が1行に混在」「時間軸なし」「フッタ数値列の冗長さ」「右パネルのラベル切れ」を解消し、UE 標準のアセットエディタに近い見た目・操作感に揃えています。

## 変更内容
### ツールバー
- ヘッダ行＋プリセット行を **SlimToolbar 風の1本の帯**（暗背景＋下辺2px線）に統合
  - **Presets ▾**：ポップアップ内にプリセット一覧（ホバーでゴースト曲線表示は維持）＋ Save as Preset / Reload
  - **Test Gust ▾**：本体クリックで突風発火、▾ で Strength / Rise / Decay を編集（ini 永続化維持）
  - Copy / Paste、Force コンボ、**Live / Preview 状態バッジ**（非操作表示）、編集パネル開閉
### グラフ
- 計算式と凡例を **チェックボックス付きチップ1行**に統合（`☑Total = (☑Constant + ☑Sway + ☑Ripple) × ☑StrengthCycle + ☑Random + ☑Gust`）。色チップは廃止（文字色で識別）
- **時間軸ラベル**（`-8s … 0s`、右端＝現在。ホバー読み出しと同じ相対表記）
- **StrengthCycle 専用の右軸**（`×0 / ×1 / ×2`、系列色）。力の値とは別スケールにマップ
- グレーアウト系列を明るく（彩度 -50% / 不透明度 60%）
- フッタを撤去し、Window 秒 / Pause をグラフ直下へ。Pause 中は最新値を読み出し表示
### 右パネル（Procedural Wind）
- `Time` グループを `Common`（Parameter Mode / Is Enabled / Time Scale）に統合
- 「Pin-driven…」注記はピン接続パラメータがあるときのみ表示
- ラベル列 190px 固定で**パラメータ名を切らない**。値ウィジェットは残り幅を埋め、Reset ボタンは右端固定
### 挙動修正（レビューで検出）
- Pause 中にノード / Force を切り替えても旧波形が残らないよう即時クリア
- Pause 中も Live 対象の生死を判定し、バッジ表示を更新（サンプルは凍結）
- Live 対象が有効で新規サンプルが無いだけの tick で Preview に落ちないよう修正（master 既存の挙動を改善）
- Presets / Gust ポップアップのラムダを `TWeakPtr` 捕捉に変更。メニューを閉じたときにゴースト曲線を確実にクリア
### ローカライズ
- 新規 LOCTEXT 9件を `ja/KawaiiPhysics.po` に追記（Presets / Strength / Rise / Decay / Copy / Paste / Window など）
