### PR TITLE
[fix] Harden Sequencer settings override termination (world cleanup, undo, per-instance restore)

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Sequencer/KawaiiPhysicsSettingsOverrideTrackEditor.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Sequencer/KawaiiPhysicsSettingsOverrideTrackEditor.cpp
@@ -8,14 +8,90 @@
 #include "GameFramework/Actor.h"
 #include "ISequencer.h"
 #include "KawaiiPhysicsEdStyle.h"
+#include "MovieScene.h"
 #include "MovieSceneKawaiiPhysicsSettingsOverrideSection.h"
 #include "MovieSceneKawaiiPhysicsSettingsOverrideTrack.h"
+#include "MovieScenePossessable.h"
+#include "MovieSceneSequence.h"
 #include "ScopedTransaction.h"
 #include "Sequencer/KawaiiPhysicsSettingsOverrideSectionSummary.h"
 #include "Styling/ISlateStyle.h"
 #include "Styling/SlateStyleRegistry.h"
 
 #define LOCTEXT_NAMESPACE "FKawaiiPhysicsSettingsOverrideTrackEditor"
+
+namespace
+{
+bool KawaiiPhysicsBindingHasSettingsOverrideTrack(UMovieScene* MovieScene, const FGuid& ObjectBinding)
+{
+	if (!MovieScene || !ObjectBinding.IsValid())
+	{
+		return false;
+	}
+
+	return MovieScene->FindTrack(UMovieSceneKawaiiPhysicsSettingsOverrideTrack::StaticClass(), ObjectBinding) !=
+		nullptr;
+}
+
+bool KawaiiPhysicsAnyParentBindingHasSettingsOverrideTrack(
+	UMovieScene* MovieScene,
+	const TArray<FGuid>& ObjectBindings)
+{
+	if (!MovieScene)
+	{
+		return false;
+	}
+
+	for (const FGuid& ObjectBinding : ObjectBindings)
+	{
+		const FMovieScenePossessable* Possessable = MovieScene->FindPossessable(ObjectBinding);
+		if (Possessable &&
+			KawaiiPhysicsBindingHasSettingsOverrideTrack(MovieScene, Possessable->GetParent()))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool KawaiiPhysicsAnyChildComponentBindingHasSettingsOverrideTrack(
+	UMovieScene* MovieScene,
+	const TArray<FGuid>& ObjectBindings)
+{
+	if (!MovieScene)
+	{
+		return false;
+	}
+
+	TSet<FGuid> ParentBindings;
+	for (const FGuid& ObjectBinding : ObjectBindings)
+	{
+		ParentBindings.Add(ObjectBinding);
+	}
+
+	for (int32 PossessableIndex = 0; PossessableIndex < MovieScene->GetPossessableCount(); ++PossessableIndex)
+	{
+		const FMovieScenePossessable& Possessable = MovieScene->GetPossessable(PossessableIndex);
+		const UClass* PossessedObjectClass = Possessable.GetPossessedObjectClass();
+		if (ParentBindings.Contains(Possessable.GetParent()) &&
+			PossessedObjectClass &&
+			PossessedObjectClass->IsChildOf(USkeletalMeshComponent::StaticClass()) &&
+			KawaiiPhysicsBindingHasSettingsOverrideTrack(MovieScene, Possessable.GetGuid()))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+FText KawaiiPhysicsAppendTrackWarning(const FText& ToolTip, const FText& Warning)
+{
+	return FText::Format(LOCTEXT("AddKawaiiPhysicsSettingsOverrideTrackTooltipWithWarning", "{0}{1}"),
+	                     ToolTip, Warning);
+}
+}
 
 TSharedRef<ISequencerTrackEditor> FKawaiiPhysicsSettingsOverrideTrackEditor::CreateTrackEditor(
 	TSharedRef<ISequencer> InSequencer)
@@ -53,11 +129,33 @@ void FKawaiiPhysicsSettingsOverrideTrackEditor::BuildObjectBindingTrackMenu(
 		return;
 	}
 
+	FText ToolTip = LOCTEXT(
+		"AddKawaiiPhysicsSettingsOverrideTrackTooltip",
+		"Adds a track that drives Kawaii Physics settings multiplier overrides on the bound skeletal mesh components.");
+
+	UMovieScene* MovieScene = GetSequencer().IsValid() ? GetFocusedMovieScene() : nullptr;
+	if (ObjectClass->IsChildOf(USkeletalMeshComponent::StaticClass()) &&
+		KawaiiPhysicsAnyParentBindingHasSettingsOverrideTrack(MovieScene, ObjectBindings))
+	{
+		ToolTip = KawaiiPhysicsAppendTrackWarning(
+			ToolTip,
+			LOCTEXT(
+				"AddKawaiiPhysicsSettingsOverrideTrackParentWarning",
+				"\nNote: the parent actor binding already has this track. Overlapping sections on the actor and this component multiply together."));
+	}
+	else if (ObjectClass->IsChildOf(AActor::StaticClass()) &&
+	         KawaiiPhysicsAnyChildComponentBindingHasSettingsOverrideTrack(MovieScene, ObjectBindings))
+	{
+		ToolTip = KawaiiPhysicsAppendTrackWarning(
+			ToolTip,
+			LOCTEXT(
+				"AddKawaiiPhysicsSettingsOverrideTrackChildWarning",
+				"\nNote: a child component binding already has this track. Overlapping sections on the actor and this component multiply together."));
+	}
+
 	MenuBuilder.AddMenuEntry(
 		LOCTEXT("AddKawaiiPhysicsSettingsOverrideTrack", "Kawaii Physics Settings Override"),
-		LOCTEXT(
-			"AddKawaiiPhysicsSettingsOverrideTrackTooltip",
-			"Adds a track that drives Kawaii Physics settings multiplier overrides on the bound skeletal mesh components."),
+		ToolTip,
 		FSlateIcon(FKawaiiPhysicsEdStyle::GetStyleSetName(), TEXT("KawaiiPhysics.TabIcon")),
 		FUIAction(FExecuteAction::CreateSP(
 			this,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Sequencer/KawaiiPhysicsSettingsOverrideTrackEditor.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Sequencer/KawaiiPhysicsSettingsOverrideTrackEditor.h
@@ -9,6 +9,8 @@
 /**
  * Sequencer に Kawaii Physics Settings Override トラックを追加する TrackEditor
  * Track editor that adds Kawaii Physics Settings Override tracks to Sequencer.
+ * 同一 SkeletalMeshComponent に複数セクション/トラックが重なる場合、倍率は成分ごとに乗算合成される
+ * Overlapping sections or tracks on the same component multiply their scales per component.
  */
 class FKawaiiPhysicsSettingsOverrideTrackEditor : public FMovieSceneTrackEditor
 {

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerModule.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerModule.cpp
@@ -2,6 +2,19 @@
 
 #include "KawaiiPhysicsSequencerModule.h"
 
+#include "KawaiiPhysicsSequencerOverrideRegistry.h"
 #include "Modules/ModuleManager.h"
+
+void FKawaiiPhysicsSequencerModule::StartupModule()
+{
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().RegisterDelegates();
+}
+
+void FKawaiiPhysicsSequencerModule::ShutdownModule()
+{
+	// 無期限リースの Entry がモジュール終了後に残らないよう先に全停止
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopAll();
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().UnregisterDelegates();
+}
 
 IMPLEMENT_MODULE(FKawaiiPhysicsSequencerModule, KawaiiPhysicsSequencer)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.cpp
@@ -3,10 +3,13 @@
 #include "KawaiiPhysicsSequencerOverrideRegistry.h"
 
 #include "Components/SkeletalMeshComponent.h"
+#include "Engine/World.h"
 #include "KawaiiPhysicsLibrary.h"
 #include "MovieSceneSection.h"
+#include "MovieSceneTrack.h"
+#include "UObject/UObjectGlobals.h"
 
-void FKawaiiPhysicsSequencerOverrideEntry::Stop()
+void FKawaiiPhysicsSequencerOverrideEntry::Stop(const float OverrideBlendOutTime)
 {
 	if (bStopped)
 	{
@@ -17,8 +20,10 @@ void FKawaiiPhysicsSequencerOverrideEntry::Stop()
 
 	if (USkeletalMeshComponent* TargetComponent = Component.Get())
 	{
+		const float EffectiveBlendOutTime =
+			OverrideBlendOutTime >= 0.0f ? OverrideBlendOutTime : FMath::Max(BlendOutTime, 0.0f);
 		UKawaiiPhysicsLibrary::StopPhysicsSettingsOverridesOnComponent(
-			TargetComponent, Handle, FilterTags, bFilterExactMatch, FMath::Max(BlendOutTime, 0.0f));
+			TargetComponent, Handle, FilterTags, bFilterExactMatch, EffectiveBlendOutTime);
 	}
 }
 
@@ -56,16 +61,66 @@ void FKawaiiPhysicsSequencerOverrideRegistry::Register(
 
 void FKawaiiPhysicsSequencerOverrideRegistry::StopForSection(const UMovieSceneSection* Section)
 {
+	StopForSectionInternal(Section, nullptr, nullptr);
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopForSection(
+	const UMovieSceneSection* Section,
+	const TWeakPtr<uint8>& OwnerFilter)
+{
+	StopForSectionInternal(Section, &OwnerFilter, nullptr);
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopForSection(
+	const UMovieSceneSection* Section,
+	const TWeakPtr<uint8>& OwnerFilter,
+	const USkeletalMeshComponent* ComponentFilter)
+{
+	StopForSectionInternal(Section, &OwnerFilter, ComponentFilter);
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopForSectionInternal(
+	const UMovieSceneSection* Section,
+	const TWeakPtr<uint8>* OptionalOwnerFilter,
+	const USkeletalMeshComponent* OptionalComponentFilter)
+{
 	if (!Section)
 	{
 		return;
+	}
+
+	TSharedPtr<uint8> OwnerFilterPin;
+	if (OptionalOwnerFilter)
+	{
+		OwnerFilterPin = OptionalOwnerFilter->Pin();
+		if (!OwnerFilterPin.IsValid())
+		{
+			return;
+		}
 	}
 
 	const TWeakObjectPtr<const UMovieSceneSection> SectionKey(Section);
 	for (auto It = Entries.CreateIterator(); It; ++It)
 	{
 		const bool bMatchesSection = It.Key() == SectionKey;
-		if (bMatchesSection)
+		bool bStopAndRemove = bMatchesSection;
+		if (bMatchesSection && OptionalOwnerFilter)
+		{
+			bStopAndRemove = false;
+			if (const TSharedPtr<FKawaiiPhysicsSequencerOverrideEntry> Entry = It.Value().Pin())
+			{
+				const TSharedPtr<uint8> EntryOwner = Entry->Owner.Pin();
+				bStopAndRemove = EntryOwner.IsValid() && EntryOwner.Get() == OwnerFilterPin.Get();
+
+				// Component まで指定されている場合は、その Component の Entry だけに絞る（無効化済み Entry はフィルタ指定時は対象外）
+				if (bStopAndRemove && OptionalComponentFilter)
+				{
+					bStopAndRemove = Entry->Component.Get() == OptionalComponentFilter;
+				}
+			}
+		}
+
+		if (bStopAndRemove)
 		{
 			if (const TSharedPtr<FKawaiiPhysicsSequencerOverrideEntry> Entry = It.Value().Pin())
 			{
@@ -73,11 +128,168 @@ void FKawaiiPhysicsSequencerOverrideRegistry::StopForSection(const UMovieSceneSe
 			}
 		}
 
-		if (bMatchesSection || !It.Key().IsValid() || !It.Value().IsValid())
+		if (bStopAndRemove || !It.Key().IsValid() || !It.Value().IsValid())
 		{
 			It.RemoveCurrent();
 		}
 	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopForWorld(const UWorld* World)
+{
+	if (!World)
+	{
+		return;
+	}
+
+	for (auto It = Entries.CreateIterator(); It; ++It)
+	{
+		bool bRemove = !It.Key().IsValid();
+		if (const TSharedPtr<FKawaiiPhysicsSequencerOverrideEntry> Entry = It.Value().Pin())
+		{
+			if (USkeletalMeshComponent* Component = Entry->Component.Get())
+			{
+				if (Component->GetWorld() == World)
+				{
+					Entry->Stop(0.0f);
+					bRemove = true;
+				}
+			}
+		}
+		else
+		{
+			bRemove = true;
+		}
+
+		if (bRemove)
+		{
+			It.RemoveCurrent();
+		}
+	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopForSectionsNotIn(
+	const UMovieSceneTrack* Track,
+	TConstArrayView<UMovieSceneSection*> LiveSections)
+{
+	if (!Track)
+	{
+		return;
+	}
+
+	TArray<const UMovieSceneSection*> SectionsToStop;
+	for (const TPair<TWeakObjectPtr<const UMovieSceneSection>, TWeakPtr<FKawaiiPhysicsSequencerOverrideEntry>>& Pair :
+	     Entries)
+	{
+		const UMovieSceneSection* Section = Pair.Key.Get();
+		if (!Section || Section->GetOuter() != Track)
+		{
+			continue;
+		}
+
+		bool bIsLive = false;
+		for (const UMovieSceneSection* LiveSection : LiveSections)
+		{
+			if (LiveSection == Section)
+			{
+				bIsLive = true;
+				break;
+			}
+		}
+
+		if (!bIsLive)
+		{
+			SectionsToStop.AddUnique(Section);
+		}
+	}
+
+	for (const UMovieSceneSection* Section : SectionsToStop)
+	{
+		StopForSection(Section);
+	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::PruneInvalidEntries()
+{
+	for (auto It = Entries.CreateIterator(); It; ++It)
+	{
+		bool bRemove = !It.Key().IsValid();
+		if (const TSharedPtr<FKawaiiPhysicsSequencerOverrideEntry> Entry = It.Value().Pin())
+		{
+			USkeletalMeshComponent* Component = Entry->Component.Get();
+			bRemove |= !IsValid(Component) || !IsValid(Component->GetWorld());
+		}
+		else
+		{
+			bRemove = true;
+		}
+
+		if (bRemove)
+		{
+			It.RemoveCurrent();
+		}
+	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::StopAll()
+{
+	for (auto It = Entries.CreateIterator(); It; ++It)
+	{
+		if (const TSharedPtr<FKawaiiPhysicsSequencerOverrideEntry> Entry = It.Value().Pin())
+		{
+			Entry->Stop(0.0f);
+		}
+	}
+
+	Entries.Empty();
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::RegisterDelegates()
+{
+	if (!WorldCleanupDelegateHandle.IsValid())
+	{
+		WorldCleanupDelegateHandle = FWorldDelegates::OnWorldCleanup.AddRaw(
+			this, &FKawaiiPhysicsSequencerOverrideRegistry::HandleWorldCleanup);
+	}
+
+	if (!PostGarbageCollectDelegateHandle.IsValid())
+	{
+		PostGarbageCollectDelegateHandle = FCoreUObjectDelegates::GetPostGarbageCollect().AddRaw(
+			this, &FKawaiiPhysicsSequencerOverrideRegistry::HandlePostGarbageCollect);
+	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::UnregisterDelegates()
+{
+	if (WorldCleanupDelegateHandle.IsValid())
+	{
+		FWorldDelegates::OnWorldCleanup.Remove(WorldCleanupDelegateHandle);
+		WorldCleanupDelegateHandle.Reset();
+	}
+
+	if (PostGarbageCollectDelegateHandle.IsValid())
+	{
+		FCoreUObjectDelegates::GetPostGarbageCollect().Remove(PostGarbageCollectDelegateHandle);
+		PostGarbageCollectDelegateHandle.Reset();
+	}
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::HandleWorldCleanup(
+	UWorld* World,
+	bool bSessionEnded,
+	bool bCleanupResources)
+{
+	(void)bSessionEnded;
+	(void)bCleanupResources;
+
+	// World cleanup デリゲートは GameThread 前提で呼ばれるため、Registry 側も既存方針どおり GameThread 限定で扱う
+	StopForWorld(World);
+}
+
+void FKawaiiPhysicsSequencerOverrideRegistry::HandlePostGarbageCollect()
+{
+	// GC 後デリゲートは GameThread 前提で呼ばれるため、Registry 側も既存方針どおり GameThread 限定で扱う
+	PruneInvalidEntries();
 }
 
 #if WITH_DEV_AUTOMATION_TESTS
@@ -94,7 +306,7 @@ int32 FKawaiiPhysicsSequencerOverrideRegistry::CountEntriesForSectionForTesting(
 	for (const TPair<TWeakObjectPtr<const UMovieSceneSection>, TWeakPtr<FKawaiiPhysicsSequencerOverrideEntry>>& Pair :
 	     Entries)
 	{
-		if (Pair.Key == SectionKey && Pair.Value.IsValid())
+		if (Pair.Key == SectionKey)
 		{
 			++Count;
 		}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.h
@@ -7,23 +7,27 @@
 #include "KawaiiPhysicsTypes.h"
 
 class UMovieSceneSection;
+class UMovieSceneTrack;
 class USkeletalMeshComponent;
+class UWorld;
 
 // Component 1 つ分の駆動オーバーライド。SectionData / PreAnimated トークン / レジストリで TSharedRef 共有
 struct KAWAIIPHYSICSSEQUENCER_API FKawaiiPhysicsSequencerOverrideEntry
 {
 	TWeakObjectPtr<USkeletalMeshComponent> Component;
+	TWeakPtr<uint8> Owner;
 	FKawaiiPhysicsTransientForceHandle Handle;
 	FGameplayTagContainer FilterTags;
 	bool bFilterExactMatch = false;
 	float BlendOutTime = 0.2f;
 	bool bStopped = false;
-	bool bPreAnimatedSaved = false;
 
-	void Stop();
+	void Stop(float OverrideBlendOutTime = -1.0f);
 };
 
 // エディタでのセクション/トラック削除など、TearDown も PreAnimated 復元も来ない経路（親サブシーケンスの ForceKeepState 下など）の保険。
+// Owner 限定オーバーロードは PreAnimated 復元を評価インスタンス単位に絞り、1 引数版はセクション破棄用に全 Entry を停止する。
+// Component まで指定する版は PreAnimated の object 単位復元用（復元対象の Component の Entry だけ止める）。
 // GameThread 限定で使用する。
 class KAWAIIPHYSICSSEQUENCER_API FKawaiiPhysicsSequencerOverrideRegistry
 {
@@ -32,11 +36,26 @@ public:
 
 	void Register(const UMovieSceneSection* Section, const TSharedRef<FKawaiiPhysicsSequencerOverrideEntry>& Entry);
 	void StopForSection(const UMovieSceneSection* Section);
+	void StopForSection(const UMovieSceneSection* Section, const TWeakPtr<uint8>& OwnerFilter);
+	void StopForSection(const UMovieSceneSection* Section, const TWeakPtr<uint8>& OwnerFilter, const USkeletalMeshComponent* ComponentFilter);
+	void StopForWorld(const UWorld* World);
+	void StopForSectionsNotIn(const UMovieSceneTrack* Track, TConstArrayView<UMovieSceneSection*> LiveSections);
+	void PruneInvalidEntries();
+	// モジュール終了・アンロード時の最終保険。全 Entry を即時停止して除去する
+	void StopAll();
+	void RegisterDelegates();
+	void UnregisterDelegates();
 
 #if WITH_DEV_AUTOMATION_TESTS
 	int32 CountEntriesForSectionForTesting(const UMovieSceneSection* Section) const;
 #endif
 
 private:
+	void StopForSectionInternal(const UMovieSceneSection* Section, const TWeakPtr<uint8>* OptionalOwnerFilter, const USkeletalMeshComponent* OptionalComponentFilter);
+	void HandleWorldCleanup(UWorld* World, bool bSessionEnded, bool bCleanupResources);
+	void HandlePostGarbageCollect();
+
 	TMultiMap<TWeakObjectPtr<const UMovieSceneSection>, TWeakPtr<FKawaiiPhysicsSequencerOverrideEntry>> Entries;
+	FDelegateHandle WorldCleanupDelegateHandle;
+	FDelegateHandle PostGarbageCollectDelegateHandle;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideSection.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideSection.cpp
@@ -5,6 +5,7 @@
 #include "Channels/MovieSceneChannelEditorData.h"
 #include "Channels/MovieSceneChannelProxy.h"
 #include "KawaiiPhysicsSequencerOverrideRegistry.h"
+#include "MovieSceneTrack.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(MovieSceneKawaiiPhysicsSettingsOverrideSection)
 
@@ -45,5 +46,18 @@ void UMovieSceneKawaiiPhysicsSettingsOverrideSection::BeginDestroy()
 	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(this);
 	Super::BeginDestroy();
 }
+
+#if WITH_EDITOR
+void UMovieSceneKawaiiPhysicsSettingsOverrideSection::PostEditUndo()
+{
+	Super::PostEditUndo();
+
+	const UMovieSceneTrack* Track = GetTypedOuter<UMovieSceneTrack>();
+	if (!Track || !Track->GetAllSections().Contains(this))
+	{
+		FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(this);
+	}
+}
+#endif
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTemplate.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTemplate.cpp
@@ -19,6 +19,8 @@ namespace
 struct FSectionData : IPersistentEvaluationData
 {
 	TMap<TWeakObjectPtr<USkeletalMeshComponent>, TSharedRef<FKawaiiPhysicsSequencerOverrideEntry>> Entries;
+	TSet<TWeakObjectPtr<USkeletalMeshComponent>> PreAnimatedSavedComponents;
+	TSharedRef<uint8> InstanceOwner = MakeShared<uint8>(0);
 
 	virtual ~FSectionData() override
 	{
@@ -32,32 +34,48 @@ struct FSectionData : IPersistentEvaluationData
 
 struct FPreAnimatedToken : IMovieScenePreAnimatedToken
 {
-	explicit FPreAnimatedToken(const TSharedRef<FKawaiiPhysicsSequencerOverrideEntry>& InEntry)
-		: Entry(InEntry)
+	FPreAnimatedToken(const UMovieSceneSection* InSourceSection, const TWeakPtr<uint8>& InOwner)
+		: SourceSection(InSourceSection)
+		, Owner(InOwner)
 	{
 	}
 
 	virtual void RestoreState(UObject& Object, const UE::MovieScene::FRestoreStateParams& Params) override
 	{
-		Entry->Stop();
+		if (const UMovieSceneSection* Section = SourceSection.Get())
+		{
+			// SavePreAnimatedState は Component 単位なので、復元対象の Component の Entry だけ止める（兄弟 Component を巻き込まない）
+			const USkeletalMeshComponent* Component = Cast<USkeletalMeshComponent>(&Object);
+			if (Component)
+			{
+				FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, Owner, Component);
+			}
+			else
+			{
+				FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, Owner);
+			}
+		}
 	}
 
-	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry;
+	TWeakObjectPtr<const UMovieSceneSection> SourceSection;
+	TWeakPtr<uint8> Owner;
 };
 
 struct FPreAnimatedTokenProducer : IMovieScenePreAnimatedTokenProducer
 {
-	explicit FPreAnimatedTokenProducer(const TSharedRef<FKawaiiPhysicsSequencerOverrideEntry>& InEntry)
-		: Entry(InEntry)
+	FPreAnimatedTokenProducer(const UMovieSceneSection* InSourceSection, const TSharedRef<uint8>& InOwner)
+		: SourceSection(InSourceSection)
+		, Owner(InOwner)
 	{
 	}
 
 	virtual IMovieScenePreAnimatedTokenPtr CacheExistingState(UObject& Object) const override
 	{
-		return FPreAnimatedToken(Entry);
+		return FPreAnimatedToken(SourceSection.Get(), Owner);
 	}
 
-	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry;
+	TWeakObjectPtr<const UMovieSceneSection> SourceSection;
+	TWeakPtr<uint8> Owner;
 };
 
 struct FExecutionToken : IMovieSceneExecutionToken
@@ -134,6 +152,7 @@ struct FExecutionToken : IMovieSceneExecutionToken
 			if (!ExistingEntry)
 			{
 				Entry->Component = Component;
+				Entry->Owner = Data.InstanceOwner;
 				Entry->Handle.Id = FAnimNode_KawaiiPhysics::GenerateTransientForceHandleId();
 				Entry->FilterTags = FilterTags;
 				Entry->bFilterExactMatch = bFilterExactMatch;
@@ -146,10 +165,14 @@ struct FExecutionToken : IMovieSceneExecutionToken
 				}
 			}
 
-			if (!Entry->bPreAnimatedSaved)
+			if (!Data.PreAnimatedSavedComponents.Contains(ComponentKey))
 			{
-				Player.SavePreAnimatedState(*Component, AnimTypeID, FPreAnimatedTokenProducer(Entry));
-				Entry->bPreAnimatedSaved = true;
+				if (const UMovieSceneSection* Section = SourceSection.Get())
+				{
+					Player.SavePreAnimatedState(*Component, AnimTypeID,
+					                            FPreAnimatedTokenProducer(Section, Data.InstanceOwner));
+					Data.PreAnimatedSavedComponents.Add(ComponentKey);
+				}
 			}
 
 			UKawaiiPhysicsLibrary::SetPhysicsSettingsOverrideOnComponent(Component, Entry->Handle, Scale, Alpha,
@@ -216,5 +239,6 @@ void FMovieSceneKawaiiPhysicsSettingsOverrideSectionTemplate::TearDown(
 			Pair.Value->Stop();
 		}
 		Data->Entries.Empty();
+		Data->PreAnimatedSavedComponents.Empty();
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTrack.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTrack.cpp
@@ -76,6 +76,14 @@ void UMovieSceneKawaiiPhysicsSettingsOverrideTrack::RemoveAllAnimationData()
 	Sections.Empty();
 }
 
+#if WITH_EDITOR
+void UMovieSceneKawaiiPhysicsSettingsOverrideTrack::PostEditUndo()
+{
+	Super::PostEditUndo();
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSectionsNotIn(this, GetAllSections());
+}
+#endif
+
 #if WITH_EDITORONLY_DATA
 FText UMovieSceneKawaiiPhysicsSettingsOverrideTrack::GetDefaultDisplayName() const
 {

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
@@ -4,6 +4,7 @@
 
 #include "Misc/AutomationTest.h"
 #include "Channels/MovieSceneChannelProxy.h"
+#include "Components/SkeletalMeshComponent.h"
 #include "Generators/MovieSceneEasingCurves.h"
 #include "KawaiiPhysicsSequencerOverrideRegistry.h"
 #include "MovieSceneKawaiiPhysicsSettingsOverrideSection.h"
@@ -226,6 +227,34 @@ bool FKawaiiPhysicsSequencerRegistryRegisterIdempotentTest::RunTest(const FStrin
 	return bOk;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryRemoveSectionAtStopsOnlyRemovedTest,
+                                 "KawaiiPhysics.Sequencer.Section.Registry_RemoveSectionAtStopsOnlyRemoved",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerRegistryRemoveSectionAtStopsOnlyRemovedTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideTrack* Track =
+		NewObject<UMovieSceneKawaiiPhysicsSettingsOverrideTrack>(GetTransientPackage());
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* SectionA =
+		CastChecked<UMovieSceneKawaiiPhysicsSettingsOverrideSection>(Track->CreateNewSection());
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* SectionB =
+		CastChecked<UMovieSceneKawaiiPhysicsSettingsOverrideSection>(Track->CreateNewSection());
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryA = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryB = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+
+	Track->AddSection(*SectionA);
+	Track->AddSection(*SectionB);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionA, EntryA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionB, EntryB);
+
+	Track->RemoveSectionAt(1);
+
+	bool bOk = TestFalse(TEXT("EntryA not stopped"), EntryA->bStopped);
+	bOk &= TestTrue(TEXT("EntryB stopped"), EntryB->bStopped);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(SectionA);
+	return bOk;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerEntryStopIdempotentTest,
                                  "KawaiiPhysics.Sequencer.Section.Entry_StopIdempotent",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -238,6 +267,196 @@ bool FKawaiiPhysicsSequencerEntryStopIdempotentTest::RunTest(const FString& Para
 	bool bOk = TestTrue(TEXT("Entry stopped"), Entry->bStopped);
 	Entry->Stop();
 	bOk &= TestTrue(TEXT("Entry still stopped"), Entry->bStopped);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerEntryStopImmediateOverrideTest,
+                                 "KawaiiPhysics.Sequencer.Section.Entry_StopImmediateOverride",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerEntryStopImmediateOverrideTest::RunTest(const FString& Parameters)
+{
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+
+	Entry->Stop(0.0f);
+	bool bOk = TestTrue(TEXT("Entry stopped immediately"), Entry->bStopped);
+	Entry->Stop(0.0f);
+	bOk &= TestTrue(TEXT("Entry still stopped"), Entry->bStopped);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryStopForSectionsNotInTest,
+                                 "KawaiiPhysics.Sequencer.Section.Registry_StopForSectionsNotIn",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerRegistryStopForSectionsNotInTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideTrack* Track =
+		NewObject<UMovieSceneKawaiiPhysicsSettingsOverrideTrack>(GetTransientPackage());
+	UMovieSceneSection* SectionA = Track->CreateNewSection();
+	UMovieSceneSection* SectionB = Track->CreateNewSection();
+	Track->AddSection(*SectionA);
+	Track->AddSection(*SectionB);
+
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryA = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryB = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionA, EntryA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionB, EntryB);
+
+	TArray<UMovieSceneSection*> LiveSections;
+	LiveSections.Add(SectionA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSectionsNotIn(Track, LiveSections);
+
+	bool bOk = TestFalse(TEXT("EntryA still active"), EntryA->bStopped);
+	bOk &= TestTrue(TEXT("EntryB stopped"), EntryB->bStopped);
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(SectionA);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryPruneInvalidEntriesTest,
+                                 "KawaiiPhysics.Sequencer.Section.Registry_PruneInvalidEntries",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerRegistryPruneInvalidEntriesTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* Section = NewSection();
+	{
+		TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+		FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, Entry);
+		TestEqual(TEXT("Entry registered"),
+		          FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(Section), 1);
+	}
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().PruneInvalidEntries();
+	return TestEqual(TEXT("Invalid entry pruned"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(Section), 0);
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryStopAllTest,
+                                 "KawaiiPhysics.Sequencer.Section.Registry_StopAll",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerRegistryStopAllTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* SectionA = NewSection();
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* SectionB = NewSection();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryA = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryB = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionA, EntryA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(SectionB, EntryB);
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopAll();
+
+	bool bOk = TestTrue(TEXT("EntryA stopped"), EntryA->bStopped);
+	bOk &= TestTrue(TEXT("EntryB stopped"), EntryB->bStopped);
+	bOk &= TestEqual(TEXT("SectionA entries removed"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(SectionA), 0);
+	bOk &= TestEqual(TEXT("SectionB entries removed"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(SectionB), 0);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerPreAnimatedRestoreStopsRecreatedEntryTest,
+                                 "KawaiiPhysics.Sequencer.Section.PreAnimated_RestoreStopsRecreatedEntry",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerPreAnimatedRestoreStopsRecreatedEntryTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* Section = NewSection();
+	TSharedRef<uint8> Owner = MakeShared<uint8>(0);
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry1 = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry2 = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	Entry1->Owner = Owner;
+	Entry2->Owner = Owner;
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, Entry1);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, Entry2);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, Owner);
+
+	bool bOk = TestTrue(TEXT("Entry1 stopped"), Entry1->bStopped);
+	bOk &= TestTrue(TEXT("Entry2 stopped"), Entry2->bStopped);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerPreAnimatedRestoreDoesNotStopOtherOwnerTest,
+                                 "KawaiiPhysics.Sequencer.Section.PreAnimated_RestoreDoesNotStopOtherOwner",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerPreAnimatedRestoreDoesNotStopOtherOwnerTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* Section = NewSection();
+	TSharedRef<uint8> OwnerA = MakeShared<uint8>(0);
+	TSharedRef<uint8> OwnerB = MakeShared<uint8>(0);
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryA = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryB = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	EntryA->Owner = OwnerA;
+	EntryB->Owner = OwnerB;
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, EntryA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, EntryB);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, OwnerA);
+
+	bool bOk = TestTrue(TEXT("EntryA stopped"), EntryA->bStopped);
+	bOk &= TestFalse(TEXT("EntryB still active"), EntryB->bStopped);
+	bOk &= TestEqual(TEXT("Other owner remains"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(Section), 1);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerPreAnimatedRestoreStopsOnlyRestoredComponentTest,
+                                 "KawaiiPhysics.Sequencer.Section.PreAnimated_RestoreStopsOnlyRestoredComponent",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerPreAnimatedRestoreStopsOnlyRestoredComponentTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* Section = NewSection();
+	TSharedRef<uint8> Owner = MakeShared<uint8>(0);
+	USkeletalMeshComponent* ComponentA = NewObject<USkeletalMeshComponent>(GetTransientPackage());
+	USkeletalMeshComponent* ComponentB = NewObject<USkeletalMeshComponent>(GetTransientPackage());
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryA = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> EntryB = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	EntryA->Owner = Owner;
+	EntryA->Component = ComponentA;
+	EntryB->Owner = Owner;
+	EntryB->Component = ComponentB;
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, EntryA);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, EntryB);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, Owner, ComponentA);
+
+	bool bOk = TestTrue(TEXT("EntryA stopped"), EntryA->bStopped);
+	bOk &= TestFalse(TEXT("EntryB still active"), EntryB->bStopped);
+	bOk &= TestEqual(TEXT("Other component remains"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(Section), 1);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section);
+	return bOk;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerPreAnimatedRestoreExpiredOwnerIsNoopTest,
+                                 "KawaiiPhysics.Sequencer.Section.PreAnimated_RestoreExpiredOwnerIsNoop",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSequencerPreAnimatedRestoreExpiredOwnerIsNoopTest::RunTest(const FString& Parameters)
+{
+	UMovieSceneKawaiiPhysicsSettingsOverrideSection* Section = NewSection();
+	TWeakPtr<uint8> ExpiredOwner;
+	TSharedRef<FKawaiiPhysicsSequencerOverrideEntry> Entry = MakeShared<FKawaiiPhysicsSequencerOverrideEntry>();
+	{
+		TSharedRef<uint8> Owner = MakeShared<uint8>(0);
+		ExpiredOwner = Owner;
+		Entry->Owner = Owner;
+	}
+
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().Register(Section, Entry);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section, ExpiredOwner);
+
+	bool bOk = TestFalse(TEXT("Entry still active"), Entry->bStopped);
+	bOk &= TestEqual(TEXT("Entry remains"),
+	                 FKawaiiPhysicsSequencerOverrideRegistry::Get().CountEntriesForSectionForTesting(Section), 1);
+	FKawaiiPhysicsSequencerOverrideRegistry::Get().StopForSection(Section);
 	return bOk;
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/KawaiiPhysicsSequencerModule.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/KawaiiPhysicsSequencerModule.h
@@ -6,4 +6,7 @@
 
 class FKawaiiPhysicsSequencerModule : public IModuleInterface
 {
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsOverrideSection.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsOverrideSection.h
@@ -43,4 +43,8 @@ public:
 
 	/** 破棄時に、このセクション由来の外部駆動を停止する / Stops externally driven overrides created by this section on destruction */
 	virtual void BeginDestroy() override;
+
+#if WITH_EDITOR
+	virtual void PostEditUndo() override;
+#endif
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsOverrideTrack.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsOverrideTrack.h
@@ -8,6 +8,10 @@
 
 #include "MovieSceneKawaiiPhysicsSettingsOverrideTrack.generated.h"
 
+/**
+ * Kawaii Physics 設定倍率を Sequencer から駆動するトラック。
+ * 同一 SkeletalMeshComponent に複数セクション/トラックが重なる場合、倍率は成分ごとに乗算合成される / Overlapping sections or tracks on the same component multiply their scales per component
+ */
 UCLASS(MinimalAPI)
 class UMovieSceneKawaiiPhysicsSettingsOverrideTrack
 	: public UMovieSceneNameableTrack
@@ -29,6 +33,10 @@ public:
 	virtual bool IsEmpty() const override;
 	virtual void RemoveAllAnimationData() override;
 	virtual bool SupportsMultipleRows() const override { return true; }
+
+#if WITH_EDITOR
+	virtual void PostEditUndo() override;
+#endif
 
 #if WITH_EDITORONLY_DATA
 	virtual FText GetDefaultDisplayName() const override;


### PR DESCRIPTION
## 概要
PR #249 で追加した Sequencer「Kawaii Physics Settings Override」トラックの終了保証を強化します。従来の 4 層（TearDown / PreAnimated / ~FSectionData / Registry）を通らない経路と、復元範囲が広すぎる問題を修正します。

## 変更内容
- `FKawaiiPhysicsSequencerOverrideEntry::Stop(OverrideBlendOutTime)`: 即時停止オプションを追加
- Registry: `OnWorldCleanup` で該当 World の Entry を即時停止、`PostGarbageCollect` で無効 Entry を prune、モジュール終了時に `StopAll`
- PreAnimated トークンを「セクション + 評価インスタンス + Component」単位に変更（フィルタ変更で Entry を作り直した後の復元漏れを修正しつつ、別 Player / 兄弟 Component を巻き込まない）
- Track / Section の `PostEditUndo` で Undo によるセクション削除を検知して停止
- TrackEditor: 親 Actor / 子 Component バインディングに既にトラックがある場合にツールチップで乗算合成を警告
- 自動テスト 10 件追加（Registry / PreAnimated / StopAll）

## 確認
- `KawaiiPhysicsSampleEditor` Win64 Development ビルド成功（UE 5.8）
- ヘッドレス `Automation RunTests KawaiiPhysics`: 202 件全通過
- PIE 確認（Undo 復帰 / PIE 終了時の固着なし / 警告ツールチップ）は未実施。`SettingsOverride_PIE_Checklist.md` に項目追加済み
