### PR TITLE
[refactor] Fix internal naming (typos, verbs, prefixes)

### DIFF
--- a/Plugins/KawaiiPhysics/Config/DefaultKawaiiPhysics.ini
+++ b/Plugins/KawaiiPhysics/Config/DefaultKawaiiPhysics.ini
@@ -66,3 +66,5 @@
 +PropertyRedirects=(OldName="/Script/KawaiiPhysics.KawaiiProceduralWindPreset.WaveSpatialOffset",NewName="RippleTipPhaseDelay")
 +PropertyRedirects=(OldName="/Script/KawaiiPhysics.KawaiiProceduralWindPreset.DirectionNoiseAngle",NewName="WindDirectionNoiseAngle")
 +PropertyRedirects=(OldName="/Script/KawaiiPhysics.KawaiiProceduralWindPreset.RandomPeriod",NewName="RandomForcePeriod")
+; AnimGraphNode の typo 修正（Planer -> Planar、v1.22.0）
++PropertyRedirects=(OldName="/Script/KawaiiPhysicsEd.AnimGraphNode_KawaiiPhysics.bEnableDebugDrawPlanerLimit",NewName="bEnableDebugDrawPlanarLimit")

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -120,7 +120,7 @@ DEFINE_STAT(STAT_KawaiiPhysics_ApplySyncBone);
 DEFINE_STAT(STAT_KawaiiPhysics_AdjustByCollision);
 DEFINE_STAT(STAT_KawaiiPhysics_AdjustByBoneConstraint);
 DEFINE_STAT(STAT_KawaiiPhysics_UpdateSphericalLimit);
-DEFINE_STAT(STAT_KawaiiPhysics_UpdatePlanerLimit);
+DEFINE_STAT(STAT_KawaiiPhysics_UpdatePlanarLimit);
 DEFINE_STAT(STAT_KawaiiPhysics_WarmUp);
 DEFINE_STAT(STAT_KawaiiPhysics_UpdatePhysicsSetting);
 DEFINE_STAT(STAT_KawaiiPhysics_UpdateCapsuleLimit);
@@ -696,8 +696,8 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 	UpdateTaperedCapsuleLimits(TaperedCapsuleLimitsData, Output, BoneContainer, ComponentTransform);
 	UpdateBoxLimits(BoxLimits, Output, BoneContainer, ComponentTransform);
 	UpdateBoxLimits(BoxLimitsData, Output, BoneContainer, ComponentTransform);
-	UpdatePlanerLimits(PlanarLimits, Output, BoneContainer, ComponentTransform);
-	UpdatePlanerLimits(PlanarLimitsData, Output, BoneContainer, ComponentTransform);
+	UpdatePlanarLimits(PlanarLimits, Output, BoneContainer, ComponentTransform);
+	UpdatePlanarLimits(PlanarLimitsData, Output, BoneContainer, ComponentTransform);
 
 	// 共有コリジョンの初期化と更新（有効時のみ）。reinit処理は関数冒頭で実行済み。
 	// subsystemはロックでスレッドセーフ化済みのためWorker(AnyThread)で実行でき、PreUpdate(GameThread)を介さない。
@@ -769,7 +769,7 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 	UpdateSkelCompMove(Output, ComponentTransform);
 
 	// 一時外力は評価ごとに1回だけ取り込み、WarmUpの反復やTeleport時のSimulateスキップに左右されないようにする
-	ConsumeAndSweepTransientExternalForces(DeltaTime);
+	ConsumeAndPruneTransientExternalForces(DeltaTime);
 
 	// 物理の荒ぶりを回避するための空回し処理
 	if (bNeedWarmUp && WarmUpFrames > 0)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -769,7 +769,7 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 	UpdateSkelCompMove(Output, ComponentTransform);
 
 	// 一時外力は評価ごとに1回だけ取り込み、WarmUpの反復やTeleport時のSimulateスキップに左右されないようにする
-	ConsumeAndPruneTransientExternalForces(DeltaTime);
+	ConsumeAndRemoveExpiredTransientExternalForces(DeltaTime);
 
 	// 物理の荒ぶりを回避するための空回し処理
 	if (bNeedWarmUp && WarmUpFrames > 0)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -227,7 +227,7 @@ void FAnimNode_KawaiiPhysics::ApplyMirrorLimits(const FBoneContainer& RequiredBo
 
 	const FReferenceSkeleton& MeshRefSkeleton = RequiredBones.GetReferenceSkeleton();
 	TArray<FQuat> CSRefRotations;
-	KawaiiPhysicsMirror::BuildComponentSpaceRefRotations(MeshRefSkeleton, CSRefRotations);
+	KawaiiPhysicsMirrorUtils::BuildComponentSpaceRefRotations(MeshRefSkeleton, CSRefRotations);
 
 	const auto FindBoneIndex = [&MeshRefSkeleton](FName BoneName) -> int32
 	{
@@ -240,11 +240,11 @@ void FAnimNode_KawaiiPhysics::ApplyMirrorLimits(const FBoneContainer& RequiredBo
 		using TLimit = typename TRemoveReference<decltype(MergedLimits)>::Type::ElementType;
 
 		TArray<TLimit> NewLimits;
-		KawaiiPhysicsMirror::AppendMirroredLimits(NodeLimits, NodeLimits, MergedLimits,
+		KawaiiPhysicsMirrorUtils::AppendMirroredLimits(NodeLimits, NodeLimits, MergedLimits,
 		                                          bSkipMirroredBoneWithExistingCollision,
 		                                          ResolveMirrorBoneName, FindBoneIndex,
 		                                          CSRefRotations, MirrorAxis, NewLimits);
-		KawaiiPhysicsMirror::AppendMirroredLimits(MergedLimits, NodeLimits, MergedLimits,
+		KawaiiPhysicsMirrorUtils::AppendMirroredLimits(MergedLimits, NodeLimits, MergedLimits,
 		                                          bSkipMirroredBoneWithExistingCollision,
 		                                          ResolveMirrorBoneName, FindBoneIndex,
 		                                          CSRefRotations, MirrorAxis, NewLimits);
@@ -422,13 +422,13 @@ void FAnimNode_KawaiiPhysics::UpdateBoxLimits(TArray<FBoxLimit>& Limits, FCompon
 	}
 }
 
-void FAnimNode_KawaiiPhysics::UpdatePlanerLimits(TArray<FPlanarLimit>& Limits, FComponentSpacePoseContext& Output,
+void FAnimNode_KawaiiPhysics::UpdatePlanarLimits(TArray<FPlanarLimit>& Limits, FComponentSpacePoseContext& Output,
                                                  const FBoneContainer& BoneContainer,
                                                  const FTransform& ComponentTransform) const
 {
 	for (auto& Planar : Limits)
 	{
-		SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_UpdatePlanerLimit);
+		SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_UpdatePlanarLimit);
 
 		if (Planar.DrivingBone.IsValidToEvaluate(BoneContainer))
 		{
@@ -833,7 +833,7 @@ void FAnimNode_KawaiiPhysics::AdjustByBoxCollision(FKawaiiPhysicsModifyBone& Bon
 	}
 }
 
-void FAnimNode_KawaiiPhysics::AdjustByPlanerCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits)
+void FAnimNode_KawaiiPhysics::AdjustByPlanarCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits)
 {
 	for (auto& Planar : Limits)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsInternal.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsInternal.h
@@ -19,7 +19,7 @@ DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_ApplySyncBone"), STAT_KawaiiPhysic
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_AdjustByCollision"), STAT_KawaiiPhysics_AdjustByCollision, STATGROUP_Anim, KAWAIIPHYSICS_API);
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_AdjustByBoneConstraint"), STAT_KawaiiPhysics_AdjustByBoneConstraint, STATGROUP_Anim, KAWAIIPHYSICS_API);
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_UpdateSphericalLimit"), STAT_KawaiiPhysics_UpdateSphericalLimit, STATGROUP_Anim, KAWAIIPHYSICS_API);
-DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_UpdatePlanerLimit"), STAT_KawaiiPhysics_UpdatePlanerLimit, STATGROUP_Anim, KAWAIIPHYSICS_API);
+DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_UpdatePlanarLimit"), STAT_KawaiiPhysics_UpdatePlanarLimit, STATGROUP_Anim, KAWAIIPHYSICS_API);
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_WarmUp"), STAT_KawaiiPhysics_WarmUp, STATGROUP_Anim, KAWAIIPHYSICS_API);
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_UpdatePhysicsSetting"), STAT_KawaiiPhysics_UpdatePhysicsSetting, STATGROUP_Anim, KAWAIIPHYSICS_API);
 DECLARE_CYCLE_STAT_EXTERN(TEXT("KawaiiPhysics_UpdateCapsuleLimit"), STAT_KawaiiPhysics_UpdateCapsuleLimit, STATGROUP_Anim, KAWAIIPHYSICS_API);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -292,7 +292,7 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 	}
 }
 
-void FAnimNode_KawaiiPhysics::ConsumeAndSweepTransientExternalForces(const float InFrameDeltaTime)
+void FAnimNode_KawaiiPhysics::ConsumeAndPruneTransientExternalForces(const float InFrameDeltaTime)
 {
 	for (int32 i = TransientForceStore.Items.Num() - 1; i >= 0; --i)
 	{
@@ -940,8 +940,8 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 		AdjustByTaperedCapsuleCollision(Bone, TaperedCapsuleLimitsData);
 		AdjustByBoxCollision(Bone, BoxLimits);
 		AdjustByBoxCollision(Bone, BoxLimitsData);
-		AdjustByPlanerCollision(Bone, PlanarLimits);
-		AdjustByPlanerCollision(Bone, PlanarLimitsData);
+		AdjustByPlanarCollision(Bone, PlanarLimits);
+		AdjustByPlanarCollision(Bone, PlanarLimitsData);
 
 		// 共有コリジョン（他の KawaiiPhysics ノードから）
 		if (bUseSharedCollision && !bSharedCollisionSource)
@@ -950,7 +950,7 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 			AdjustByCapsuleCollision(Bone, SharedCapsuleLimits);
 			AdjustByTaperedCapsuleCollision(Bone, SharedTaperedCapsuleLimits);
 			AdjustByBoxCollision(Bone, SharedBoxLimits);
-			AdjustByPlanerCollision(Bone, SharedPlanarLimits);
+			AdjustByPlanarCollision(Bone, SharedPlanarLimits);
 		}
 
 		if (bAllowWorldCollision)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -292,7 +292,7 @@ void FAnimNode_KawaiiPhysics::UpdatePhysicsSettingsOfModifyBones()
 	}
 }
 
-void FAnimNode_KawaiiPhysics::ConsumeAndPruneTransientExternalForces(const float InFrameDeltaTime)
+void FAnimNode_KawaiiPhysics::ConsumeAndRemoveExpiredTransientExternalForces(const float InFrameDeltaTime)
 {
 	for (int32 i = TransientForceStore.Items.Num() - 1; i >= 0; --i)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.cpp
@@ -34,7 +34,7 @@ void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::NotifyBegin(USkeletalMesh
 		return;
 	}
 
-	PruneStaleStates();
+	CleanupStaleStates();
 
 	const FActiveStateKey Key = MakeStateKey(MeshComp, EventReference);
 	if (FActiveState* ExistingState = ActiveStates.Find(Key))
@@ -119,7 +119,7 @@ void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::NotifyEnd(USkeletalMeshCo
 		}
 	}
 
-	PruneStaleStates();
+	CleanupStaleStates();
 
 	Super::NotifyEnd(MeshComp, Animation, EventReference);
 }
@@ -149,7 +149,7 @@ UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::MakeStateKey(
 	return Key;
 }
 
-void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::PruneStaleStates()
+void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::CleanupStaleStates()
 {
 	for (auto It = ActiveStates.CreateIterator(); It; ++It)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.cpp
@@ -34,7 +34,7 @@ void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::NotifyBegin(USkeletalMesh
 		return;
 	}
 
-	SweepStaleStates();
+	PruneStaleStates();
 
 	const FActiveStateKey Key = MakeStateKey(MeshComp, EventReference);
 	if (FActiveState* ExistingState = ActiveStates.Find(Key))
@@ -119,7 +119,7 @@ void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::NotifyEnd(USkeletalMeshCo
 		}
 	}
 
-	SweepStaleStates();
+	PruneStaleStates();
 
 	Super::NotifyEnd(MeshComp, Animation, EventReference);
 }
@@ -149,7 +149,7 @@ UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::MakeStateKey(
 	return Key;
 }
 
-void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::SweepStaleStates()
+void UAnimNotifyState_KawaiiPhysicsSettingsMultiplier::PruneStaleStates()
 {
 	for (auto It = ActiveStates.CreateIterator(); It; ++It)
 	{

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.cpp
@@ -706,8 +706,8 @@ FKawaiiPhysicsProceduralWindSample FKawaiiPhysics_ExternalForce_ProceduralWind::
 // (Seed, GridIndex, Channel) から決定論的なハッシュ値を作る（FNV-1aベースのミックス + fmix32相当の追加撹拌）。
 // RandomStream の内部状態を跨いで持ち回さず、都度この値から種を作ることで実行順序やスレッドに依存しない
 // 再現性を持たせている
-uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed, const int32 GridIndex,
-                                                               const int32 Channel)
+uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::ComputeStableHash(const int32 Seed, const int32 GridIndex,
+                                                                      const int32 Channel)
 {
 	// FNV-1a
 	uint32 Hash = 0x811C9DC5u;
@@ -727,12 +727,12 @@ uint32 FKawaiiPhysics_ExternalForce_ProceduralWind::StableHash(const int32 Seed,
 	return Hash;
 }
 
-// グリッド点 GridIndex における疑似ランダム値 [-1, 1] を返す。StableHash を種にすることで、
+// グリッド点 GridIndex における疑似ランダム値 [-1, 1] を返す。ComputeStableHash を種にすることで、
 // 呼び出し順序に関係なく同じ GridIndex なら常に同じ値になる
-float FKawaiiPhysics_ExternalForce_ProceduralWind::NoiseValueAt(const int32 GridIndex, const int32 Seed,
-                                                                const int32 Channel)
+float FKawaiiPhysics_ExternalForce_ProceduralWind::SampleNoiseAt(const int32 GridIndex, const int32 Seed,
+                                                                 const int32 Channel)
 {
-	FRandomStream RandomStream(StableHash(Seed, GridIndex, Channel));
+	FRandomStream RandomStream(ComputeStableHash(Seed, GridIndex, Channel));
 	return RandomStream.FRandRange(-1.0f, 1.0f);
 }
 
@@ -748,8 +748,8 @@ float FKawaiiPhysics_ExternalForce_ProceduralWind::SampleSmoothNoise(const float
 	const float SmoothAlpha = Alpha * Alpha * (3.0f - 2.0f * Alpha);
 
 	// 隣接グリッド点のランダム値を補間して返す
-	return FMath::Lerp(NoiseValueAt(GridIndex, Seed, Channel),
-	                   NoiseValueAt(GridIndex + 1, Seed, Channel), SmoothAlpha);
+	return FMath::Lerp(SampleNoiseAt(GridIndex, Seed, Channel),
+	                   SampleNoiseAt(GridIndex + 1, Seed, Channel), SmoothAlpha);
 }
 
 void FKawaiiPhysics_ExternalForce_ProceduralWind::Initialize(const FAnimationInitializeContext& Context)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsMirrorUtils.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsMirrorUtils.cpp
@@ -2,7 +2,7 @@
 
 #include "KawaiiPhysicsMirrorUtils.h"
 
-namespace KawaiiPhysicsMirror
+namespace KawaiiPhysicsMirrorUtils
 {
 	FVector MirrorOffsetLocation(const FVector& OffsetLocation, const FQuat& SourceBoneRefCS,
 	                             const FQuat& TargetBoneRefCS, EAxis::Type MirrorAxis)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsMirrorLimitsTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsMirrorLimitsTest.cpp
@@ -83,12 +83,12 @@ bool FKawaiiPhysicsMirrorIdentityOffsetTest::RunTest(const FString& Parameters)
 
 	for (int32 Index = 0; Index < UE_ARRAY_COUNT(Axes); ++Index)
 	{
-		const FVector MirroredLocation = KawaiiPhysicsMirror::MirrorOffsetLocation(
+		const FVector MirroredLocation = KawaiiPhysicsMirrorUtils::MirrorOffsetLocation(
 			FVector::ZeroVector, SourceRotations[Index], TargetRotations[Index], Axes[Index]);
 		TestTrue(TEXT("Zero offset location remains zero"),
 		         MirroredLocation.Equals(FVector::ZeroVector, KINDA_SMALL_NUMBER));
 
-		const FQuat MirroredRotation = KawaiiPhysicsMirror::MirrorOffsetRotation(
+		const FQuat MirroredRotation = KawaiiPhysicsMirrorUtils::MirrorOffsetRotation(
 			FQuat::Identity, SourceRotations[Index], TargetRotations[Index], Axes[Index]);
 		TestTrue(TEXT("Identity offset rotation remains identity"),
 		         IsSameRotation(MirroredRotation, FQuat::Identity, KINDA_SMALL_NUMBER));
@@ -112,14 +112,14 @@ bool FKawaiiPhysicsMirrorSymmetricSkeletonTest::RunTest(const FString& Parameter
 	{
 		const FQuat TargetBoneRefCS = FAnimationRuntime::MirrorQuat(SourceBoneRefCS, MirrorAxis);
 
-		const FVector MirroredLocation = KawaiiPhysicsMirror::MirrorOffsetLocation(
+		const FVector MirroredLocation = KawaiiPhysicsMirrorUtils::MirrorOffsetLocation(
 			SourceLocation, SourceBoneRefCS, TargetBoneRefCS, MirrorAxis);
 		const FVector ExpectedLocation = ExpectedMirroredVector(SourceLocation, MirrorAxis);
 		TestTrue(FString::Printf(TEXT("Symmetric location: got %s expected %s"),
 		                         *MirroredLocation.ToString(), *ExpectedLocation.ToString()),
 		         MirroredLocation.Equals(ExpectedLocation, GMirrorVectorTol));
 
-		const FQuat MirroredRotation = KawaiiPhysicsMirror::MirrorOffsetRotation(
+		const FQuat MirroredRotation = KawaiiPhysicsMirrorUtils::MirrorOffsetRotation(
 			SourceRotation, SourceBoneRefCS, TargetBoneRefCS, MirrorAxis);
 		const FQuat ExpectedRotation = ExpectedMirroredZRotation(30.0f, MirrorAxis);
 		TestTrue(TEXT("Symmetric rotation matches the hand-derived mirrored Z rotation"),
@@ -143,17 +143,17 @@ bool FKawaiiPhysicsMirrorRoundTripTest::RunTest(const FString& Parameters)
 
 	for (EAxis::Type MirrorAxis : Axes)
 	{
-		const FVector MirroredLocation = KawaiiPhysicsMirror::MirrorOffsetLocation(
+		const FVector MirroredLocation = KawaiiPhysicsMirrorUtils::MirrorOffsetLocation(
 			SourceLocation, SourceBoneRefCS, TargetBoneRefCS, MirrorAxis);
-		const FVector RoundTripLocation = KawaiiPhysicsMirror::MirrorOffsetLocation(
+		const FVector RoundTripLocation = KawaiiPhysicsMirrorUtils::MirrorOffsetLocation(
 			MirroredLocation, TargetBoneRefCS, SourceBoneRefCS, MirrorAxis);
 		TestTrue(FString::Printf(TEXT("Round-trip location: got %s expected %s"),
 		                         *RoundTripLocation.ToString(), *SourceLocation.ToString()),
 		         RoundTripLocation.Equals(SourceLocation, 0.01f));
 
-		const FQuat MirroredRotation = KawaiiPhysicsMirror::MirrorOffsetRotation(
+		const FQuat MirroredRotation = KawaiiPhysicsMirrorUtils::MirrorOffsetRotation(
 			SourceRotation, SourceBoneRefCS, TargetBoneRefCS, MirrorAxis);
-		const FQuat RoundTripRotation = KawaiiPhysicsMirror::MirrorOffsetRotation(
+		const FQuat RoundTripRotation = KawaiiPhysicsMirrorUtils::MirrorOffsetRotation(
 			MirroredRotation, TargetBoneRefCS, SourceBoneRefCS, MirrorAxis);
 		TestTrue(TEXT("Round-trip rotation returns to source"),
 		         IsSameRotation(RoundTripRotation, SourceRotation, 0.01f));
@@ -184,7 +184,7 @@ bool FKawaiiPhysicsMirrorBuildComponentRefRotationsTest::RunTest(const FString& 
 	}
 
 	TArray<FQuat> CSRefRotations;
-	KawaiiPhysicsMirror::BuildComponentSpaceRefRotations(RefSkeleton, CSRefRotations);
+	KawaiiPhysicsMirrorUtils::BuildComponentSpaceRefRotations(RefSkeleton, CSRefRotations);
 
 	TestTrue(TEXT("Component-space ref rotations count matches bone count"), CSRefRotations.Num() == 4);
 	TestTrue(TEXT("Root CS rotation matches local"), IsSameRotation(CSRefRotations[0], RootRotation));
@@ -242,19 +242,19 @@ bool FKawaiiPhysicsAppendMirroredLimitsTest::RunTest(const FString& Parameters)
 	CenterSourceLimits.Add(MakeSphere(CenterBoneName));
 
 	TArray<FSphericalLimit> OutNewLimits;
-	KawaiiPhysicsMirror::AppendMirroredLimits(
+	KawaiiPhysicsMirrorUtils::AppendMirroredLimits(
 		CenterSourceLimits, TArray<FSphericalLimit>(), TArray<FSphericalLimit>(), true,
 		ResolveMirrorBoneName, FindBoneIndex, CSRefRotations, EAxis::X, OutNewLimits);
 	TestTrue(TEXT("Center or unresolved mirror bones are skipped"), OutNewLimits.Num() == 0);
 
 	TArray<FSphericalLimit> ExistingNonMirror;
 	ExistingNonMirror.Add(MakeSphere(TargetBoneName, ECollisionSourceType::AnimNode));
-	KawaiiPhysicsMirror::AppendMirroredLimits(
+	KawaiiPhysicsMirrorUtils::AppendMirroredLimits(
 		SourceLimits, ExistingNonMirror, TArray<FSphericalLimit>(), true,
 		ResolveMirrorBoneName, FindBoneIndex, CSRefRotations, EAxis::X, OutNewLimits);
 	TestTrue(TEXT("Existing non-Mirror target collision skips generation"), OutNewLimits.Num() == 0);
 
-	KawaiiPhysicsMirror::AppendMirroredLimits(
+	KawaiiPhysicsMirrorUtils::AppendMirroredLimits(
 		SourceLimits, ExistingNonMirror, TArray<FSphericalLimit>(), false,
 		ResolveMirrorBoneName, FindBoneIndex, CSRefRotations, EAxis::X, OutNewLimits);
 	TestTrue(TEXT("bSkipExisting=false allows generation"), OutNewLimits.Num() == 1);
@@ -262,7 +262,7 @@ bool FKawaiiPhysicsAppendMirroredLimitsTest::RunTest(const FString& Parameters)
 
 	TArray<FSphericalLimit> ExistingMirror;
 	ExistingMirror.Add(MakeSphere(TargetBoneName, ECollisionSourceType::Mirror));
-	KawaiiPhysicsMirror::AppendMirroredLimits(
+	KawaiiPhysicsMirrorUtils::AppendMirroredLimits(
 		SourceLimits, ExistingMirror, TArray<FSphericalLimit>(), true,
 		ResolveMirrorBoneName, FindBoneIndex, CSRefRotations, EAxis::X, OutNewLimits);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsProceduralWindTest.cpp
@@ -413,12 +413,12 @@ bool FKawaiiPhysicsProceduralWindNoisePropertiesTest::RunTest(const FString& Par
 	// ノイズ範囲、格子点一致、連続性、ハッシュのスナップショット値を確認する。
 	using FWind = FKawaiiPhysics_ExternalForce_ProceduralWind;
 
-	// StableHashの実装は仕様式を持たないFNV-1a派生のビット演算のため、期待値は現行実装から採取したスナップショット値（回帰検出用）
-	TestEqual(TEXT("StableHash(0, 0, 0)"), FWind::StableHash(0, 0, 0), 672839204u);
-	TestEqual(TEXT("StableHash(123, 0, 0)"), FWind::StableHash(123, 0, 0), 961409981u);
-	TestEqual(TEXT("StableHash(123, 1, 0)"), FWind::StableHash(123, 1, 0), 688218621u);
-	TestEqual(TEXT("StableHash(123, -1, 0)"), FWind::StableHash(123, -1, 0), 2476066305u);
-	TestEqual(TEXT("StableHash(-17, 42, 3)"), FWind::StableHash(-17, 42, 3), 1090092324u);
+	// ComputeStableHashの実装は仕様式を持たないFNV-1a派生のビット演算のため、期待値は現行実装から採取したスナップショット値（回帰検出用）
+	TestEqual(TEXT("ComputeStableHash(0, 0, 0)"), FWind::ComputeStableHash(0, 0, 0), 672839204u);
+	TestEqual(TEXT("ComputeStableHash(123, 0, 0)"), FWind::ComputeStableHash(123, 0, 0), 961409981u);
+	TestEqual(TEXT("ComputeStableHash(123, 1, 0)"), FWind::ComputeStableHash(123, 1, 0), 688218621u);
+	TestEqual(TEXT("ComputeStableHash(123, -1, 0)"), FWind::ComputeStableHash(123, -1, 0), 2476066305u);
+	TestEqual(TEXT("ComputeStableHash(-17, 42, 3)"), FWind::ComputeStableHash(-17, 42, 3), 1090092324u);
 
 	// Uを-8〜12の範囲で0.01刻みに走査し、値域[-1,1]と隣接差分が閾値以下に収まる連続性（滑らかな補間）を確認
 	float Previous = FWind::SampleSmoothNoise(-8.0f, 2468, 0);
@@ -436,11 +436,11 @@ bool FKawaiiPhysicsProceduralWindNoisePropertiesTest::RunTest(const FString& Par
 		Previous = Value;
 	}
 
-	// 整数座標では滑らか補間の結果が格子点の生値（NoiseValueAt）と一致する（補間の境界条件）ことを確認
+	// 整数座標では滑らか補間の結果が格子点の生値（SampleNoiseAt）と一致する（補間の境界条件）ことを確認
 	for (int32 GridIndex = -8; GridIndex <= 8; ++GridIndex)
 	{
 		const float Smooth = FWind::SampleSmoothNoise(static_cast<float>(GridIndex), 2468, 1);
-		const float Grid = FWind::NoiseValueAt(GridIndex, 2468, 1);
+		const float Grid = FWind::SampleNoiseAt(GridIndex, 2468, 1);
 		TestTrue(FString::Printf(TEXT("Grid match %d: smooth=%.9f grid=%.9f"), GridIndex, Smooth, Grid),
 		         Smooth == Grid);
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -331,7 +331,7 @@ struct FKawaiiPhysicsTestAccessor
 		{
 			Limit.UpdateRuntimeCache();
 		}
-		Node.AdjustByPlanerCollision(Bone, Limits);
+		Node.AdjustByPlanarCollision(Bone, Limits);
 	}
 	void CallAngleLimit(FKawaiiPhysicsModifyBone& Bone, const FKawaiiPhysicsModifyBone& ParentBone)
 	{
@@ -576,8 +576,8 @@ private:
 			Node.AdjustByTaperedCapsuleCollision(Bone, Node.TaperedCapsuleLimitsData);
 			Node.AdjustByBoxCollision(Bone, Node.BoxLimits);
 			Node.AdjustByBoxCollision(Bone, Node.BoxLimitsData);
-			Node.AdjustByPlanerCollision(Bone, Node.PlanarLimits);
-			Node.AdjustByPlanerCollision(Bone, Node.PlanarLimitsData);
+			Node.AdjustByPlanarCollision(Bone, Node.PlanarLimits);
+			Node.AdjustByPlanarCollision(Bone, Node.PlanarLimitsData);
 		}
 
 		// BoneConstraint after collision（SimulateOnce 516-522）

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
@@ -352,8 +352,8 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentSharesHandleTest::RunTes
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 1);
 	bOk &= TestTrue(TEXT("Handle set"), Handle.Id != 0);
 
-	MatchingNode.ConsumeAndSweepTransientExternalForces(0.0f);
-	OtherNode.ConsumeAndSweepTransientExternalForces(0.0f);
+	MatchingNode.ConsumeAndPruneTransientExternalForces(0.0f);
+	OtherNode.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bOk &= TestEqual(TEXT("Matching Items.Num"), MatchingNode.TransientForceStore.Items.Num(), 1);
 	if (MatchingNode.TransientForceStore.Items.IsValidIndex(0))
@@ -364,8 +364,8 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentSharesHandleTest::RunTes
 
 	MatchingNode.RequestStopTransientExternalForce(Handle.Id, 0.0f);
 	OtherNode.RequestStopTransientExternalForce(Handle.Id, 0.0f);
-	MatchingNode.ConsumeAndSweepTransientExternalForces(0.0f);
-	OtherNode.ConsumeAndSweepTransientExternalForces(0.0f);
+	MatchingNode.ConsumeAndPruneTransientExternalForces(0.0f);
+	OtherNode.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bOk &= TestEqual(TEXT("Matching stopped Items.Num"), MatchingNode.TransientForceStore.Items.Num(), 0);
 	bOk &= TestEqual(TEXT("Other stopped Items.Num"), OtherNode.TransientForceStore.Items.Num(), 0);
@@ -398,7 +398,7 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentRejectsLiveObjectRefTest
 
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 0);
 	bOk &= TestEqual(TEXT("Handle unset"), Handle.Id, static_cast<int64>(0));
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -435,7 +435,7 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentNoMatchLeavesHandleUnset
 
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 0);
 	bOk &= TestEqual(TEXT("Handle unset"), Handle.Id, static_cast<int64>(0));
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -450,7 +450,7 @@ bool FKawaiiPhysicsTransientForceGustConsumeCreatesActiveGustTest::RunTest(const
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 2.0f), INDEX_NONE);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bool bOk = true;
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
@@ -486,13 +486,13 @@ bool FKawaiiPhysicsTransientForceLifetimeSweepTest::RunTest(const FString& Param
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(1.0f, 0.05f, 0.0f, FVector::ForwardVector, INDEX_NONE);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 	bool bOk = TestEqual(TEXT("Initial consume"), Node.TransientForceStore.Items.Num(), 1);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.13f);
+	Node.ConsumeAndPruneTransientExternalForces(0.13f);
 	bOk &= TestEqual(TEXT("Still alive"), Node.TransientForceStore.Items.Num(), 1);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.13f);
+	Node.ConsumeAndPruneTransientExternalForces(0.13f);
 	bOk &= TestEqual(TEXT("Expired"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -509,7 +509,7 @@ bool FKawaiiPhysicsTransientForceMultiGustTest::RunTest(const FString& Parameter
 	Node.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector(0.0f, 1.0f, 0.0f), INDEX_NONE);
 	Node.RequestTransientGust(3.0f, 0.1f, 0.1f, FVector(0.0f, 0.0f, 1.0f), INDEX_NONE);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	return TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
 }
@@ -526,7 +526,7 @@ bool FKawaiiPhysicsTransientForceCapDropsOldestTest::RunTest(const FString& Para
 		Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(static_cast<float>(Index), 1.0f, 0.0f), INDEX_NONE);
 	}
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), FAnimNode_KawaiiPhysics::MaxTransientExternalForces);
 	for (int32 Index = 0; Index < Node.TransientForceStore.Items.Num(); ++Index)
@@ -572,7 +572,7 @@ bool FKawaiiPhysicsTransientForcePendingCapBoundsQueueTest::RunTest(const FStrin
 		}
 	}
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 8);
 
 	return bOk;
@@ -589,7 +589,7 @@ bool FKawaiiPhysicsTransientForceDirectionSentinelBoundaryTest::RunTest(const FS
 	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 0.5f, 0.0f, 0.0f), INDEX_NONE);
 	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 10.0f, 0.0f, 0.0f), INDEX_NONE);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* ZeroWind = GetTransientWind(Node, 0);
@@ -625,7 +625,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, 1);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Indexed inherited wind valid"), Wind != nullptr);
@@ -645,7 +645,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Fallback inherited wind valid"), Wind != nullptr);
@@ -664,7 +664,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 3.0f), 1);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Explicit inherited wind valid"), Wind != nullptr);
@@ -682,7 +682,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 	{
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Default inherited wind valid"), Wind != nullptr);
@@ -717,7 +717,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Spread Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
@@ -748,7 +748,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		// cap を超える authored wind では最古（先頭側）から切り捨てられる仕様を固定する。
 		bOk &= TestEqual(TEXT("Spread cap Items.Num"), Node.TransientForceStore.Items.Num(),
@@ -772,7 +772,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Default Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -794,7 +794,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector(5.0f, 0.0f, 0.0f),
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Explicit Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
@@ -829,7 +829,7 @@ bool FKawaiiPhysicsTransientForceGustHoldLifetimeTest::RunTest(const FString& Pa
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 	if (Node.TransientForceStore.Items.IsValidIndex(0))
@@ -850,7 +850,7 @@ bool FKawaiiPhysicsTransientForceRealTimeEnvelopeTest::RunTest(const FString& Pa
 	AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE, 1.0f, 0, true);
 
-	Node.ConsumeAndSweepTransientExternalForces(0.0f);
+	Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -884,7 +884,7 @@ bool FKawaiiPhysicsTransientForceBlowRealTimeEnvelopeFlagTest::RunTest(const FSt
 		FAnimNode_KawaiiPhysics Node;
 		AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 		Node.RequestTransientGust(4.0f, RiseTime, DecayTime, FVector::ZeroVector, INDEX_NONE, HoldTime, 0, false);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Wind-time Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -899,7 +899,7 @@ bool FKawaiiPhysicsTransientForceBlowRealTimeEnvelopeFlagTest::RunTest(const FSt
 		FAnimNode_KawaiiPhysics Node;
 		AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 		Node.RequestTransientGust(4.0f, RiseTime, DecayTime, FVector::ZeroVector, INDEX_NONE, HoldTime, 0, true);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Real-time Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -935,7 +935,7 @@ bool FKawaiiPhysicsTransientForceHandleIdTest::RunTest(const FString& Parameters
 		FInstancedStruct Force = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce>();
 		const int64 GeneratedHandle = Node.RequestTransientExternalForce(MoveTemp(Force), 1.0f);
 		bOk &= TestTrue(TEXT("RequestTransientExternalForce generates handle"), GeneratedHandle > 0);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("Generated handle stamped"), Node.TransientForceStore.Items[0].HandleId, GeneratedHandle);
 	}
 
@@ -952,7 +952,7 @@ bool FKawaiiPhysicsTransientForceHandleIdTest::RunTest(const FString& Parameters
 			0.0f, SpreadHandle);
 		bOk &= TestEqual(TEXT("RequestTransientGust returns passed handle"), ReturnedHandle, SpreadHandle);
 
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("Spread Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		for (const FKawaiiPhysicsTransientExternalForce& Item : Node.TransientForceStore.Items)
 		{
@@ -975,10 +975,10 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 101);
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::RightVector, INDEX_NONE, 1.0f, 202);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		Node.RequestStopTransientExternalForce(101, 0.5f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Stop Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Stopped lifetime"), Node.TransientForceStore.Items[0].RemainingLifetime, 0.7f);
@@ -996,7 +996,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		}
 
 		Node.RequestStopTransientExternalForce(999, 0.1f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("No-op Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("No-op lifetime"),
 		                      Node.TransientForceStore.Items[1].RemainingLifetime, 2.0f);
@@ -1006,9 +1006,9 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		FInstancedStruct Force = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce>();
 		Node.RequestTransientExternalForce(MoveTemp(Force), 5.0f, 303);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 		Node.RequestStopTransientExternalForce(303, 0.4f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Generic Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Generic lifetime"),
@@ -1019,7 +1019,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 404);
 		Node.RequestStopTransientExternalForce(404, 0.3f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("StartStop Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("StartStop lifetime"),
@@ -1036,7 +1036,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 505);
 		Node.RequestStopTransientExternalForce(505, 0.0f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Immediate stop removes item"), Node.TransientForceStore.Items.Num(), 0);
 	}
@@ -1047,17 +1047,17 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		// RemainingLifetimeもMinではなく新フェード全体をカバーするよう延長される必要がある。
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 0.0f, 606);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Extend initial lifetime"),
 		                      Node.TransientForceStore.Items[0].RemainingLifetime, 1.0f);
 
 		// 自然終了間際まで経過させ、残寿命をこれから要求するBlendOutTimeより短くしておく
-		Node.ConsumeAndSweepTransientExternalForces(0.85f);
+		Node.ConsumeAndPruneTransientExternalForces(0.85f);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Extend near-expiry lifetime"),
 		                      Node.TransientForceStore.Items[0].RemainingLifetime, 0.15f);
 
 		Node.RequestStopTransientExternalForce(606, 2.0f);
-		Node.ConsumeAndSweepTransientExternalForces(0.0f);
+		Node.ConsumeAndPruneTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Extend Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		if (Node.TransientForceStore.Items.IsValidIndex(0))
@@ -1113,15 +1113,15 @@ bool FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest::RunTest(const FStri
 		                A.TransientForceStore.Queue.Get() != B.TransientForceStore.Queue.Get());
 		bOk &= TestEqual(TEXT("B pending is empty after copy"), GetPendingGustCount(B), 0);
 		bOk &= TestEqual(TEXT("B pending stops empty after copy"), GetPendingStopCount(B), 0);
-		B.ConsumeAndSweepTransientExternalForces(0.0f);
+		B.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("B consume yields no items"), B.TransientForceStore.Items.Num(), 0);
 
 		bOk &= TestEqual(TEXT("A pending stops preserved after copy"), GetPendingStopCount(A), 1);
-		A.ConsumeAndSweepTransientExternalForces(0.0f);
+		A.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("A consume still yields one item"), A.TransientForceStore.Items.Num(), 1);
 
 		B.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
-		B.ConsumeAndSweepTransientExternalForces(0.0f);
+		B.ConsumeAndPruneTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("B new consume yields one item"), B.TransientForceStore.Items.Num(), 1);
 		bOk &= TestEqual(TEXT("A items unaffected by B"), A.TransientForceStore.Items.Num(), 1);
 	}
@@ -1129,7 +1129,7 @@ bool FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest::RunTest(const FStri
 	{
 		FAnimNode_KawaiiPhysics A;
 		A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
-		A.ConsumeAndSweepTransientExternalForces(0.0f);
+		A.ConsumeAndPruneTransientExternalForces(0.0f);
 		FAnimNode_KawaiiPhysics B = A;
 
 		bOk &= TestEqual(TEXT("B copied Items empty"), B.TransientForceStore.Items.Num(), 0);
@@ -1147,7 +1147,7 @@ bool FKawaiiPhysicsTransientForceSurviveReflectionCopyTest::RunTest(const FStrin
 {
 	FAnimNode_KawaiiPhysics A;
 	A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
-	A.ConsumeAndSweepTransientExternalForces(0.0f);
+	A.ConsumeAndPruneTransientExternalForces(0.0f);
 	A.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
 	A.RequestStopTransientExternalForce(88, 0.25f);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
@@ -352,8 +352,8 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentSharesHandleTest::RunTes
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 1);
 	bOk &= TestTrue(TEXT("Handle set"), Handle.Id != 0);
 
-	MatchingNode.ConsumeAndPruneTransientExternalForces(0.0f);
-	OtherNode.ConsumeAndPruneTransientExternalForces(0.0f);
+	MatchingNode.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
+	OtherNode.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bOk &= TestEqual(TEXT("Matching Items.Num"), MatchingNode.TransientForceStore.Items.Num(), 1);
 	if (MatchingNode.TransientForceStore.Items.IsValidIndex(0))
@@ -364,8 +364,8 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentSharesHandleTest::RunTes
 
 	MatchingNode.RequestStopTransientExternalForce(Handle.Id, 0.0f);
 	OtherNode.RequestStopTransientExternalForce(Handle.Id, 0.0f);
-	MatchingNode.ConsumeAndPruneTransientExternalForces(0.0f);
-	OtherNode.ConsumeAndPruneTransientExternalForces(0.0f);
+	MatchingNode.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
+	OtherNode.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bOk &= TestEqual(TEXT("Matching stopped Items.Num"), MatchingNode.TransientForceStore.Items.Num(), 0);
 	bOk &= TestEqual(TEXT("Other stopped Items.Num"), OtherNode.TransientForceStore.Items.Num(), 0);
@@ -398,7 +398,7 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentRejectsLiveObjectRefTest
 
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 0);
 	bOk &= TestEqual(TEXT("Handle unset"), Handle.Id, static_cast<int64>(0));
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -435,7 +435,7 @@ bool FKawaiiPhysicsTransientForceAddTransientOnComponentNoMatchLeavesHandleUnset
 
 	bool bOk = TestEqual(TEXT("AppliedCount"), AppliedCount, 0);
 	bOk &= TestEqual(TEXT("Handle unset"), Handle.Id, static_cast<int64>(0));
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -450,7 +450,7 @@ bool FKawaiiPhysicsTransientForceGustConsumeCreatesActiveGustTest::RunTest(const
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 2.0f), INDEX_NONE);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bool bOk = true;
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
@@ -486,13 +486,13 @@ bool FKawaiiPhysicsTransientForceLifetimeSweepTest::RunTest(const FString& Param
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(1.0f, 0.05f, 0.0f, FVector::ForwardVector, INDEX_NONE);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 	bool bOk = TestEqual(TEXT("Initial consume"), Node.TransientForceStore.Items.Num(), 1);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.13f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.13f);
 	bOk &= TestEqual(TEXT("Still alive"), Node.TransientForceStore.Items.Num(), 1);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.13f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.13f);
 	bOk &= TestEqual(TEXT("Expired"), Node.TransientForceStore.Items.Num(), 0);
 
 	return bOk;
@@ -509,7 +509,7 @@ bool FKawaiiPhysicsTransientForceMultiGustTest::RunTest(const FString& Parameter
 	Node.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector(0.0f, 1.0f, 0.0f), INDEX_NONE);
 	Node.RequestTransientGust(3.0f, 0.1f, 0.1f, FVector(0.0f, 0.0f, 1.0f), INDEX_NONE);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	return TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
 }
@@ -526,7 +526,7 @@ bool FKawaiiPhysicsTransientForceCapDropsOldestTest::RunTest(const FString& Para
 		Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(static_cast<float>(Index), 1.0f, 0.0f), INDEX_NONE);
 	}
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), FAnimNode_KawaiiPhysics::MaxTransientExternalForces);
 	for (int32 Index = 0; Index < Node.TransientForceStore.Items.Num(); ++Index)
@@ -572,7 +572,7 @@ bool FKawaiiPhysicsTransientForcePendingCapBoundsQueueTest::RunTest(const FStrin
 		}
 	}
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 	bOk &= TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 8);
 
 	return bOk;
@@ -589,7 +589,7 @@ bool FKawaiiPhysicsTransientForceDirectionSentinelBoundaryTest::RunTest(const FS
 	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 0.5f, 0.0f, 0.0f), INDEX_NONE);
 	Node.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector(KINDA_SMALL_NUMBER * 10.0f, 0.0f, 0.0f), INDEX_NONE);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 3);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* ZeroWind = GetTransientWind(Node, 0);
@@ -625,7 +625,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, 1);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Indexed inherited wind valid"), Wind != nullptr);
@@ -645,7 +645,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Fallback inherited wind valid"), Wind != nullptr);
@@ -664,7 +664,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 		FAnimNode_KawaiiPhysics Node;
 		AddStandardAuthoredWinds(Node);
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector(0.0f, 0.0f, 3.0f), 1);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Explicit inherited wind valid"), Wind != nullptr);
@@ -682,7 +682,7 @@ bool FKawaiiPhysicsTransientForceInheritFromAuthoredTest::RunTest(const FString&
 	{
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(3.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
 		bOk &= TestTrue(TEXT("Default inherited wind valid"), Wind != nullptr);
@@ -717,7 +717,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Spread Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
@@ -748,7 +748,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		// cap を超える authored wind では最古（先頭側）から切り捨てられる仕様を固定する。
 		bOk &= TestEqual(TEXT("Spread cap Items.Num"), Node.TransientForceStore.Items.Num(),
@@ -772,7 +772,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector::ZeroVector,
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Default Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -794,7 +794,7 @@ bool FKawaiiPhysicsTransientForceSpreadAcrossAuthoredWindsTest::RunTest(const FS
 
 		Node.RequestTransientGust(3.0f, 0.1f, 0.3f, FVector(5.0f, 0.0f, 0.0f),
 		                          FAnimNode_KawaiiPhysics::TransientGustInheritAllWinds);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Explicit Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind0 = GetTransientWind(Node, 0);
@@ -829,7 +829,7 @@ bool FKawaiiPhysicsTransientForceGustHoldLifetimeTest::RunTest(const FString& Pa
 	FAnimNode_KawaiiPhysics Node;
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 	if (Node.TransientForceStore.Items.IsValidIndex(0))
@@ -850,7 +850,7 @@ bool FKawaiiPhysicsTransientForceRealTimeEnvelopeTest::RunTest(const FString& Pa
 	AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 	Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ZeroVector, INDEX_NONE, 1.0f, 0, true);
 
-	Node.ConsumeAndPruneTransientExternalForces(0.0f);
+	Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 	bool bOk = TestEqual(TEXT("Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 	FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -884,7 +884,7 @@ bool FKawaiiPhysicsTransientForceBlowRealTimeEnvelopeFlagTest::RunTest(const FSt
 		FAnimNode_KawaiiPhysics Node;
 		AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 		Node.RequestTransientGust(4.0f, RiseTime, DecayTime, FVector::ZeroVector, INDEX_NONE, HoldTime, 0, false);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Wind-time Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -899,7 +899,7 @@ bool FKawaiiPhysicsTransientForceBlowRealTimeEnvelopeFlagTest::RunTest(const FSt
 		FAnimNode_KawaiiPhysics Node;
 		AddAuthoredProceduralWind(Node, true, FVector::ForwardVector, EExternalForceSpace::WorldSpace, 2.0f, false);
 		Node.RequestTransientGust(4.0f, RiseTime, DecayTime, FVector::ZeroVector, INDEX_NONE, HoldTime, 0, true);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Real-time Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		FKawaiiPhysics_ExternalForce_ProceduralWind* Wind = GetTransientWind(Node);
@@ -935,7 +935,7 @@ bool FKawaiiPhysicsTransientForceHandleIdTest::RunTest(const FString& Parameters
 		FInstancedStruct Force = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce>();
 		const int64 GeneratedHandle = Node.RequestTransientExternalForce(MoveTemp(Force), 1.0f);
 		bOk &= TestTrue(TEXT("RequestTransientExternalForce generates handle"), GeneratedHandle > 0);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("Generated handle stamped"), Node.TransientForceStore.Items[0].HandleId, GeneratedHandle);
 	}
 
@@ -952,7 +952,7 @@ bool FKawaiiPhysicsTransientForceHandleIdTest::RunTest(const FString& Parameters
 			0.0f, SpreadHandle);
 		bOk &= TestEqual(TEXT("RequestTransientGust returns passed handle"), ReturnedHandle, SpreadHandle);
 
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("Spread Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		for (const FKawaiiPhysicsTransientExternalForce& Item : Node.TransientForceStore.Items)
 		{
@@ -975,10 +975,10 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 101);
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::RightVector, INDEX_NONE, 1.0f, 202);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		Node.RequestStopTransientExternalForce(101, 0.5f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Stop Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Stopped lifetime"), Node.TransientForceStore.Items[0].RemainingLifetime, 0.7f);
@@ -996,7 +996,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		}
 
 		Node.RequestStopTransientExternalForce(999, 0.1f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("No-op Items.Num"), Node.TransientForceStore.Items.Num(), 2);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("No-op lifetime"),
 		                      Node.TransientForceStore.Items[1].RemainingLifetime, 2.0f);
@@ -1006,9 +1006,9 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		FInstancedStruct Force = FInstancedStruct::Make<FKawaiiPhysics_ExternalForce>();
 		Node.RequestTransientExternalForce(MoveTemp(Force), 5.0f, 303);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		Node.RequestStopTransientExternalForce(303, 0.4f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Generic Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Generic lifetime"),
@@ -1019,7 +1019,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 404);
 		Node.RequestStopTransientExternalForce(404, 0.3f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("StartStop Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("StartStop lifetime"),
@@ -1036,7 +1036,7 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 1.0f, 505);
 		Node.RequestStopTransientExternalForce(505, 0.0f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Immediate stop removes item"), Node.TransientForceStore.Items.Num(), 0);
 	}
@@ -1047,17 +1047,17 @@ bool FKawaiiPhysicsTransientForceStopTest::RunTest(const FString& Parameters)
 		// RemainingLifetimeもMinではなく新フェード全体をカバーするよう延長される必要がある。
 		FAnimNode_KawaiiPhysics Node;
 		Node.RequestTransientGust(4.0f, 0.2f, 0.6f, FVector::ForwardVector, INDEX_NONE, 0.0f, 606);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Extend initial lifetime"),
 		                      Node.TransientForceStore.Items[0].RemainingLifetime, 1.0f);
 
 		// 自然終了間際まで経過させ、残寿命をこれから要求するBlendOutTimeより短くしておく
-		Node.ConsumeAndPruneTransientExternalForces(0.85f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.85f);
 		bOk &= TestTransientForceFloatNear(*this, TEXT("Extend near-expiry lifetime"),
 		                      Node.TransientForceStore.Items[0].RemainingLifetime, 0.15f);
 
 		Node.RequestStopTransientExternalForce(606, 2.0f);
-		Node.ConsumeAndPruneTransientExternalForces(0.0f);
+		Node.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 
 		bOk &= TestEqual(TEXT("Extend Items.Num"), Node.TransientForceStore.Items.Num(), 1);
 		if (Node.TransientForceStore.Items.IsValidIndex(0))
@@ -1113,15 +1113,15 @@ bool FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest::RunTest(const FStri
 		                A.TransientForceStore.Queue.Get() != B.TransientForceStore.Queue.Get());
 		bOk &= TestEqual(TEXT("B pending is empty after copy"), GetPendingGustCount(B), 0);
 		bOk &= TestEqual(TEXT("B pending stops empty after copy"), GetPendingStopCount(B), 0);
-		B.ConsumeAndPruneTransientExternalForces(0.0f);
+		B.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("B consume yields no items"), B.TransientForceStore.Items.Num(), 0);
 
 		bOk &= TestEqual(TEXT("A pending stops preserved after copy"), GetPendingStopCount(A), 1);
-		A.ConsumeAndPruneTransientExternalForces(0.0f);
+		A.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("A consume still yields one item"), A.TransientForceStore.Items.Num(), 1);
 
 		B.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
-		B.ConsumeAndPruneTransientExternalForces(0.0f);
+		B.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		bOk &= TestEqual(TEXT("B new consume yields one item"), B.TransientForceStore.Items.Num(), 1);
 		bOk &= TestEqual(TEXT("A items unaffected by B"), A.TransientForceStore.Items.Num(), 1);
 	}
@@ -1129,7 +1129,7 @@ bool FKawaiiPhysicsTransientForceStoreCopyIsIndependentTest::RunTest(const FStri
 	{
 		FAnimNode_KawaiiPhysics A;
 		A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
-		A.ConsumeAndPruneTransientExternalForces(0.0f);
+		A.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 		FAnimNode_KawaiiPhysics B = A;
 
 		bOk &= TestEqual(TEXT("B copied Items empty"), B.TransientForceStore.Items.Num(), 0);
@@ -1147,7 +1147,7 @@ bool FKawaiiPhysicsTransientForceSurviveReflectionCopyTest::RunTest(const FStrin
 {
 	FAnimNode_KawaiiPhysics A;
 	A.RequestTransientGust(1.0f, 0.1f, 0.1f, FVector::ForwardVector, INDEX_NONE);
-	A.ConsumeAndPruneTransientExternalForces(0.0f);
+	A.ConsumeAndRemoveExpiredTransientExternalForces(0.0f);
 	A.RequestTransientGust(2.0f, 0.1f, 0.1f, FVector::RightVector, INDEX_NONE);
 	A.RequestStopTransientExternalForce(88, 0.25f);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -691,11 +691,11 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	 * キュー済み一時外力を worker で取り込み、寿命切れを掃除する。worker 専用で 1 evaluate 1 回だけ呼ぶ。
 	 * BP再コンパイルやノード再初期化で失われる。Initialize(Context) は呼ばれないため汎用外力では制限あり
 	 * （ProceduralWind は PreApply で RuntimeState を遅延生成するため安全）。
-	 * Consume queued transient forces on the worker and prune expired entries. Worker-only; call once per evaluate.
+	 * Consume queued transient forces on the worker and remove expired entries. Worker-only; call once per evaluate.
 	 * Lost on BP recompile or node re-init. Initialize(Context) is not called, which limits generic use
 	 * (ProceduralWind is safe because it lazily creates RuntimeState in PreApply).
 	 */
-	void ConsumeAndPruneTransientExternalForces(float InFrameDeltaTime);
+	void ConsumeAndRemoveExpiredTransientExternalForces(float InFrameDeltaTime);
 
 	/**
 	 * 物理設定への一時倍率をリクエストする。任意スレッド可で、Mutex 保護されたキューへ積む。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -691,11 +691,11 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	 * キュー済み一時外力を worker で取り込み、寿命切れを掃除する。worker 専用で 1 evaluate 1 回だけ呼ぶ。
 	 * BP再コンパイルやノード再初期化で失われる。Initialize(Context) は呼ばれないため汎用外力では制限あり
 	 * （ProceduralWind は PreApply で RuntimeState を遅延生成するため安全）。
-	 * Consume queued transient forces on the worker and sweep expired entries. Worker-only; call once per evaluate.
+	 * Consume queued transient forces on the worker and prune expired entries. Worker-only; call once per evaluate.
 	 * Lost on BP recompile or node re-init. Initialize(Context) is not called, which limits generic use
 	 * (ProceduralWind is safe because it lazily creates RuntimeState in PreApply).
 	 */
-	void ConsumeAndSweepTransientExternalForces(float InFrameDeltaTime);
+	void ConsumeAndPruneTransientExternalForces(float InFrameDeltaTime);
 
 	/**
 	 * 物理設定への一時倍率をリクエストする。任意スレッド可で、Mutex 保護されたキューへ積む。
@@ -1332,7 +1332,7 @@ protected:
 	 * @param BoneContainer The bone container.
 	 * @param ComponentTransform The component transform.
 	 */
-	void UpdatePlanerLimits(TArray<FPlanarLimit>& Limits, FComponentSpacePoseContext& Output,
+	void UpdatePlanarLimits(TArray<FPlanarLimit>& Limits, FComponentSpacePoseContext& Output,
 	                        const FBoneContainer& BoneContainer, const FTransform& ComponentTransform) const;
 
 	/**
@@ -1499,7 +1499,7 @@ protected:
 	 * @param Bone The bone to adjust.
 	 * @param Limits An array of planar limits.
 	 */
-	void AdjustByPlanerCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits);
+	void AdjustByPlanarCollision(FKawaiiPhysicsModifyBone& Bone, TArray<FPlanarLimit>& Limits);
 
 	/**
 	 * Adjusts the bone position based on angle limits.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
@@ -137,12 +137,12 @@ private:
 	 * 有効な NotifyState はアニメーション更新ごとに毎フレーム Tick されるため、このフレーム数だけ触られていないエントリは NotifyEnd を失って（例: エディタ再インスタンス化）Notify 側の帳簿だけが残っている。ノード側の倍率は Lease で既にフェード済み。
 	 * 既知の制限: 掃除はこの Notify の次の NotifyBegin/NotifyEnd（どの Component 上でも可）で走るため、それまでは弱参照キーと数値だけの小さなエントリが残る。アセット共有オブジェクトに Ticker を持たせる寿命リスクの方が大きいため意図的にこの設計にしている。
 	 * A live NotifyState ticks every frame the animation updates, so an entry untouched for this many frames has lost NotifyEnd (for example, editor reinstancing) and only notify-side bookkeeping remains; the node-side multiplier has already faded via the lease.
-	 * Known limitation: the sweep runs on the next NotifyBegin/NotifyEnd of this notify (on any component), so a small weak-keyed, numeric-only entry can linger until then. This is intentional: a ticker on an asset-shared object would carry a bigger lifetime risk.
+	 * Known limitation: the prune runs on the next NotifyBegin/NotifyEnd of this notify (on any component), so a small weak-keyed, numeric-only entry can linger until then. This is intentional: a ticker on an asset-shared object would carry a bigger lifetime risk.
 	 */
 	static constexpr uint64 StaleStateFrameThreshold = 300;
 
 	static FActiveStateKey MakeStateKey(USkeletalMeshComponent* MeshComp,
 	                                    const FAnimNotifyEventReference& EventReference);
-	void SweepStaleStates();
+	void PruneStaleStates();
 	float ResolveWeight(USkeletalMeshComponent* MeshComp, const FActiveState& State) const;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
@@ -137,12 +137,12 @@ private:
 	 * 有効な NotifyState はアニメーション更新ごとに毎フレーム Tick されるため、このフレーム数だけ触られていないエントリは NotifyEnd を失って（例: エディタ再インスタンス化）Notify 側の帳簿だけが残っている。ノード側の倍率は Lease で既にフェード済み。
 	 * 既知の制限: 掃除はこの Notify の次の NotifyBegin/NotifyEnd（どの Component 上でも可）で走るため、それまでは弱参照キーと数値だけの小さなエントリが残る。アセット共有オブジェクトに Ticker を持たせる寿命リスクの方が大きいため意図的にこの設計にしている。
 	 * A live NotifyState ticks every frame the animation updates, so an entry untouched for this many frames has lost NotifyEnd (for example, editor reinstancing) and only notify-side bookkeeping remains; the node-side multiplier has already faded via the lease.
-	 * Known limitation: the prune runs on the next NotifyBegin/NotifyEnd of this notify (on any component), so a small weak-keyed, numeric-only entry can linger until then. This is intentional: a ticker on an asset-shared object would carry a bigger lifetime risk.
+	 * Known limitation: the cleanup runs on the next NotifyBegin/NotifyEnd of this notify (on any component), so a small weak-keyed, numeric-only entry can linger until then. This is intentional: a ticker on an asset-shared object would carry a bigger lifetime risk.
 	 */
 	static constexpr uint64 StaleStateFrameThreshold = 300;
 
 	static FActiveStateKey MakeStateKey(USkeletalMeshComponent* MeshComp,
 	                                    const FAnimNotifyEventReference& EventReference);
-	void PruneStaleStates();
+	void CleanupStaleStates();
 	float ResolveWeight(USkeletalMeshComponent* MeshComp, const FActiveState& State) const;
 };

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsAddExternalForce.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsAddExternalForce.h
@@ -18,7 +18,7 @@
  * 単発の AnimNotify で KawaiiPhysics に外力を追加する（タグでフィルタ可能）。
  * AnimNotify that adds external forces to KawaiiPhysics nodes when triggered (filterable by tag).
  */
-UCLASS(Blueprintable, meta = (DisplayName = "KawaiiPhysics: Add ExternalForce"))
+UCLASS(Blueprintable, meta = (DisplayName = "KawaiiPhysics: Add ExternalForce (Pulse)"))
 class KAWAIIPHYSICS_API UAnimNotify_KawaiiPhysicsAddExternalForce : public UAnimNotify
 {
 	GENERATED_BODY()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -439,8 +439,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_ProceduralWind : public FK
 	void ConsumePendingRequests();
 
 	FKawaiiPhysicsProceduralWindSample ComputeWindSample(float InTime, float InLengthRate = 0.0f) const;
-	static uint32 StableHash(int32 Seed, int32 GridIndex, int32 Channel);
-	static float NoiseValueAt(int32 GridIndex, int32 Seed, int32 Channel);
+	static uint32 ComputeStableHash(int32 Seed, int32 GridIndex, int32 Channel);
+	static float SampleNoiseAt(int32 GridIndex, int32 Seed, int32 Channel);
 	static float SampleSmoothNoise(float U, int32 Seed, int32 Channel = 0);
 
 	virtual void Initialize(const FAnimationInitializeContext& Context) override;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
@@ -236,7 +236,7 @@ public:
 	                                                               bool bBoneSubdivisionCollisionOnly)
 	{
 		KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
-			TEXT("SetbBoneSubdivisionCollisionOnly"),
+			TEXT("SetBoneSubdivisionCollisionOnly"),
 			[bBoneSubdivisionCollisionOnly](FAnimNode_KawaiiPhysics& InKawaiiPhysics) {
 				InKawaiiPhysics.bBoneSubdivisionCollisionOnly = bBoneSubdivisionCollisionOnly;
 				InKawaiiPhysics.RequestModifyBonesReinit();
@@ -436,7 +436,7 @@ public:
 		const FKawaiiPhysicsReference& KawaiiPhysics, bool bSkipMirroredBoneWithExistingCollision)
 	{
 		KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
-			TEXT("SetbSkipMirroredBoneWithExistingCollision"),
+			TEXT("SetSkipMirroredBoneWithExistingCollision"),
 			[bSkipMirroredBoneWithExistingCollision](FAnimNode_KawaiiPhysics& InKawaiiPhysics) {
 				InKawaiiPhysics.bSkipMirroredBoneWithExistingCollision = bSkipMirroredBoneWithExistingCollision;
 				InKawaiiPhysics.RequestModifyBonesReinit();
@@ -992,7 +992,7 @@ public:
 	                                                        bool bSharedCollisionSource)
 	{
 		KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
-			TEXT("SetbSharedCollisionSource"),
+			TEXT("SetSharedCollisionSource"),
 			[bSharedCollisionSource](FAnimNode_KawaiiPhysics& InKawaiiPhysics) {
 				InKawaiiPhysics.bSharedCollisionSource = bSharedCollisionSource;
 				InKawaiiPhysics.RequestSharedCollisionReinit();
@@ -1015,7 +1015,7 @@ public:
 	                                                     bool bUseSharedCollision)
 	{
 		KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
-			TEXT("SetbUseSharedCollision"),
+			TEXT("SetUseSharedCollision"),
 			[bUseSharedCollision](FAnimNode_KawaiiPhysics& InKawaiiPhysics) {
 				InKawaiiPhysics.bUseSharedCollision = bUseSharedCollision;
 				InKawaiiPhysics.RequestSharedCollisionReinit();

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsMirrorUtils.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsMirrorUtils.h
@@ -8,7 +8,7 @@
 #include "ReferenceSkeleton.h"
 #include "Templates/Function.h"
 
-namespace KawaiiPhysicsMirror
+namespace KawaiiPhysicsMirrorUtils
 {
 	/**
 	 * ボーンローカル空間のコリジョンオフセット位置をミラー先ボーンのローカル空間へ変換

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/AnimGraphNode_KawaiiPhysics.cpp
@@ -779,7 +779,7 @@ void UAnimGraphNode_KawaiiPhysics::CustomizeDetailDebugVisualizations(IDetailLay
 			]
 			+ SUniformGridPanel::Slot(0, 1)
 			[
-				CreateDebugButton(TEXT("Plane"),  bEnableDebugDrawPlanerLimit)
+				CreateDebugButton(TEXT("Plane"),  bEnableDebugDrawPlanarLimit)
 			]
 			+ SUniformGridPanel::Slot(1, 1)
 			[

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditMode.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditMode.cpp
@@ -132,7 +132,7 @@ void FKawaiiPhysicsEditMode::Render(const FSceneView* View, FViewport* Viewport,
 		RenderCapsuleLimit(PDI);
 		RenderTaperedCapsuleLimit(PDI);
 		RenderBoxLimit(PDI);
-		RenderPlanerLimit(PDI);
+		RenderPlanarLimit(PDI);
 		RenderBoneConstraint(PDI);
 		RenderExternalForces(PDI);
 
@@ -578,9 +578,9 @@ void FKawaiiPhysicsEditMode::RenderBoxLimit(FPrimitiveDrawInterface* PDI) const
 	}
 }
 
-void FKawaiiPhysicsEditMode::RenderPlanerLimit(FPrimitiveDrawInterface* PDI)
+void FKawaiiPhysicsEditMode::RenderPlanarLimit(FPrimitiveDrawInterface* PDI) const
 {
-	if (GraphNode->bEnableDebugDrawPlanerLimit)
+	if (GraphNode->bEnableDebugDrawPlanarLimit)
 	{
 		auto DrawPlanarLimit = [&](const auto& Plane, int32 Index, const FMaterialRenderProxy* MaterialProxy,
 		                           bool bUseHit = true)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsEditorLibrary.cpp
@@ -64,13 +64,6 @@ namespace
 	constexpr int32 KawaiiPhysicsPlacementEstimatedOtherNodeWidth = 250;
 	constexpr int32 KawaiiPhysicsPlacementEstimatedOtherNodeHeight = 120;
 
-	// UE5.5未満ではUEdGraphNode_Comment継承クラスがリンクできないため、素のコメント枠を使う
-#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
-	using FKawaiiMcpCommentNode = UKawaiiPhysicsMcpCommentNode;
-#else
-	using FKawaiiMcpCommentNode = UEdGraphNode_Comment;
-#endif
-
 	UAnimGraphNode_KawaiiPhysics* GetGraphNode(const FKawaiiPhysicsGraphNodeHandle& Handle)
 	{
 		return Handle.Node.Get();
@@ -191,7 +184,7 @@ namespace
 		}
 	}
 
-	struct FKawaiiTagNameFilter
+	struct FKawaiiPhysicsTagNameFilter
 	{
 		TSet<FName> ExactNames;
 		TArray<FString> ChildPrefixes;
@@ -220,9 +213,9 @@ namespace
 		}
 	};
 
-	FKawaiiTagNameFilter MakeTagNameFilter(const FGameplayTagContainer& FilterTags, const bool bFilterExactMatch)
+	FKawaiiPhysicsTagNameFilter MakeTagNameFilter(const FGameplayTagContainer& FilterTags, const bool bFilterExactMatch)
 	{
-		FKawaiiTagNameFilter Result;
+		FKawaiiPhysicsTagNameFilter Result;
 		for (const FGameplayTag& FilterTag : FilterTags)
 		{
 			const FName TagName = FilterTag.GetTagName();
@@ -769,11 +762,11 @@ namespace
 		return nullptr;
 	}
 
-	bool CalculateMcpCommentBounds(const TArray<FKawaiiPhysicsGraphNodeHandle>& Handles,
-	                               int32& OutNodePosX,
-	                               int32& OutNodePosY,
-	                               int32& OutNodeWidth,
-	                               int32& OutNodeHeight)
+	bool ComputeMcpCommentBounds(const TArray<FKawaiiPhysicsGraphNodeHandle>& Handles,
+	                             int32& OutNodePosX,
+	                             int32& OutNodePosY,
+	                             int32& OutNodeWidth,
+	                             int32& OutNodeHeight)
 	{
 		int32 MinX = TNumericLimits<int32>::Max();
 		int32 MinY = TNumericLimits<int32>::Max();
@@ -811,7 +804,12 @@ namespace
 		return true;
 	}
 
-	void ApplyMcpCommentNodeState(FKawaiiMcpCommentNode* CommentNode,
+	// UE5.5未満ではUEdGraphNode_Comment継承クラスがリンクできないため、素のコメント枠を使う
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+	void ApplyMcpCommentNodeState(UKawaiiPhysicsMcpCommentNode* CommentNode,
+#else
+	void ApplyMcpCommentNodeState(UEdGraphNode_Comment* CommentNode,
+#endif
 	                              const TArray<FKawaiiPhysicsGraphNodeHandle>& Handles,
 	                              const FString& CommentText,
 	                              const FString& Prompt,
@@ -826,7 +824,7 @@ namespace
 		int32 NodePosY = 0;
 		int32 NodeWidth = 0;
 		int32 NodeHeight = 0;
-		if (!CalculateMcpCommentBounds(Handles, NodePosX, NodePosY, NodeWidth, NodeHeight))
+		if (!ComputeMcpCommentBounds(Handles, NodePosX, NodePosY, NodeWidth, NodeHeight))
 		{
 			return;
 		}
@@ -882,10 +880,17 @@ namespace
 		// 同じコメント本文の枠があれば更新し、なければ新規作成する。戻り値は新規作成の有無を表す。
 		for (UEdGraphNode* Node : Graph->Nodes)
 		{
-			FKawaiiMcpCommentNode* CommentNode = Cast<FKawaiiMcpCommentNode>(Node);
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+			UKawaiiPhysicsMcpCommentNode* CommentNode = Cast<UKawaiiPhysicsMcpCommentNode>(Node);
 			if (!CommentNode ||
-				CommentNode->GetClass() != FKawaiiMcpCommentNode::StaticClass() ||
+				CommentNode->GetClass() != UKawaiiPhysicsMcpCommentNode::StaticClass() ||
 				CommentNode->NodeComment != CommentText)
+#else
+			UEdGraphNode_Comment* CommentNode = Cast<UEdGraphNode_Comment>(Node);
+			if (!CommentNode ||
+				CommentNode->GetClass() != UEdGraphNode_Comment::StaticClass() ||
+				CommentNode->NodeComment != CommentText)
+#endif
 			{
 				continue;
 			}
@@ -897,8 +902,13 @@ namespace
 		}
 
 		Graph->Modify();
-		FGraphNodeCreator<FKawaiiMcpCommentNode> NodeCreator(*Graph);
-		FKawaiiMcpCommentNode* CommentNode = NodeCreator.CreateNode(false);
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+		FGraphNodeCreator<UKawaiiPhysicsMcpCommentNode> NodeCreator(*Graph);
+		UKawaiiPhysicsMcpCommentNode* CommentNode = NodeCreator.CreateNode(false);
+#else
+		FGraphNodeCreator<UEdGraphNode_Comment> NodeCreator(*Graph);
+		UEdGraphNode_Comment* CommentNode = NodeCreator.CreateNode(false);
+#endif
 		NodeCreator.Finalize();
 		ApplyMcpCommentNodeState(CommentNode, Handles, CommentText, Prompt, true);
 		Graph->NotifyNodeChanged(CommentNode);
@@ -981,7 +991,7 @@ namespace
 			}
 
 #if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
-			if (const FKawaiiMcpCommentNode* CommentNode = Cast<FKawaiiMcpCommentNode>(Node))
+			if (const UKawaiiPhysicsMcpCommentNode* CommentNode = Cast<UKawaiiPhysicsMcpCommentNode>(Node))
 			{
 				if (DoPlacementRectsOverlap(
 					CandidateRect,
@@ -1481,7 +1491,7 @@ void UKawaiiPhysicsEditorLibrary::GetAnimBlueprintAssetsReferencingTags(
 	FAssetRegistryModule& AssetRegistryModule =
 		FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
 	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
-	const FKawaiiTagNameFilter TagNameFilter = MakeTagNameFilter(FilterTags, bFilterExactMatch);
+	const FKawaiiPhysicsTagNameFilter TagNameFilter = MakeTagNameFilter(FilterTags, bFilterExactMatch);
 	const FName GameplayTagPackageName = FGameplayTag::StaticStruct()->GetOutermost()->GetFName();
 	const FName GameplayTagStructName = FGameplayTag::StaticStruct()->GetFName();
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDiffSnapshot.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDiffSnapshot.cpp
@@ -119,7 +119,7 @@ namespace KawaiiPhysicsPresetDiff
 		return Snapshots;
 	}
 
-	FString SnapshotToClipboardText(const FKawaiiPhysicsPresetDiffSnapshot& Snapshot, const FText& ContextLabel)
+	FString MakeClipboardTextFromSnapshot(const FKawaiiPhysicsPresetDiffSnapshot& Snapshot, const FText& ContextLabel)
 	{
 		TArray<FString> Lines;
 		Lines.Add(TEXT("Context\tPreset\tPresetPath\tPropertyName\tDisplayName\tCategory\tNodeValue\tPresetValue"));

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDiffSnapshot.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsPresetDiffSnapshot.h
@@ -101,7 +101,7 @@ namespace KawaiiPhysicsPresetDiff
 	 * 差分行だけをタブ区切りのクリップボード文字列に変換する。
 	 * Convert only differing rows to tab-separated clipboard text.
 	 */
-	FString SnapshotToClipboardText(const FKawaiiPhysicsPresetDiffSnapshot& Snapshot, const FText& ContextLabel);
+	FString MakeClipboardTextFromSnapshot(const FKawaiiPhysicsPresetDiffSnapshot& Snapshot, const FText& ContextLabel);
 
 	/**
 	 * 差分プロパティの値ペア配列を生成する。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsWindScopeStyle.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/KawaiiPhysicsWindScopeStyle.h
@@ -6,7 +6,7 @@
 
 #include "SKawaiiPhysicsWindScopeWindow.h"
 
-struct FKawaiiWindScopeComponentStyle
+struct FKawaiiPhysicsWindScopeComponentStyle
 {
 	EKawaiiPhysicsWindScopeComponent Component;
 	FText Label;
@@ -16,9 +16,9 @@ struct FKawaiiWindScopeComponentStyle
 };
 
 // 各波形成分の表示スタイル（色・凡例ラベル・線種）を定義する
-inline const TArray<FKawaiiWindScopeComponentStyle>& GetWindScopeComponentStyles()
+inline const TArray<FKawaiiPhysicsWindScopeComponentStyle>& GetWindScopeComponentStyles()
 {
-	static const TArray<FKawaiiWindScopeComponentStyle> Styles =
+	static const TArray<FKawaiiPhysicsWindScopeComponentStyle> Styles =
 	{
 		{EKawaiiPhysicsWindScopeComponent::Total, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "TotalLabel", "Total"), FLinearColor::White, 2.0f, false},
 		{EKawaiiPhysicsWindScopeComponent::Constant, NSLOCTEXT("KawaiiPhysicsWindScopeWindow", "ConstantLabel", "Constant"), FLinearColor(1.0f, 0.48f, 0.08f), 1.0f, false},

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsPresetDiffWindow.cpp
@@ -725,7 +725,7 @@ FReply SKawaiiPhysicsPresetDiffWindow::OnCopyClicked()
 		return FReply::Handled();
 	}
 
-	const FString ClipboardText = KawaiiPhysicsPresetDiff::SnapshotToClipboardText(*SelectedSnapshot, ContextLabel);
+	const FString ClipboardText = KawaiiPhysicsPresetDiff::MakeClipboardTextFromSnapshot(*SelectedSnapshot, ContextLabel);
 	FPlatformApplicationMisc::ClipboardCopy(*ClipboardText);
 	KawaiiPhysicsEdWindowUtils::ShowNotification(
 		LOCTEXT("CopySucceeded", "Copied preset diff to clipboard."),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.cpp
@@ -106,7 +106,7 @@ namespace KawaiiPhysicsWindScopeEditPanelPrivate
 			return FLinearColor(0.28f, 0.3f, 0.34f, 1.0f);
 		}
 
-		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 		{
 			if (Style.Component == LinkedSeries.GetValue())
 			{
@@ -129,15 +129,15 @@ namespace KawaiiPhysicsWindScopeEditPanelPrivate
 		return FText::AsNumber(Value, &Options);
 	}
 
-	FText FormatSummaryValueWithUnit(const FText& ValueText, EKawaiiWindScopeSummaryUnit Unit)
+	FText FormatSummaryValueWithUnit(const FText& ValueText, EKawaiiPhysicsWindScopeSummaryUnit Unit)
 	{
 		switch (Unit)
 		{
-		case EKawaiiWindScopeSummaryUnit::Seconds:
+		case EKawaiiPhysicsWindScopeSummaryUnit::Seconds:
 			return FText::Format(LOCTEXT("SummaryValueSeconds", "{0}s"), ValueText);
-		case EKawaiiWindScopeSummaryUnit::Degrees:
+		case EKawaiiPhysicsWindScopeSummaryUnit::Degrees:
 			return FText::Format(LOCTEXT("SummaryValueDegrees", "{0}°"), ValueText);
-		case EKawaiiWindScopeSummaryUnit::None:
+		case EKawaiiPhysicsWindScopeSummaryUnit::None:
 		default:
 			return ValueText;
 		}
@@ -150,7 +150,7 @@ namespace KawaiiPhysicsWindScopeEditPanelPrivate
 			return false;
 		}
 
-		for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+		for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 		{
 			if (Group.GroupId == GroupId)
 			{
@@ -160,10 +160,10 @@ namespace KawaiiPhysicsWindScopeEditPanelPrivate
 		return false;
 	}
 
-	class SKawaiiWindScopeGroupHoverBorder : public SBorder
+	class SKawaiiPhysicsWindScopeGroupHoverBorder : public SBorder
 	{
 	public:
-		SLATE_BEGIN_ARGS(SKawaiiWindScopeGroupHoverBorder)
+		SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeGroupHoverBorder)
 			{
 			}
 			SLATE_DEFAULT_SLOT(FArguments, Content)
@@ -205,9 +205,9 @@ namespace KawaiiPhysicsWindScopeEditPanelPrivate
 	};
 }
 
-const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
+const TArray<FKawaiiPhysicsWindScopeParamGroup>& GetWindScopeParamGroups()
 {
-	static const TArray<FKawaiiWindScopeParamGroup> Groups =
+	static const TArray<FKawaiiPhysicsWindScopeParamGroup> Groups =
 	{
 		{
 			LOCTEXT("CommonGroupLabel", "Common"),
@@ -229,7 +229,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirectionNoiseAngle),
 					LOCTEXT("SummaryLabelNoise", "Noise"),
-					EKawaiiWindScopeSummaryUnit::Degrees,
+					EKawaiiPhysicsWindScopeSummaryUnit::Degrees,
 					true
 				},
 			},
@@ -265,7 +265,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, SwayPeriod),
 					LOCTEXT("SummaryLabelPeriod", "Period"),
-					EKawaiiWindScopeSummaryUnit::Seconds
+					EKawaiiPhysicsWindScopeSummaryUnit::Seconds
 				},
 			},
 			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Sway),
@@ -286,12 +286,12 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RipplePeriod),
 					LOCTEXT("SummaryLabelPeriod", "Period"),
-					EKawaiiWindScopeSummaryUnit::Seconds
+					EKawaiiPhysicsWindScopeSummaryUnit::Seconds
 				},
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RippleTipPhaseDelay),
 					LOCTEXT("SummaryLabelTipDelay", "Tip Delay"),
-					EKawaiiWindScopeSummaryUnit::Degrees
+					EKawaiiPhysicsWindScopeSummaryUnit::Degrees
 				},
 			},
 			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Ripple),
@@ -313,7 +313,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, StrengthCyclePeriod),
 					LOCTEXT("SummaryLabelPeriod", "Period"),
-					EKawaiiWindScopeSummaryUnit::Seconds
+					EKawaiiPhysicsWindScopeSummaryUnit::Seconds
 				},
 			},
 			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::StrengthCycle),
@@ -334,7 +334,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 				{
 					GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, RandomForcePeriod),
 					LOCTEXT("SummaryLabelPeriod", "Period"),
-					EKawaiiWindScopeSummaryUnit::Seconds
+					EKawaiiPhysicsWindScopeSummaryUnit::Seconds
 				},
 			},
 			TOptional<EKawaiiPhysicsWindScopeComponent>(EKawaiiPhysicsWindScopeComponent::Random),
@@ -351,7 +351,7 @@ const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups()
 FString SerializeWindScopeCollapsedGroups(const TSet<FName>& CollapsedGroups)
 {
 	TArray<FString> GroupIdStrings;
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		if (CollapsedGroups.Contains(Group.GroupId))
 		{
@@ -390,11 +390,11 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 	LoadCollapsedGroupsFromConfig();
 	GroupAreas.Reset();
 	GroupPropertyNames.Reset();
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		TArray<FName> PropertyNames;
 		PropertyNames.Reserve(Group.Params.Num());
-		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 		{
 			PropertyNames.Add(Param.PropertyName);
 		}
@@ -436,13 +436,13 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 		]
 	];
 	// 固定グループ（表示モード・有効）はカテゴリ化せずヘッダー直下に常時表示
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		if (!Group.bPinned)
 		{
 			continue;
 		}
-		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 		{
 			ScrollBox->AddSlot()
 			.Padding(4.0f, 0.0f, 4.0f, 4.0f)
@@ -457,7 +457,7 @@ void SKawaiiPhysicsWindScopeEditPanel::Construct(const FArguments& InArgs)
 		SNew(SSeparator)
 		.Orientation(Orient_Horizontal)
 	];
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		if (Group.bPinned)
 		{
@@ -505,10 +505,10 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeHeaderIconButton(
 		];
 }
 
-TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group)
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKawaiiPhysicsWindScopeParamGroup& Group)
 {
 	TSharedRef<SWidget> HeaderContent =
-		SNew(KawaiiPhysicsWindScopeEditPanelPrivate::SKawaiiWindScopeGroupHoverBorder)
+		SNew(KawaiiPhysicsWindScopeEditPanelPrivate::SKawaiiPhysicsWindScopeGroupHoverBorder)
 		.BorderImage(FAppStyle::Get().GetBrush(TEXT("Brushes.Header")))
 		.BorderBackgroundColor_Lambda([this, LinkedSeries = Group.LinkedSeries]()
 		{
@@ -592,7 +592,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKaw
 
 	TSharedRef<SVerticalBox> BodyBox = SNew(SVerticalBox);
 
-	for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+	for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 	{
 		BodyBox->AddSlot()
 		.AutoHeight()
@@ -624,7 +624,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeGroupWidget(const FKaw
 	return GroupArea.ToSharedRef();
 }
 
-TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef)
+TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaiiPhysicsWindScopeParamDef& ParamDef)
 {
 	FProperty* Property = KawaiiPhysicsWindScopeEditPanelPrivate::FindWindScopeProperty(ParamDef.PropertyName);
 	const FText Label = Property ? Property->GetDisplayNameText() : FText::FromString(ParamDef.PropertyName.ToString());
@@ -661,7 +661,7 @@ TSharedRef<SWidget> SKawaiiPhysicsWindScopeEditPanel::MakeParamRow(const FKawaii
 				}
 				if (Item.IsValid() && OnParamEdit.IsBound())
 				{
-					OnParamEdit.Execute(PropertyName, static_cast<double>(static_cast<uint8>(*Item)), INDEX_NONE, EKawaiiWindEditPhase::Committed);
+					OnParamEdit.Execute(PropertyName, static_cast<double>(static_cast<uint8>(*Item)), INDEX_NONE, EKawaiiPhysicsWindEditPhase::Committed);
 				}
 			})
 			.ToolTipText(ToolTipText)
@@ -949,7 +949,7 @@ void SKawaiiPhysicsWindScopeEditPanel::SyncParameterModeComboSelection()
 		return;
 	}
 
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!Values || !Values->bValid)
 	{
 		return;
@@ -1044,7 +1044,7 @@ FReply SKawaiiPhysicsWindScopeEditPanel::OnCollapseAllClicked()
 {
 	bApplyingGroupExpansionBatch = true;
 	CollapsedGroups.Reset();
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		CollapsedGroups.Add(Group.GroupId);
 	}
@@ -1063,15 +1063,15 @@ FReply SKawaiiPhysicsWindScopeEditPanel::OnCollapseAllClicked()
 
 bool SKawaiiPhysicsWindScopeEditPanel::IsAdvancedMode() const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	return Values && Values->bValid && Values->ParameterMode == EKawaiiProceduralWindParameterMode::Advanced;
 }
 
 bool SKawaiiPhysicsWindScopeEditPanel::IsParamAdvancedOnly(FName PropertyName) const
 {
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
-		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 		{
 			if (Param.PropertyName == PropertyName)
 			{
@@ -1096,7 +1096,7 @@ FLinearColor SKawaiiPhysicsWindScopeEditPanel::ResolveSeriesDisplayColor(
 
 EVisibility SKawaiiPhysicsWindScopeEditPanel::GetResetVisibility(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	return Values && Values->ModifiedFromDefault.Contains(PropertyName)
 		       ? EVisibility::Visible
 		       : EVisibility::Hidden;
@@ -1132,7 +1132,7 @@ EVisibility SKawaiiPhysicsWindScopeEditPanel::GetGroupModifiedDotVisibility(FNam
 		return EVisibility::Collapsed;
 	}
 
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	const TArray<FName>* PropertyNames = GroupPropertyNames.Find(GroupId);
 	if (!Values || !PropertyNames)
 	{
@@ -1158,8 +1158,8 @@ EVisibility SKawaiiPhysicsWindScopeEditPanel::GetGroupSummaryVisibility(FName Gr
 
 EVisibility SKawaiiPhysicsWindScopeEditPanel::GetLiveValueVisibility(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
-	const FKawaiiWindScopeEditValues* LiveValues = LiveEditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* LiveValues = LiveEditValues.Get();
 	if (!Values || !Values->bValid || !LiveValues || !LiveValues->bValid)
 	{
 		return EVisibility::Collapsed;
@@ -1221,7 +1221,7 @@ EVisibility SKawaiiPhysicsWindScopeEditPanel::GetLiveValueVisibility(FName Prope
 
 FText SKawaiiPhysicsWindScopeEditPanel::GetLiveValueText(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* LiveValues = LiveEditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* LiveValues = LiveEditValues.Get();
 	if (!LiveValues || !LiveValues->bValid)
 	{
 		return FText::GetEmpty();
@@ -1280,8 +1280,8 @@ FText SKawaiiPhysicsWindScopeEditPanel::GetLiveValueText(FName PropertyName) con
 
 FText SKawaiiPhysicsWindScopeEditPanel::GetGroupSummaryText(FName GroupId) const
 {
-	const FKawaiiWindScopeParamGroup* TargetGroup = nullptr;
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	const FKawaiiPhysicsWindScopeParamGroup* TargetGroup = nullptr;
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		if (Group.GroupId == GroupId)
 		{
@@ -1290,14 +1290,14 @@ FText SKawaiiPhysicsWindScopeEditPanel::GetGroupSummaryText(FName GroupId) const
 		}
 	}
 
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!TargetGroup || !Values || !Values->bValid)
 	{
 		return FText::GetEmpty();
 	}
 
 	TArray<FText> SummaryTexts;
-	for (const FKawaiiWindScopeSummaryItem& Item : TargetGroup->SummaryItems)
+	for (const FKawaiiPhysicsWindScopeSummaryItem& Item : TargetGroup->SummaryItems)
 	{
 		if (Item.PropertyName.IsNone() || !IsParamVisibleInCurrentMode(Item.PropertyName))
 		{
@@ -1347,7 +1347,7 @@ FText SKawaiiPhysicsWindScopeEditPanel::GetGroupSummaryText(FName GroupId) const
 
 FText SKawaiiPhysicsWindScopeEditPanel::GetParameterModeText() const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	return Values && Values->bValid
 		       ? KawaiiPhysicsWindScopeEditPanelPrivate::FormatParameterMode(Values->ParameterMode)
 		       : FText::GetEmpty();
@@ -1355,7 +1355,7 @@ FText SKawaiiPhysicsWindScopeEditPanel::GetParameterModeText() const
 
 ECheckBoxState SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!Values || !Values->bValid || PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce, bIsEnabled))
 	{
 		return ECheckBoxState::Undetermined;
@@ -1365,7 +1365,7 @@ ECheckBoxState SKawaiiPhysicsWindScopeEditPanel::GetBoolCheckState(FName Propert
 
 float SKawaiiPhysicsWindScopeEditPanel::GetFloatValue(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!Values || !Values->bValid)
 	{
 		return 0.0f;
@@ -1380,7 +1380,7 @@ float SKawaiiPhysicsWindScopeEditPanel::GetFloatValue(FName PropertyName) const
 
 int32 SKawaiiPhysicsWindScopeEditPanel::GetIntValue(FName PropertyName) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!Values || !Values->bValid || PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, Seed))
 	{
 		return 0;
@@ -1390,7 +1390,7 @@ int32 SKawaiiPhysicsWindScopeEditPanel::GetIntValue(FName PropertyName) const
 
 TOptional<float> SKawaiiPhysicsWindScopeEditPanel::GetIntervalValue(FName PropertyName, int32 ComponentIndex) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	const FFloatInterval* Interval = Values && Values->bValid
 		                                 ? Values->IntervalValues.Find(PropertyName)
 		                                 : nullptr;
@@ -1403,7 +1403,7 @@ TOptional<float> SKawaiiPhysicsWindScopeEditPanel::GetIntervalValue(FName Proper
 
 TOptional<FVector::FReal> SKawaiiPhysicsWindScopeEditPanel::GetVectorValue(FName PropertyName, int32 ComponentIndex) const
 {
-	const FKawaiiWindScopeEditValues* Values = EditValues.Get();
+	const FKawaiiPhysicsWindScopeEditValues* Values = EditValues.Get();
 	if (!Values || !Values->bValid ||
 		PropertyName != GET_MEMBER_NAME_CHECKED(FKawaiiPhysics_ExternalForce_ProceduralWind, WindDirection) ||
 		ComponentIndex < 0 || ComponentIndex > 2)
@@ -1417,7 +1417,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleBegin(FName PropertyName, int32 Vec
 {
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, 0.0, VectorComponentIndex, EKawaiiWindEditPhase::Begin);
+		OnParamEdit.Execute(PropertyName, 0.0, VectorComponentIndex, EKawaiiPhysicsWindEditPhase::Begin);
 	}
 }
 
@@ -1425,7 +1425,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleScalarChanged(FName PropertyName, d
 {
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Interactive);
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiPhysicsWindEditPhase::Interactive);
 	}
 }
 
@@ -1437,7 +1437,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleScalarCommitted(
 	(void)CommitType;
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Committed);
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiPhysicsWindEditPhase::Committed);
 	}
 }
 
@@ -1448,7 +1448,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleVectorChanged(
 {
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiWindEditPhase::Interactive);
+		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiPhysicsWindEditPhase::Interactive);
 	}
 }
 
@@ -1461,7 +1461,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleVectorCommitted(
 	(void)CommitType;
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiWindEditPhase::Committed);
+		OnParamEdit.Execute(PropertyName, NewValue, ComponentIndex, EKawaiiPhysicsWindEditPhase::Committed);
 	}
 }
 
@@ -1470,7 +1470,7 @@ void SKawaiiPhysicsWindScopeEditPanel::HandleBoolChanged(ECheckBoxState NewState
 	const double NewValue = NewState == ECheckBoxState::Checked ? 1.0 : 0.0;
 	if (OnParamEdit.IsBound())
 	{
-		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiWindEditPhase::Committed);
+		OnParamEdit.Execute(PropertyName, NewValue, INDEX_NONE, EKawaiiPhysicsWindEditPhase::Committed);
 	}
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeEditPanel.h
@@ -10,7 +10,7 @@
 class SExpandableArea;
 
 // Wind Scope 編集パネルの1プロパティ定義
-struct FKawaiiWindScopeParamDef
+struct FKawaiiPhysicsWindScopeParamDef
 {
 	FName PropertyName;
 	float SliderMin = 0.0f;
@@ -20,7 +20,7 @@ struct FKawaiiWindScopeParamDef
 };
 
 // 折りたたみ時サマリーの単位 / Unit suffix for collapsed summaries.
-enum class EKawaiiWindScopeSummaryUnit : uint8
+enum class EKawaiiPhysicsWindScopeSummaryUnit : uint8
 {
 	None,
 	Seconds,
@@ -28,33 +28,33 @@ enum class EKawaiiWindScopeSummaryUnit : uint8
 };
 
 // 折りたたみ時サマリーの1項目 / Single item shown in a collapsed summary.
-struct FKawaiiWindScopeSummaryItem
+struct FKawaiiPhysicsWindScopeSummaryItem
 {
 	FName PropertyName;
 	FText ShortLabel;
-	EKawaiiWindScopeSummaryUnit Unit = EKawaiiWindScopeSummaryUnit::None;
+	EKawaiiPhysicsWindScopeSummaryUnit Unit = EKawaiiPhysicsWindScopeSummaryUnit::None;
 	bool bHideWhenZero = false;
 };
 
 // Wind Scope 編集パネルのグループ定義
-struct FKawaiiWindScopeParamGroup
+struct FKawaiiPhysicsWindScopeParamGroup
 {
 	FText GroupLabel;
 	/** グループ永続化ID / Stable group ID used for persistence. */
 	FName GroupId;
 	/** 折りたたみ時に表示するサマリー項目 / Summary items shown when collapsed. */
-	TArray<FKawaiiWindScopeSummaryItem> SummaryItems;
+	TArray<FKawaiiPhysicsWindScopeSummaryItem> SummaryItems;
 	TOptional<EKawaiiPhysicsWindScopeComponent> LinkedSeries;
-	TArray<FKawaiiWindScopeParamDef> Params;
+	TArray<FKawaiiPhysicsWindScopeParamDef> Params;
 	/** 折りたたみカテゴリにせずヘッダー直下に常時表示する / Pinned below the header instead of a collapsible category. */
 	bool bPinned = false;
 };
 
-const TArray<FKawaiiWindScopeParamGroup>& GetWindScopeParamGroups();
+const TArray<FKawaiiPhysicsWindScopeParamGroup>& GetWindScopeParamGroups();
 FString SerializeWindScopeCollapsedGroups(const TSet<FName>& CollapsedGroups);
 TSet<FName> ParseWindScopeCollapsedGroups(const FString& CollapsedGroupsValue);
 
-DECLARE_DELEGATE_RetVal_FourParams(bool, FOnWindParamEdit, FName, double, int32, EKawaiiWindEditPhase);
+DECLARE_DELEGATE_RetVal_FourParams(bool, FOnWindParamEdit, FName, double, int32, EKawaiiPhysicsWindEditPhase);
 DECLARE_DELEGATE_RetVal_OneParam(bool, FOnWindParamReset, FName);
 DECLARE_DELEGATE_OneParam(FOnWindScopeHighlightSeries, TOptional<EKawaiiPhysicsWindScopeComponent>);
 
@@ -65,8 +65,8 @@ public:
 	SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeEditPanel)
 		{
 		}
-		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, EditValues)
-		SLATE_ATTRIBUTE(const FKawaiiWindScopeEditValues*, LiveEditValues)
+		SLATE_ATTRIBUTE(const FKawaiiPhysicsWindScopeEditValues*, EditValues)
+		SLATE_ATTRIBUTE(const FKawaiiPhysicsWindScopeEditValues*, LiveEditValues)
 		SLATE_EVENT(FOnWindParamEdit, OnParamEdit)
 		SLATE_EVENT(FOnWindParamReset, OnParamReset)
 		SLATE_EVENT(FOnWindScopeHighlightSeries, OnHighlightSeries)
@@ -77,8 +77,8 @@ public:
 	virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
 
 private:
-	TSharedRef<SWidget> MakeGroupWidget(const FKawaiiWindScopeParamGroup& Group);
-	TSharedRef<SWidget> MakeParamRow(const FKawaiiWindScopeParamDef& ParamDef);
+	TSharedRef<SWidget> MakeGroupWidget(const FKawaiiPhysicsWindScopeParamGroup& Group);
+	TSharedRef<SWidget> MakeParamRow(const FKawaiiPhysicsWindScopeParamDef& ParamDef);
 	TSharedRef<SWidget> MakeResetButton(FName PropertyName) const;
 	TSharedRef<SWidget> MakeHeaderIconButton(const FName IconName, const FText& ToolTipText, FOnClicked OnClicked) const;
 
@@ -118,8 +118,8 @@ private:
 	void HandleVectorCommitted(FName PropertyName, int32 ComponentIndex, FVector::FReal NewValue, ETextCommit::Type CommitType) const;
 	void HandleBoolChanged(ECheckBoxState NewState, FName PropertyName) const;
 
-	TAttribute<const FKawaiiWindScopeEditValues*> EditValues;
-	TAttribute<const FKawaiiWindScopeEditValues*> LiveEditValues;
+	TAttribute<const FKawaiiPhysicsWindScopeEditValues*> EditValues;
+	TAttribute<const FKawaiiPhysicsWindScopeEditValues*> LiveEditValues;
 	FOnWindParamEdit OnParamEdit;
 	FOnWindParamReset OnParamReset;
 	FOnWindScopeHighlightSeries OnHighlightSeries;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -132,7 +132,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		return nullptr;
 	}
 
-	struct FKawaiiWindScopeRange
+	struct FKawaiiPhysicsWindScopeRange
 	{
 		float MinTime = 0.0f;
 		float MaxTime = 1.0f;
@@ -463,10 +463,10 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 	void FillWindScopeEditValuesFromWind(
 		const FKawaiiPhysics_ExternalForce_ProceduralWind* Wind,
-		FKawaiiWindScopeEditValues& OutValues,
+		FKawaiiPhysicsWindScopeEditValues& OutValues,
 		const bool bTrackDefaultDiff)
 	{
-		OutValues = FKawaiiWindScopeEditValues();
+		OutValues = FKawaiiPhysicsWindScopeEditValues();
 		if (!Wind)
 		{
 			return;
@@ -474,9 +474,9 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 		static const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
 		OutValues.bValid = true;
-		for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+		for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 		{
-			for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+			for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 			{
 				FProperty* Property = FindProceduralWindProperty(Param.PropertyName);
 				if (!Property)
@@ -538,7 +538,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 	FLinearColor ResolveBaseComponentColor(EKawaiiPhysicsWindScopeComponent Component)
 	{
-		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 		{
 			if (Style.Component == Component)
 			{
@@ -549,7 +549,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 	}
 
 	bool IsSeriesActiveFromValues(
-		const FKawaiiWindScopeEditValues* Values,
+		const FKawaiiPhysicsWindScopeEditValues* Values,
 		EKawaiiPhysicsWindScopeComponent Component,
 		bool bGustActive)
 	{
@@ -594,11 +594,11 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		}
 	}
 
-	FKawaiiWindScopeRange ComputeWindScopeRange(const TArray<FKawaiiProceduralWindScopeSample>& Samples,
+	FKawaiiPhysicsWindScopeRange ComputeWindScopeRange(const TArray<FKawaiiProceduralWindScopeSample>& Samples,
 	                                           float DisplaySeconds,
 	                                           const FKawaiiPhysicsWindScopeSeriesVisibility& Visibility)
 	{
-		FKawaiiWindScopeRange Range;
+		FKawaiiPhysicsWindScopeRange Range;
 		// 直近 DisplaySeconds 秒分を表示ウィンドウとする
 		Range.MaxTime = Samples.Num() > 0 ? Samples.Last().Time : 0.0f;
 		Range.MinTime = Range.MaxTime - FMath::Max(DisplaySeconds, 0.1f);
@@ -612,7 +612,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 				continue;
 			}
 
-			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+			for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 			{
 				if (!Visibility.IsVisible(Style.Component) ||
 					Style.Component == EKawaiiPhysicsWindScopeComponent::StrengthCycle)
@@ -653,7 +653,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 	float ComputeStrengthCycleAxisMax(
 		const TArray<FKawaiiProceduralWindScopeSample>& Samples,
 		float MinTime,
-		const FKawaiiWindScopeEditValues* EditValues)
+		const FKawaiiPhysicsWindScopeEditValues* EditValues)
 	{
 		float MaxValue = 0.0f;
 		bool bHasValue = false;
@@ -802,10 +802,10 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 		}
 	}
 
-	class SKawaiiWindScopeLegendHoverBorder : public SBorder
+	class SKawaiiPhysicsWindScopeLegendHoverBorder : public SBorder
 	{
 	public:
-		SLATE_BEGIN_ARGS(SKawaiiWindScopeLegendHoverBorder)
+		SLATE_BEGIN_ARGS(SKawaiiPhysicsWindScopeLegendHoverBorder)
 			{
 			}
 			SLATE_DEFAULT_SLOT(FArguments, Content)
@@ -846,9 +846,9 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 	// 凡例1項目（表示切替チェックボックス＋ラベル）を生成する
 	TSharedRef<SWidget> MakeWindScopeLegendItem(SKawaiiPhysicsWindScopeWindow* Owner,
-	                                            const FKawaiiWindScopeComponentStyle& Style)
+	                                            const FKawaiiPhysicsWindScopeComponentStyle& Style)
 	{
-		return SNew(SKawaiiWindScopeLegendHoverBorder)
+		return SNew(SKawaiiPhysicsWindScopeLegendHoverBorder)
 			.BorderImage(FCoreStyle::Get().GetBrush(TEXT("NoBrush")))
 			.Padding(FMargin(0.0f))
 			.OnHovered_Lambda([Owner, Component = Style.Component]()
@@ -894,7 +894,7 @@ namespace KawaiiPhysicsWindScopeWindowPrivate
 
 		const auto AddSeries = [&FormulaLegend, Owner](EKawaiiPhysicsWindScopeComponent Component)
 		{
-			for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+			for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 			{
 				if (Style.Component == Component)
 				{
@@ -1038,7 +1038,7 @@ void SKawaiiPhysicsWindScopeGraph::SetActiveEditGuide(TOptional<FName> PropertyN
 	Invalidate(EInvalidateWidgetReason::Paint);
 }
 
-void SKawaiiPhysicsWindScopeGraph::SetEditValues(const FKawaiiWindScopeEditValues* InEditValues)
+void SKawaiiPhysicsWindScopeGraph::SetEditValues(const FKawaiiPhysicsWindScopeEditValues* InEditValues)
 {
 	EditValues = InEditValues;
 	Invalidate(EInvalidateWidgetReason::Paint);
@@ -1099,7 +1099,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	const FVector2D GraphSize(
 		FMath::Max(LocalSize.X - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingLeft - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingRight, 1.0f),
 		FMath::Max(LocalSize.Y - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingTop - KawaiiPhysicsWindScopeWindowPrivate::WindScopeGraphPaddingBottom, 1.0f));
-	const KawaiiPhysicsWindScopeWindowPrivate::FKawaiiWindScopeRange Range = KawaiiPhysicsWindScopeWindowPrivate::ComputeWindScopeRange(Samples, DisplaySeconds, Visibility);
+	const KawaiiPhysicsWindScopeWindowPrivate::FKawaiiPhysicsWindScopeRange Range = KawaiiPhysicsWindScopeWindowPrivate::ComputeWindScopeRange(Samples, DisplaySeconds, Visibility);
 	const float StrengthCycleAxisMin = 0.0f;
 	const float StrengthCycleAxisMax = KawaiiPhysicsWindScopeWindowPrivate::ComputeStrengthCycleAxisMax(Samples, Range.MinTime, EditValues);
 	const FLinearColor GridColor(0.22f, 0.24f, 0.28f, 0.55f);
@@ -1160,7 +1160,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 	}
 
 	// 各波形成分のポリラインを描画（StrengthCycle等 bDashed 指定の系列は破線）
-	for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+	for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 	{
 		if (!Visibility.IsVisible(Style.Component))
 		{
@@ -1531,7 +1531,7 @@ int32 SKawaiiPhysicsWindScopeGraph::OnPaint(const FPaintArgs& Args,
 		CursorTextLines.Emplace(
 			FString::Printf(TEXT("t=%.2fs"), Samples[SampleIndex].Time - Range.MaxTime),
 			FLinearColor(1.0f, 1.0f, 1.0f, 0.92f));
-		for (const FKawaiiWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
+		for (const FKawaiiPhysicsWindScopeComponentStyle& Style : GetWindScopeComponentStyles())
 		{
 			if (!Visibility.IsVisible(Style.Component))
 			{
@@ -2115,7 +2115,7 @@ void SKawaiiPhysicsWindScopeWindow::SetArgs(FKawaiiPhysicsWindScopeWindowArgs In
 	}
 	PreviewTime = 0.0f;
 	LastLiveSampleCount = 0;
-	CachedLiveEditValues = FKawaiiWindScopeEditValues();
+	CachedLiveEditValues = FKawaiiPhysicsWindScopeEditValues();
 	bHasDragStartWind = false;
 	if (GraphWidget.IsValid())
 	{
@@ -2155,7 +2155,7 @@ void SKawaiiPhysicsWindScopeWindow::OnExternalForceSelectionChanged(
 	}
 	LastLiveSampleCount = 0;
 	PreviewTime = 0.0f;
-	CachedLiveEditValues = FKawaiiWindScopeEditValues();
+	CachedLiveEditValues = FKawaiiPhysicsWindScopeEditValues();
 	bHasDragStartWind = false;
 	if (GraphWidget.IsValid())
 	{
@@ -2282,12 +2282,12 @@ bool SKawaiiPhysicsWindScopeWindow::IsWindEditable() const
 	return ResolveGraphNode() != nullptr;
 }
 
-const FKawaiiWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetEditValues() const
+const FKawaiiPhysicsWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetEditValues() const
 {
 	return &CachedEditValues;
 }
 
-const FKawaiiWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetLiveEditValues() const
+const FKawaiiPhysicsWindScopeEditValues* SKawaiiPhysicsWindScopeWindow::GetLiveEditValues() const
 {
 	return CachedLiveEditValues.bValid ? &CachedLiveEditValues : nullptr;
 }
@@ -2304,7 +2304,7 @@ bool SKawaiiPhysicsWindScopeWindow::IsSeriesActive(EKawaiiPhysicsWindScopeCompon
 {
 	const bool bGustActive = DisplaySamples.Num() > 0 && !FMath::IsNearlyZero(DisplaySamples.Last().Sample.Gust);
 	// Live 値が有効な間は runtime 側（DynamicParams 反映後）で判定し、グラフの live 波形と凡例/式ヘッダの淡色表示を一致させる
-	const FKawaiiWindScopeEditValues* Values = CachedLiveEditValues.bValid ? &CachedLiveEditValues : &CachedEditValues;
+	const FKawaiiPhysicsWindScopeEditValues* Values = CachedLiveEditValues.bValid ? &CachedLiveEditValues : &CachedEditValues;
 	return KawaiiPhysicsWindScopeWindowPrivate::IsSeriesActiveFromValues(Values, Component, bGustActive);
 }
 
@@ -3054,7 +3054,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 	FName PropertyName,
 	double NewValue,
 	int32 VectorComponentIndex,
-	EKawaiiWindEditPhase Phase)
+	EKawaiiPhysicsWindEditPhase Phase)
 {
 	const auto ClearActiveEditGuide = [this]()
 	{
@@ -3069,8 +3069,8 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		return false;
 	};
 	const bool bHasMatchingDragStart = bHasDragStartWind && DragStartPropertyName == PropertyName;
-	const bool bApplyAsCommitted = Phase == EKawaiiWindEditPhase::Committed ||
-		(Phase == EKawaiiWindEditPhase::Interactive && !bHasMatchingDragStart);
+	const bool bApplyAsCommitted = Phase == EKawaiiPhysicsWindEditPhase::Committed ||
+		(Phase == EKawaiiPhysicsWindEditPhase::Interactive && !bHasMatchingDragStart);
 
 	if (GraphWidget.IsValid())
 	{
@@ -3104,7 +3104,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		return FailEdit();
 	}
 
-	if (Phase == EKawaiiWindEditPhase::Begin)
+	if (Phase == EKawaiiPhysicsWindEditPhase::Begin)
 	{
 		DragStartWind = *Wind;
 		DragStartPropertyName = PropertyName;
@@ -3112,7 +3112,7 @@ bool SKawaiiPhysicsWindScopeWindow::ApplyWindParamEdit(
 		return true;
 	}
 
-	if (Phase == EKawaiiWindEditPhase::Interactive && bHasMatchingDragStart)
+	if (Phase == EKawaiiPhysicsWindEditPhase::Interactive && bHasMatchingDragStart)
 	{
 		if (!KawaiiPhysicsWindScopeWindowPrivate::SetProceduralWindPropertyValue(*Wind, Property, NewValue, VectorComponentIndex))
 		{
@@ -3476,7 +3476,7 @@ void SKawaiiPhysicsWindScopeWindow::SyncEditValuesAfterWrite(
 
 void SKawaiiPhysicsWindScopeWindow::UpdateLiveEditValuesFromRuntime()
 {
-	CachedLiveEditValues = FKawaiiWindScopeEditValues();
+	CachedLiveEditValues = FKawaiiPhysicsWindScopeEditValues();
 
 	UAnimGraphNode_KawaiiPhysics* GraphNode = ResolveGraphNode();
 	FAnimNode_KawaiiPhysics* RuntimeNode = KawaiiPhysicsEdUtils::ResolveLiveKawaiiPhysicsNode(GraphNode);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.h
@@ -61,7 +61,7 @@ struct FKawaiiPhysicsWindScopeSeriesVisibility
 };
 
 // 編集パネルが表示する現在値キャッシュ
-struct FKawaiiWindScopeEditValues
+struct FKawaiiPhysicsWindScopeEditValues
 {
 	bool bValid = false;
 	bool bIsEnabled = true;
@@ -74,7 +74,7 @@ struct FKawaiiWindScopeEditValues
 };
 
 // 編集操作のフェーズ
-enum class EKawaiiWindEditPhase : uint8
+enum class EKawaiiPhysicsWindEditPhase : uint8
 {
 	Begin,
 	Interactive,
@@ -97,7 +97,7 @@ public:
 	void SetSeriesVisibility(const FKawaiiPhysicsWindScopeSeriesVisibility& InVisibility);
 	void SetHighlightSeries(TOptional<EKawaiiPhysicsWindScopeComponent> InHighlightSeries);
 	void SetActiveEditGuide(TOptional<FName> PropertyName);
-	void SetEditValues(const FKawaiiWindScopeEditValues* InEditValues);
+	void SetEditValues(const FKawaiiPhysicsWindScopeEditValues* InEditValues);
 	void SetGhostSamples(TArray<FVector2D> InGhostSamples);
 	void SetPaused(bool bInPaused);
 
@@ -122,7 +122,7 @@ private:
 	TOptional<EKawaiiPhysicsWindScopeComponent> HighlightSeries;
 	TOptional<FName> ActiveEditGuide;
 	TOptional<FVector2D> HoverMousePosition;
-	const FKawaiiWindScopeEditValues* EditValues = nullptr;
+	const FKawaiiPhysicsWindScopeEditValues* EditValues = nullptr;
 	float DisplaySeconds = 8.0f;
 	bool bPaused = false;
 };
@@ -185,8 +185,8 @@ private:
 	FSlateColor GetModeBadgeColor() const;
 	EVisibility GetTargetNodeEmptyStateVisibility() const;
 	bool IsWindEditable() const;
-	const FKawaiiWindScopeEditValues* GetEditValues() const;
-	const FKawaiiWindScopeEditValues* GetLiveEditValues() const;
+	const FKawaiiPhysicsWindScopeEditValues* GetEditValues() const;
+	const FKawaiiPhysicsWindScopeEditValues* GetLiveEditValues() const;
 
 	void RebuildPresetButtons();
 	TSharedRef<SWidget> GeneratePresetMenu();
@@ -209,7 +209,7 @@ private:
 		bool bShowNotification = true);
 	bool PushParamsToLiveRuntime(const FKawaiiProceduralWindDynamicParams& Params);
 	bool PushGustToLiveRuntime(float Strength, float RiseTime, float DecayTime);
-	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiWindEditPhase Phase);
+	bool ApplyWindParamEdit(FName PropertyName, double NewValue, int32 VectorComponentIndex, EKawaiiPhysicsWindEditPhase Phase);
 	// 放棄されたドラッグ編集をトランザクションとして確定する / Finalizes an abandoned drag edit as a transaction.
 	void FinalizeAbandonedWindDrag();
 	bool ResetWindParamToDefault(FName PropertyName);
@@ -252,8 +252,8 @@ private:
 	TArray<FKawaiiProceduralWindScopeSample> DisplaySamples;
 	FText CurrentModeText;
 	float DisplaySeconds = 8.0f;
-	FKawaiiWindScopeEditValues CachedEditValues;
-	FKawaiiWindScopeEditValues CachedLiveEditValues;
+	FKawaiiPhysicsWindScopeEditValues CachedEditValues;
+	FKawaiiPhysicsWindScopeEditValues CachedLiveEditValues;
 	FKawaiiPhysics_ExternalForce_ProceduralWind DragStartWind;
 	FName DragStartPropertyName;
 	float GustStrength;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorScriptingTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsEditorScriptingTest.cpp
@@ -33,12 +33,6 @@
 
 namespace
 {
-#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
-	using FKawaiiMcpCommentNode = UKawaiiPhysicsMcpCommentNode;
-#else
-	using FKawaiiMcpCommentNode = UEdGraphNode_Comment;
-#endif
-
 	const FGameplayTag& GetKawaiiPhysicsEditorScriptingTagA()
 	{
 		static const FGameplayTag Tag =
@@ -412,7 +406,11 @@ namespace
 		return Count;
 	}
 
-	FKawaiiMcpCommentNode* FindMcpCommentNode(UEdGraph* Graph, const FString& CommentText)
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+	UKawaiiPhysicsMcpCommentNode* FindMcpCommentNode(UEdGraph* Graph, const FString& CommentText)
+#else
+	UEdGraphNode_Comment* FindMcpCommentNode(UEdGraph* Graph, const FString& CommentText)
+#endif
 	{
 		if (!Graph)
 		{
@@ -421,10 +419,17 @@ namespace
 
 		for (UEdGraphNode* Node : Graph->Nodes)
 		{
-			FKawaiiMcpCommentNode* CommentNode = Cast<FKawaiiMcpCommentNode>(Node);
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+			UKawaiiPhysicsMcpCommentNode* CommentNode = Cast<UKawaiiPhysicsMcpCommentNode>(Node);
 			if (CommentNode &&
-				CommentNode->GetClass() == FKawaiiMcpCommentNode::StaticClass() &&
+				CommentNode->GetClass() == UKawaiiPhysicsMcpCommentNode::StaticClass() &&
 				CommentNode->NodeComment == CommentText)
+#else
+			UEdGraphNode_Comment* CommentNode = Cast<UEdGraphNode_Comment>(Node);
+			if (CommentNode &&
+				CommentNode->GetClass() == UEdGraphNode_Comment::StaticClass() &&
+				CommentNode->NodeComment == CommentText)
+#endif
 			{
 				return CommentNode;
 			}
@@ -1174,7 +1179,11 @@ bool FKawaiiPhysicsEditorScriptingPlacementAutoConnectCommentFrameTest::RunTest(
 	}
 	bOk &= TestNotNull(TEXT("AutoConnectCommentFrame finds a spawned ComponentToLocalSpace node"), ConversionNode);
 
-	FKawaiiMcpCommentNode* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+	UKawaiiPhysicsMcpCommentNode* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
+#else
+	UEdGraphNode_Comment* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
+#endif
 	bOk &= TestNotNull(TEXT("AutoConnectCommentFrame finds the MCP comment node"), McpCommentNode);
 
 	if (ConversionNode && RootNode)
@@ -1664,12 +1673,13 @@ bool FKawaiiPhysicsEditorScriptingPlacementCommentTest::RunTest(const FString& P
 			NAME_None,
 			CommentText,
 			InitialPrompt);
-	FKawaiiMcpCommentNode* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
 #if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
+	UKawaiiPhysicsMcpCommentNode* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
 	FDateTime InitialCommentCreatedAt;
 	FDateTime InitialCommentUpdatedAt;
 	const int32 ExpectedCommentNodeCount = 2;
 #else
+	UEdGraphNode_Comment* McpCommentNode = FindMcpCommentNode(Fixture.AnimGraph, ExpectedTitle);
 	const int32 ExpectedCommentNodeCount = 1;
 #endif
 
@@ -1683,8 +1693,13 @@ bool FKawaiiPhysicsEditorScriptingPlacementCommentTest::RunTest(const FString& P
 	                FirstHandles.IsValidIndex(0) && FirstHandles[0].IsValid());
 	bOk &= TestTrue(TEXT("Second comment handle is valid"),
 	                FirstHandles.IsValidIndex(1) && FirstHandles[1].IsValid());
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
 	bOk &= TestEqual(TEXT("Exactly one MCP comment node is created"),
-	                 CountExactNodesOfClass(Fixture.AnimGraph, FKawaiiMcpCommentNode::StaticClass()), 1);
+	                 CountExactNodesOfClass(Fixture.AnimGraph, UKawaiiPhysicsMcpCommentNode::StaticClass()), 1);
+#else
+	bOk &= TestEqual(TEXT("Exactly one MCP comment node is created"),
+	                 CountExactNodesOfClass(Fixture.AnimGraph, UEdGraphNode_Comment::StaticClass()), 1);
+#endif
 	bOk &= TestEqual(TEXT("Comment frame count matches supported node mode"),
 	                 CountNodesOfClass(Fixture.AnimGraph, UEdGraphNode_Comment::StaticClass()), ExpectedCommentNodeCount);
 	bOk &= TestNotNull(TEXT("MCP comment node is found by title"), McpCommentNode);
@@ -1748,8 +1763,13 @@ bool FKawaiiPhysicsEditorScriptingPlacementCommentTest::RunTest(const FString& P
 	                SecondHandles.IsValidIndex(0) && SecondHandles[0].IsValid());
 	bOk &= TestTrue(TEXT("Second comment upsert handle is valid"),
 	                SecondHandles.IsValidIndex(1) && SecondHandles[1].IsValid());
+#if KAWAII_PHYSICS_MCP_COMMENT_NODE_SUPPORTED
 	bOk &= TestEqual(TEXT("Comment upsert keeps one MCP comment"),
-	                 CountExactNodesOfClass(Fixture.AnimGraph, FKawaiiMcpCommentNode::StaticClass()), 1);
+	                 CountExactNodesOfClass(Fixture.AnimGraph, UKawaiiPhysicsMcpCommentNode::StaticClass()), 1);
+#else
+	bOk &= TestEqual(TEXT("Comment upsert keeps one MCP comment"),
+	                 CountExactNodesOfClass(Fixture.AnimGraph, UEdGraphNode_Comment::StaticClass()), 1);
+#endif
 	bOk &= TestEqual(TEXT("Comment upsert keeps expected comment frame count"),
 	                 CountNodesOfClass(Fixture.AnimGraph, UEdGraphNode_Comment::StaticClass()), ExpectedCommentNodeCount);
 	bOk &= TestEqual(TEXT("Comment upsert keeps KawaiiPhysics node count unchanged"),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsPresetDiffSnapshotTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsPresetDiffSnapshotTest.cpp
@@ -283,7 +283,7 @@ bool FKawaiiPhysicsPresetDiffSnapshotClipboardTest::RunTest(const FString& Param
 	}
 
 	const FText ContextLabel = FText::FromString(TEXT("PresetDiffSnapshotClipboardContext"));
-	const FString ClipboardText = KawaiiPhysicsPresetDiff::SnapshotToClipboardText(*Snapshot, ContextLabel);
+	const FString ClipboardText = KawaiiPhysicsPresetDiff::MakeClipboardTextFromSnapshot(*Snapshot, ContextLabel);
 
 	bool bOk = true;
 	bOk &= TestTrue(TEXT("Clipboard text contains header"),

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/Tests/KawaiiPhysicsWindScopeEditPanelTest.cpp
@@ -38,7 +38,7 @@ bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Par
 	TSet<FName> GroupIds;
 	const FKawaiiPhysics_ExternalForce_ProceduralWind DefaultWind;
 
-	for (const FKawaiiWindScopeParamGroup& Group : GetWindScopeParamGroups())
+	for (const FKawaiiPhysicsWindScopeParamGroup& Group : GetWindScopeParamGroups())
 	{
 		bOk &= TestFalse(
 			FString::Printf(TEXT("Wind Scope edit group ID is set: %s"), *Group.GroupLabel.ToString()),
@@ -56,10 +56,10 @@ bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Par
 				Group.SummaryItems.Num() > 0);
 		}
 
-		for (const FKawaiiWindScopeSummaryItem& SummaryItem : Group.SummaryItems)
+		for (const FKawaiiPhysicsWindScopeSummaryItem& SummaryItem : Group.SummaryItems)
 		{
 			bool bSummaryItemPropertyExistsInGroup = false;
-			for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+			for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 			{
 				if (Param.PropertyName == SummaryItem.PropertyName)
 				{
@@ -91,8 +91,8 @@ bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Par
 					CastField<FFloatProperty>(SummaryItemProperty));
 			}
 
-			if (SummaryItem.Unit == EKawaiiWindScopeSummaryUnit::Seconds ||
-				SummaryItem.Unit == EKawaiiWindScopeSummaryUnit::Degrees)
+			if (SummaryItem.Unit == EKawaiiPhysicsWindScopeSummaryUnit::Seconds ||
+				SummaryItem.Unit == EKawaiiPhysicsWindScopeSummaryUnit::Degrees)
 			{
 				const bool bSupportedSummaryUnitType =
 					CastField<FFloatProperty>(SummaryItemProperty) ||
@@ -104,7 +104,7 @@ bool FKawaiiPhysicsWindScopeEditPanelDefinitionsTest::RunTest(const FString& Par
 			}
 		}
 
-		for (const FKawaiiWindScopeParamDef& Param : Group.Params)
+		for (const FKawaiiPhysicsWindScopeParamDef& Param : Group.Params)
 		{
 			FProperty* Property = FindWindScopeTestProperty(Param.PropertyName);
 			bOk &= TestNotNull(

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/AnimGraphNode_KawaiiPhysics.h
@@ -122,7 +122,7 @@ public:
 
 	/** Enables or disables debug drawing for planar limits. */
 	UPROPERTY()
-	bool bEnableDebugDrawPlanerLimit = true;
+	bool bEnableDebugDrawPlanarLimit = true;
 
 	/** Enables or disables debug drawing for bone constraints. */
 	UPROPERTY()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEditMode.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Public/KawaiiPhysicsEditMode.h
@@ -60,7 +60,7 @@ private:
 	void RenderCapsuleLimit(FPrimitiveDrawInterface* PDI) const;
 	void RenderTaperedCapsuleLimit(FPrimitiveDrawInterface* PDI) const;
 	void RenderBoxLimit(FPrimitiveDrawInterface* PDI) const;
-	void RenderPlanerLimit(FPrimitiveDrawInterface* PDI);
+	void RenderPlanarLimit(FPrimitiveDrawInterface* PDI) const;
 
 	void RenderBoneConstraint(FPrimitiveDrawInterface* PDI) const;
 	void RenderExternalForces(FPrimitiveDrawInterface* PDI) const;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerMultiplierRegistry.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/KawaiiPhysicsSequencerMultiplierRegistry.cpp
@@ -210,7 +210,7 @@ void FKawaiiPhysicsSequencerMultiplierRegistry::StopForSectionsNotIn(
 	}
 }
 
-void FKawaiiPhysicsSequencerMultiplierRegistry::PruneInvalidEntries()
+void FKawaiiPhysicsSequencerMultiplierRegistry::RemoveInvalidEntries()
 {
 	for (auto It = Entries.CreateIterator(); It; ++It)
 	{
@@ -331,7 +331,7 @@ void FKawaiiPhysicsSequencerMultiplierRegistry::HandleWorldCleanup(
 void FKawaiiPhysicsSequencerMultiplierRegistry::HandlePostGarbageCollect()
 {
 	// GC 後デリゲートは GameThread 前提で呼ばれるため、Registry 側も既存方針どおり GameThread 限定で扱う
-	PruneInvalidEntries();
+	RemoveInvalidEntries();
 }
 
 #if WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
@@ -469,11 +469,11 @@ bool FKawaiiPhysicsSequencerRegistryStopForSectionsNotInTest::RunTest(const FStr
 	return bOk;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryPruneInvalidEntriesTest,
-                                 "KawaiiPhysics.Sequencer.Section.Registry_PruneInvalidEntries",
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSequencerRegistryRemoveInvalidEntriesTest,
+                                 "KawaiiPhysics.Sequencer.Section.Registry_RemoveInvalidEntries",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
-bool FKawaiiPhysicsSequencerRegistryPruneInvalidEntriesTest::RunTest(const FString& Parameters)
+bool FKawaiiPhysicsSequencerRegistryRemoveInvalidEntriesTest::RunTest(const FString& Parameters)
 {
 	UMovieSceneKawaiiPhysicsSettingsMultiplierSection* Section = NewSection();
 	{
@@ -483,8 +483,8 @@ bool FKawaiiPhysicsSequencerRegistryPruneInvalidEntriesTest::RunTest(const FStri
 		          FKawaiiPhysicsSequencerMultiplierRegistry::Get().CountEntriesForSectionForTesting(Section), 1);
 	}
 
-	FKawaiiPhysicsSequencerMultiplierRegistry::Get().PruneInvalidEntries();
-	return TestEqual(TEXT("Invalid entry pruned"),
+	FKawaiiPhysicsSequencerMultiplierRegistry::Get().RemoveInvalidEntries();
+	return TestEqual(TEXT("Invalid entry removed"),
 	                 FKawaiiPhysicsSequencerMultiplierRegistry::Get().CountEntriesForSectionForTesting(Section), 0);
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/KawaiiPhysicsSequencerMultiplierRegistry.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/KawaiiPhysicsSequencerMultiplierRegistry.h
@@ -41,7 +41,7 @@ public:
 	void StopForSection(const UMovieSceneSection* Section, const TWeakPtr<uint8>& OwnerFilter, const USkeletalMeshComponent* ComponentFilter);
 	void StopForWorld(const UWorld* World);
 	void StopForSectionsNotIn(const UMovieSceneTrack* Track, TConstArrayView<UMovieSceneSection*> LiveSections);
-	void PruneInvalidEntries();
+	void RemoveInvalidEntries();
 	// 現在のフィルタと一致する生存 Entry の LastQueuedNodeCount 合計（適用済み数ではない）。生存 Entry が無ければ bOutHasLiveEntry=false（未評価と 0 件を区別するため）
 	int32 GetQueuedNodeCount(
 		const UMovieSceneSection* Section,


### PR DESCRIPTION
## 概要
BP互換に影響しない内部の非 UE 的な命名を是正する。挙動の変更はなし（機械的な改名のみ）。

## 変更内容
- typo `Planer` → `Planar`（`UpdatePlanarLimits` / `AdjustByPlanarCollision` / `RenderPlanarLimit`（const 化）/ STAT 名 / `bEnableDebugDrawPlanarLimit`）。AnimGraphNode の UPROPERTY 改名は `DefaultKawaiiPhysics.ini` の `PropertyRedirects` で既存アセットの値を引き継ぐ
- `CallAnimNodeFunction` の名前文字列 `TEXT("Setb…")` 4 件を UFUNCTION 名に一致させる
- `using FKawaiiMcpCommentNode = U…` エイリアス（UObject に F 接頭辞）を廃止し実名を使用
- 動詞なしの関数名を是正: `NoiseValueAt` → `SampleNoiseAt`、`StableHash` → `ComputeStableHash`、`SnapshotToClipboardText` → `MakeClipboardTextFromSnapshot`、`CalculateMcpCommentBounds` → `ComputeMcpCommentBounds`
- GC 用途の `Sweep` を役割どおりの動詞に変更（`CleanupStaleStates` = 放置された帳簿の掃除 / `ConsumeAndRemoveExpiredTransientExternalForces` = 期限切れ一時外力の除去＋キュー消費）。UE の `Sweep` は形状スイープの意味
- エディタ私的型 11 件の `FKawaii…` → `FKawaiiPhysics…`（Wind Scope 系 / `FKawaiiPhysicsTagNameFilter`）
- `UAnimNotify_KawaiiPhysicsAddExternalForce` の DisplayName を「KawaiiPhysics: Add ExternalForce (Pulse)」にし、NotifyState と同名だった衝突を解消
- namespace `KawaiiPhysicsMirror` → `KawaiiPhysicsMirrorUtils`（ファイル名と一致）

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 224/224（フィルタ: KawaiiPhysics）
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件（WARN 0 件）
- PIE: docs/pie/INDEX.md に 2 項目登録（PropertyRedirect の値引き継ぎ / Add Notify メニューの別名表示）、未
- 性能: ホットパスのロジック変更なし（性能ベンチ 不要）
