### PR TITLE
[fix] Release Sequencer settings override by handle regardless of current tag filter

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerOverrideRegistry.cpp
@@ -22,8 +22,9 @@ void FKawaiiPhysicsSequencerOverrideEntry::Stop(const float OverrideBlendOutTime
 	{
 		const float EffectiveBlendOutTime =
 			OverrideBlendOutTime >= 0.0f ? OverrideBlendOutTime : FMath::Max(BlendOutTime, 0.0f);
+		// ハンドルは Entry ごとに一意なので、リタグ後のノードも確実に止めるためフィルタを使わない
 		UKawaiiPhysicsLibrary::StopPhysicsSettingsOverridesOnComponent(
-			TargetComponent, Handle, FilterTags, bFilterExactMatch, EffectiveBlendOutTime);
+			TargetComponent, Handle, FGameplayTagContainer(), false, EffectiveBlendOutTime);
 	}
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTemplate.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/MovieSceneKawaiiPhysicsSettingsOverrideTemplate.cpp
@@ -272,9 +272,18 @@ struct FExecutionToken : IMovieSceneExecutionToken
 				}
 			}
 
-			Entry->LastQueuedNodeCount =
+			const int32 PreviousQueuedNodeCount = Entry->LastQueuedNodeCount;
+			const int32 NewQueuedNodeCount =
 				UKawaiiPhysicsLibrary::SetPhysicsSettingsOverrideOnComponent(Component, Entry->Handle, Scale, Alpha,
 				                                                             FilterTags, bFilterExactMatch);
+			Entry->LastQueuedNodeCount = NewQueuedNodeCount;
+			if (PreviousQueuedNodeCount > 0 && NewQueuedNodeCount == 0)
+			{
+				// 駆動済みノードがセクション中にフィルタ外へ出た場合は全ノードに Stop を届かせて Entry を破棄する
+				Entry->Stop();
+				Data.Entries.Remove(ComponentKey);
+				continue;
+			}
 			SeenComponents.Add(ComponentKey);
 		}
 


### PR DESCRIPTION
## 概要
マージ済みの設定オーバーライド機能群（lease コア / AnimNotify / Sequencer、`99063a1..1fad00b`）を横断レビューした結果の修正。Sequencer 経路は無期限リースで駆動するため、駆動後にノードの `KawaiiPhysicsTag` が変わってフィルタ外になると Stop が届かず、ノード再初期化／World 破棄までオーバーライドが残留していた。

## 変更内容
- `FKawaiiPhysicsSequencerOverrideEntry::Stop`: 空フィルタで `StopPhysicsSettingsOverridesOnComponent` を呼び、現在のタグに関係なくハンドル一致で解放する（ハンドルは Entry ごとに一意なので副作用なし）
- Sequencer 実行トークン: Component の駆動ノード数が `>0 → 0` に転じたら Entry を Stop・破棄する（セクション途中のリタグでも即時解除。再一致時は次評価で Entry を再作成）

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 208/208（フィルタ: KawaiiPhysics、うち Sequencer/SettingsOverride 系 61 件）
- 規約リンタ: Tools/lint-kp.ps1 -Base master → 0 件
- PIE: docs/pie/SettingsOverride_PIE_Checklist.md §2 に「セクション再生中のリタグ後に即時解除」1 項目を追加（未・INDEX.md に登録済）。Sequencer 経路のリタグはヘッドレスで再現不可のため、ノードレベルのハンドル Stop は既存テスト `KawaiiPhysics.SettingsOverride.DrivenStopImmediate` でカバー
- 性能: ホットパス変更なし