### PR TITLE
[add] PhysicsAsset mode for Simple World Collision skeletal meshes

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -124,6 +124,10 @@ TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxPhysicsAssetBodies(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies"), -1,
 	TEXT("-1でDeveloperSettingsの値を使用。0でPhysicsAssetモードのSkeletalMeshを収集しない。1以上でSkelComp単位最大body数を上書き / "
 		"-1 uses the DeveloperSettings value; 0 does not gather SkeletalMeshes in PhysicsAsset mode; >=1 overrides the max PhysicsAsset bodies per SkelComp."));
+TAutoConsoleVariable<int32> CVarSimpleWorldCollisionRegatherOnScaleChange(
+	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.RegatherOnScaleChange"), -1,
+	TEXT("-1でDeveloperSettingsの値を使用。0で無効、1でスケール変化時に再収集 / "
+		"-1 uses the DeveloperSettings value; 0 disables, 1 re-gathers on scale change."));
 TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.CleanupMaxAge"), 60,
 	TEXT("SimpleWorld Entry/Descのエイジアウト閾値（フレーム数） / Age-out threshold (in frames) for SimpleWorld entries/descs."));

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -120,6 +120,10 @@ TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxComponents(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxComponents"), -1,
 	TEXT("-1でDeveloperSettingsの値を使用。0以上でSkelComp単位の最大収集コンポーネント数を上書き / "
 		"-1 uses the DeveloperSettings value; >=0 overrides the max gathered components per SkelComp."));
+TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxPhysicsAssetBodies(
+	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies"), -1,
+	TEXT("-1でDeveloperSettingsの値を使用。0以上でPhysicsAssetモードのSkelComp単位最大body数を上書き / "
+		"-1 uses the DeveloperSettings value; >=0 overrides the max PhysicsAsset bodies per SkelComp."));
 TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.CleanupMaxAge"), 60,
 	TEXT("SimpleWorld Entry/Descのエイジアウト閾値（フレーム数） / Age-out threshold (in frames) for SimpleWorld entries/descs."));

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -122,8 +122,8 @@ TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxComponents(
 		"-1 uses the DeveloperSettings value; >=0 overrides the max gathered components per SkelComp."));
 TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxPhysicsAssetBodies(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies"), -1,
-	TEXT("-1でDeveloperSettingsの値を使用。0以上でPhysicsAssetモードのSkelComp単位最大body数を上書き / "
-		"-1 uses the DeveloperSettings value; >=0 overrides the max PhysicsAsset bodies per SkelComp."));
+	TEXT("-1でDeveloperSettingsの値を使用。0でPhysicsAssetモードのSkeletalMeshを収集しない。1以上でSkelComp単位最大body数を上書き / "
+		"-1 uses the DeveloperSettings value; 0 does not gather SkeletalMeshes in PhysicsAsset mode; >=1 overrides the max PhysicsAsset bodies per SkelComp."));
 TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.CleanupMaxAge"), 60,
 	TEXT("SimpleWorld Entry/Descのエイジアウト閾値（フレーム数） / Age-out threshold (in frames) for SimpleWorld entries/descs."));

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -360,6 +360,7 @@ extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionEnable;
 extern TAutoConsoleVariable<float> CVarSimpleWorldCollisionGatherIntervalScale;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxComponents;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxPhysicsAssetBodies;
+extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionRegatherOnScaleChange;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionDebugDraw;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionForceEnableOnServer;
@@ -841,6 +842,10 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 	const int32 EffectiveMaxPhysicsAssetBodies = MaxPhysicsAssetBodiesCVarValue >= 0
 		? MaxPhysicsAssetBodiesCVarValue
 		: KawaiiSettings->SimpleWorldCollisionMaxPhysicsAssetBodies;
+	const int32 RegatherOnScaleChangeCVarValue = CVarSimpleWorldCollisionRegatherOnScaleChange.GetValueOnGameThread();
+	const bool bRegatherOnScaleChange = RegatherOnScaleChangeCVarValue >= 0
+		? RegatherOnScaleChangeCVarValue != 0
+		: KawaiiSettings->bSimpleWorldCollisionRegatherOnScaleChange;
 #if ENABLE_DRAW_DEBUG
 	const bool bDebugDraw = CVarSimpleWorldCollisionDebugDraw.GetValueOnGameThread() != 0;
 #endif
@@ -984,6 +989,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 				NewComponent.InstanceIndex = InstanceIndex;
 				NewComponent.bStatic = (Component->GetMobility() == EComponentMobility::Static);
 				NewComponent.FadeAlpha = Entry->bHasGatheredOnce ? 0.0f : 1.0f;
+				NewComponent.GatheredScale3D = Scale3D;
 
 				if (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent* ExistingComponent =
 					Entry->GatheredComponents.FindByPredicate(
@@ -1082,8 +1088,12 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 					continue;
 				}
 
+				// SkinnedAsset / PhysicsAsset の差し替え、および（opt-in 時の）コンポーネントスケール変化は
+				// 焼き込み済み Limit と食い違うため次 Tick で再収集する
 				if (SkeletalComponent->GetSkinnedAsset() != ComponentIt->GatheredSkinnedAsset.Get()
-					|| SkeletalComponent->GetPhysicsAsset() != ComponentIt->GatheredPhysicsAsset.Get())
+					|| SkeletalComponent->GetPhysicsAsset() != ComponentIt->GatheredPhysicsAsset.Get()
+					|| (bRegatherOnScaleChange
+						&& !SkeletalComponent->GetComponentScale().Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER)))
 				{
 					ComponentIt.RemoveCurrent();
 					Entry->TimeSinceLastGather = FLT_MAX;
@@ -1132,6 +1142,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 			if (!ComponentIt->bStatic)
 			{
 				FTransform CurrentComponentTM = GetScaleStrippedComponentTransform(*Component);
+				FVector CurrentScale3D = Component->GetComponentScale();
 				if (ComponentIt->InstanceIndex != INDEX_NONE)
 				{
 					const UInstancedStaticMeshComponent* ISMComponent =
@@ -1155,6 +1166,16 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 						continue;
 					}
 					CurrentComponentTM = GetScaleStrippedKawaiiPhysicsSimpleWorldInstanceTransform(InstanceTM);
+					CurrentScale3D = InstanceTM.GetScale3D();
+				}
+
+				// opt-in 時、スケール変化は焼き込み済み Limit と食い違うため次 Tick で再収集する
+				if (bRegatherOnScaleChange && !CurrentScale3D.Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER))
+				{
+					ComponentIt.RemoveCurrent();
+					Entry->TimeSinceLastGather = FLT_MAX;
+					bDirty = true;
+					continue;
 				}
 
 				if (!ComponentIt->LastComponentTM.Equals(CurrentComponentTM, KINDA_SMALL_NUMBER))

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -27,6 +27,14 @@ namespace
 	constexpr float GSimpleWorldGroundBoxHalfThickness = 10.0f;
 	const FName GSimpleWorldIgnoreTagName(TEXT("KawaiiPhysics.IgnoreSimpleWorldCollision"));
 
+	// SkeletalMeshComponentのPhysicsAsset収集結果。BoundsBoxフォールバック可否を区別する。
+	enum class EKawaiiPhysicsSimpleWorldSkeletalBuildResult : uint8
+	{
+		Built,
+		NoPhysicsAssetData,
+		NoAcceptedBodies,
+	};
+
 	void InitializeGatheredSimpleWorldLimit(FCollisionLimitBase& Limit)
 	{
 		Limit.bEnable = true;
@@ -112,7 +120,7 @@ namespace
 		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
 		TArray<KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding>& OutBodyBindings);
 
-	bool BuildSkeletalLocalLimitsForSimpleWorldComponent(
+	EKawaiiPhysicsSimpleWorldSkeletalBuildResult BuildSkeletalLocalLimitsForSimpleWorldComponent(
 		const USkeletalMeshComponent& SkelComp,
 		const FVector& Scale3D,
 		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
@@ -127,7 +135,7 @@ namespace
 		const USkinnedAsset* SkinnedAsset = SkelComp.GetSkinnedAsset();
 		if (!PhysicsAsset || !SkinnedAsset || SkelComp.GetNumComponentSpaceTransforms() == 0)
 		{
-			return false;
+			return EKawaiiPhysicsSimpleWorldSkeletalBuildResult::NoPhysicsAssetData;
 		}
 
 		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
@@ -139,7 +147,9 @@ namespace
 			OutLocalLimits,
 			OutBodyBindings);
 
-		return NumBodies > 0;
+		return NumBodies > 0
+			? EKawaiiPhysicsSimpleWorldSkeletalBuildResult::Built
+			: EKawaiiPhysicsSimpleWorldSkeletalBuildResult::NoAcceptedBodies;
 	}
 
 	bool BuildLocalLimitsForSimpleWorldComponent(
@@ -168,14 +178,23 @@ namespace
 				return false;
 			}
 
-			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::PhysicsAsset
-				&& BuildSkeletalLocalLimitsForSimpleWorldComponent(
-					*SkelComp, Scale3D, Desc, MaxPhysicsAssetBodies, OutLocalLimits, OutBodyBindings))
+			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::PhysicsAsset)
 			{
-				return true;
+				const EKawaiiPhysicsSimpleWorldSkeletalBuildResult BuildResult =
+					BuildSkeletalLocalLimitsForSimpleWorldComponent(
+						*SkelComp, Scale3D, Desc, MaxPhysicsAssetBodies, OutLocalLimits, OutBodyBindings);
+				if (BuildResult == EKawaiiPhysicsSimpleWorldSkeletalBuildResult::Built)
+				{
+					return true;
+				}
+				if (BuildResult == EKawaiiPhysicsSimpleWorldSkeletalBuildResult::NoAcceptedBodies)
+				{
+					// PhysicsAsset があるのに採用 body が 0 なのは作者が意図的にコリジョンを切っている状態なので Box 化しない。
+					return false;
+				}
 			}
 
-			// PhysicsAsset未設定、SkinnedAsset未設定、ComponentSpaceTransforms未生成、または採用bodyなしの場合はBoundsBoxへフォールバックする。
+			// PhysicsAsset未設定、SkinnedAsset未設定、ComponentSpaceTransforms未生成の場合はBoundsBoxへフォールバックする。
 			KawaiiPhysicsSimpleWorldCollision::AppendBoundsLocalLimits(
 				Component.Bounds,
 				ComponentTM,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -114,6 +114,7 @@ namespace
 
 	bool BuildSkeletalLocalLimitsForSimpleWorldComponent(
 		const USkeletalMeshComponent& SkelComp,
+		const FVector& Scale3D,
 		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
 		int32 MaxPhysicsAssetBodies,
 		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
@@ -132,7 +133,7 @@ namespace
 		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
 			*PhysicsAsset,
 			SkinnedAsset->GetRefSkeleton(),
-			SkelComp.GetComponentScale(),
+			Scale3D,
 			Desc.ComplexShapeApproximation,
 			MaxPhysicsAssetBodies,
 			OutLocalLimits,
@@ -161,8 +162,15 @@ namespace
 			}
 
 			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::PhysicsAsset
+				&& MaxPhysicsAssetBodies <= 0)
+			{
+				// CVarの0指定はPhysicsAssetモードのSkeletalMesh収集を丸ごと止める安全弁として扱う。
+				return false;
+			}
+
+			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::PhysicsAsset
 				&& BuildSkeletalLocalLimitsForSimpleWorldComponent(
-					*SkelComp, Desc, MaxPhysicsAssetBodies, OutLocalLimits, OutBodyBindings))
+					*SkelComp, Scale3D, Desc, MaxPhysicsAssetBodies, OutLocalLimits, OutBodyBindings))
 			{
 				return true;
 			}
@@ -818,6 +826,8 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 	const bool bDebugDraw = CVarSimpleWorldCollisionDebugDraw.GetValueOnGameThread() != 0;
 #endif
 
+	int32 TotalGatheredComponents = 0;
+	int32 TotalSkeletalBodies = 0;
 	for (const FSimpleWorldTickEntry& TickEntry : Entries)
 	{
 		const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>& Entry = TickEntry.Entry;
@@ -1179,7 +1189,18 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 			DrawSimpleWorldCollisionDebug(*World, Center, Radius, *Entry);
 		}
 #endif
+
+		TotalGatheredComponents += Entry->GatheredComponents.Num();
+		for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent :
+			Entry->GatheredComponents)
+		{
+			TotalSkeletalBodies += GatheredComponent.BodyBindings.Num();
+		}
 	}
+
+	// DWORDカウンタは毎フレームリセットされるため、CleanupゲートではなくSimpleWorldのTickごとに更新する。
+	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, TotalGatheredComponents);
+	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, TotalSkeletalBodies);
 }
 
 void UKawaiiPhysicsSharedCollisionSubsystem::Deinitialize()
@@ -1248,8 +1269,6 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Tick(float DeltaTime)
 		FWriteScopeLock SimpleWorldWriteLock(SimpleWorldRegistryLock);
 		const int32 SimpleWorldCleanupMaxAge = CVarSimpleWorldCollisionCleanupMaxAge.GetValueOnGameThread();
 
-		int32 TotalGatheredComponents = 0;
-		int32 TotalSkeletalBodies = 0;
 		for (auto It = SimpleWorldRegistry.CreateIterator(); It; ++It)
 		{
 			if (!It->Key.IsValid() || !It->Value.IsValid())
@@ -1264,16 +1283,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Tick(float DeltaTime)
 				It.RemoveCurrent();
 				continue;
 			}
-
-			TotalGatheredComponents += It->Value->GatheredComponents.Num();
-			for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent :
-				It->Value->GatheredComponents)
-			{
-				TotalSkeletalBodies += GatheredComponent.BodyBindings.Num();
-			}
 		}
-		SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, TotalGatheredComponents);
-		SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, TotalSkeletalBodies);
 	}
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -11,10 +11,12 @@
 #include "Components/SkeletalMeshComponent.h"
 #include "DrawDebugHelpers.h"
 #include "Engine/OverlapResult.h"
+#include "Engine/SkinnedAsset.h"
 #include "Engine/World.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/PlayerController.h"
 #include "PhysicsEngine/BodySetup.h"
+#include "PhysicsEngine/PhysicsAsset.h"
 
 namespace
 {
@@ -106,18 +108,66 @@ namespace
 		const FTransform& ComponentTM,
 		const FVector& Scale3D,
 		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
-		FKawaiiPhysicsSharedCollisionData& OutLocalLimits)
+		int32 MaxPhysicsAssetBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding>& OutBodyBindings);
+
+	bool BuildSkeletalLocalLimitsForSimpleWorldComponent(
+		const USkeletalMeshComponent& SkelComp,
+		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+		int32 MaxPhysicsAssetBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding>& OutBodyBindings)
 	{
 		OutLocalLimits.Reset();
+		OutBodyBindings.Reset();
 
-		if (Cast<const USkeletalMeshComponent>(&Component))
+		const UPhysicsAsset* PhysicsAsset = SkelComp.GetPhysicsAsset();
+		const USkinnedAsset* SkinnedAsset = SkelComp.GetSkinnedAsset();
+		if (!PhysicsAsset || !SkinnedAsset || SkelComp.GetNumComponentSpaceTransforms() == 0)
+		{
+			return false;
+		}
+
+		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
+			*PhysicsAsset,
+			SkinnedAsset->GetRefSkeleton(),
+			SkelComp.GetComponentScale(),
+			Desc.ComplexShapeApproximation,
+			MaxPhysicsAssetBodies,
+			OutLocalLimits,
+			OutBodyBindings);
+
+		return NumBodies > 0;
+	}
+
+	bool BuildLocalLimitsForSimpleWorldComponent(
+		UPrimitiveComponent& Component,
+		const FTransform& ComponentTM,
+		const FVector& Scale3D,
+		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+		int32 MaxPhysicsAssetBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding>& OutBodyBindings)
+	{
+		OutLocalLimits.Reset();
+		OutBodyBindings.Reset();
+
+		if (const USkeletalMeshComponent* SkelComp = Cast<const USkeletalMeshComponent>(&Component))
 		{
 			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::Ignore)
 			{
 				return false;
 			}
 
-			// PhysicsAsset は Phase 2a では BoundsBox と同じ扱い。Phase 3以降でbone transform込み変換を実装する。
+			if (Desc.SkeletalMeshMode == EKawaiiPhysicsSimpleWorldSkeletalMeshMode::PhysicsAsset
+				&& BuildSkeletalLocalLimitsForSimpleWorldComponent(
+					*SkelComp, Desc, MaxPhysicsAssetBodies, OutLocalLimits, OutBodyBindings))
+			{
+				return true;
+			}
+
+			// PhysicsAsset未設定、SkinnedAsset未設定、ComponentSpaceTransforms未生成、または採用bodyなしの場合はBoundsBoxへフォールバックする。
 			KawaiiPhysicsSimpleWorldCollision::AppendBoundsLocalLimits(
 				Component.Bounds,
 				ComponentTM,
@@ -140,6 +190,57 @@ namespace
 	}
 
 #if ENABLE_DRAW_DEBUG
+	void DrawKawaiiPhysicsSimpleWorldLimitRange(
+		const UWorld& World,
+		const FKawaiiPhysicsSharedCollisionData& LocalLimits,
+		int32 SphereOffset,
+		int32 NumSpheres,
+		int32 CapsuleOffset,
+		int32 NumCapsules,
+		int32 TaperedCapsuleOffset,
+		int32 NumTaperedCapsules,
+		int32 BoxOffset,
+		int32 NumBoxes,
+		const FTransform& Transform,
+		const FColor& ShapeColor)
+	{
+		constexpr float ShapeThickness = 1.5f;
+		constexpr uint8 DepthPriority = 0;
+
+		for (int32 LimitIndex = 0; LimitIndex < NumSpheres; ++LimitIndex)
+		{
+			const FSphericalLimit& Limit = LocalLimits.SphericalLimits[SphereOffset + LimitIndex];
+			const FVector LocationWS = Transform.TransformPosition(Limit.Location);
+			DrawDebugSphere(&World, LocationWS, Limit.Radius, 12, ShapeColor, false, -1.0f, DepthPriority,
+				ShapeThickness);
+		}
+		for (int32 LimitIndex = 0; LimitIndex < NumCapsules; ++LimitIndex)
+		{
+			const FCapsuleLimit& Limit = LocalLimits.CapsuleLimits[CapsuleOffset + LimitIndex];
+			const FVector LocationWS = Transform.TransformPosition(Limit.Location);
+			const FQuat RotationWS = Transform.TransformRotation(Limit.Rotation);
+			DrawDebugCapsule(&World, LocationWS, Limit.Length * 0.5f, Limit.Radius, RotationWS, ShapeColor, false,
+				-1.0f, DepthPriority, ShapeThickness);
+		}
+		for (int32 LimitIndex = 0; LimitIndex < NumTaperedCapsules; ++LimitIndex)
+		{
+			const FTaperedCapsuleLimit& Limit = LocalLimits.TaperedCapsuleLimits[TaperedCapsuleOffset + LimitIndex];
+			const FVector LocationWS = Transform.TransformPosition(Limit.Location);
+			const FQuat RotationWS = Transform.TransformRotation(Limit.Rotation);
+			const float AverageRadius = (Limit.Radius0 + Limit.Radius1) * 0.5f;
+			DrawDebugCapsule(&World, LocationWS, Limit.Length * 0.5f, AverageRadius, RotationWS, ShapeColor, false,
+				-1.0f, DepthPriority, ShapeThickness);
+		}
+		for (int32 LimitIndex = 0; LimitIndex < NumBoxes; ++LimitIndex)
+		{
+			const FBoxLimit& Limit = LocalLimits.BoxLimits[BoxOffset + LimitIndex];
+			const FVector LocationWS = Transform.TransformPosition(Limit.Location);
+			const FQuat RotationWS = Transform.TransformRotation(Limit.Rotation);
+			DrawDebugBox(&World, LocationWS, Limit.Extent, RotationWS, ShapeColor, false, -1.0f, DepthPriority,
+				ShapeThickness);
+		}
+	}
+
 	// シンプルワールドコリジョンのデバッグ描画（GameThread専用）。収集済み形状はComponentローカル形状+ComponentTMから
 	// 描画時に都度ワールド変換する。フェード中はFadeAlphaに応じて薄い色にする（PublishScratchは半径縮小済みで
 	// アルファ情報が失われるため使わない）。地面Boxのみ別途Green表示する。
@@ -164,34 +265,51 @@ namespace
 			const FColor ShapeColor = FMath::Lerp(FLinearColor(0.0f, 0.35f, 0.35f), FLinearColor(0.0f, 1.0f, 1.0f), Alpha).
 				ToFColor(false);
 
-			for (const FSphericalLimit& Limit : Component.LocalLimits.SphericalLimits)
+			if (Component.BodyBindings.IsEmpty())
 			{
-				const FVector LocationWS = Component.LastComponentTM.TransformPosition(Limit.Location);
-				DrawDebugSphere(&World, LocationWS, Limit.Radius, 12, ShapeColor, false, -1.0f, DepthPriority,
-					ShapeThickness);
+				DrawKawaiiPhysicsSimpleWorldLimitRange(
+					World,
+					Component.LocalLimits,
+					0,
+					Component.LocalLimits.SphericalLimits.Num(),
+					0,
+					Component.LocalLimits.CapsuleLimits.Num(),
+					0,
+					Component.LocalLimits.TaperedCapsuleLimits.Num(),
+					0,
+					Component.LocalLimits.BoxLimits.Num(),
+					Component.LastComponentTM,
+					ShapeColor);
+				continue;
 			}
-			for (const FCapsuleLimit& Limit : Component.LocalLimits.CapsuleLimits)
+
+			int32 SphereOffset = 0;
+			int32 CapsuleOffset = 0;
+			int32 TaperedCapsuleOffset = 0;
+			int32 BoxOffset = 0;
+			const int32 NumBodies = FMath::Min(Component.BodyBindings.Num(), Component.LastBodyWorldTMs.Num());
+			for (int32 BodyIndex = 0; BodyIndex < NumBodies; ++BodyIndex)
 			{
-				const FVector LocationWS = Component.LastComponentTM.TransformPosition(Limit.Location);
-				const FQuat RotationWS = Component.LastComponentTM.TransformRotation(Limit.Rotation);
-				DrawDebugCapsule(&World, LocationWS, Limit.Length * 0.5f, Limit.Radius, RotationWS, ShapeColor, false,
-					-1.0f, DepthPriority, ShapeThickness);
-			}
-			for (const FTaperedCapsuleLimit& Limit : Component.LocalLimits.TaperedCapsuleLimits)
-			{
-				// DrawDebugCapsuleで近似（半径は両端の平均）
-				const FVector LocationWS = Component.LastComponentTM.TransformPosition(Limit.Location);
-				const FQuat RotationWS = Component.LastComponentTM.TransformRotation(Limit.Rotation);
-				const float AverageRadius = (Limit.Radius0 + Limit.Radius1) * 0.5f;
-				DrawDebugCapsule(&World, LocationWS, Limit.Length * 0.5f, AverageRadius, RotationWS, ShapeColor, false,
-					-1.0f, DepthPriority, ShapeThickness);
-			}
-			for (const FBoxLimit& Limit : Component.LocalLimits.BoxLimits)
-			{
-				const FVector LocationWS = Component.LastComponentTM.TransformPosition(Limit.Location);
-				const FQuat RotationWS = Component.LastComponentTM.TransformRotation(Limit.Rotation);
-				DrawDebugBox(&World, LocationWS, Limit.Extent, RotationWS, ShapeColor, false, -1.0f, DepthPriority,
-					ShapeThickness);
+				const KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding& Binding =
+					Component.BodyBindings[BodyIndex];
+				DrawKawaiiPhysicsSimpleWorldLimitRange(
+					World,
+					Component.LocalLimits,
+					SphereOffset,
+					Binding.NumSphericalLimits,
+					CapsuleOffset,
+					Binding.NumCapsuleLimits,
+					TaperedCapsuleOffset,
+					Binding.NumTaperedCapsuleLimits,
+					BoxOffset,
+					Binding.NumBoxLimits,
+					Component.LastBodyWorldTMs[BodyIndex],
+					ShapeColor);
+
+				SphereOffset += Binding.NumSphericalLimits;
+				CapsuleOffset += Binding.NumCapsuleLimits;
+				TaperedCapsuleOffset += Binding.NumTaperedCapsuleLimits;
+				BoxOffset += Binding.NumBoxLimits;
 			}
 		}
 
@@ -214,6 +332,7 @@ extern TAutoConsoleVariable<float> CVarSharedCollisionCleanupInterval;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionEnable;
 extern TAutoConsoleVariable<float> CVarSimpleWorldCollisionGatherIntervalScale;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxComponents;
+extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionMaxPhysicsAssetBodies;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionDebugDraw;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionForceEnableOnServer;
@@ -230,6 +349,7 @@ DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SharedCollision_NumSlots"), STAT_
 DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_Gather"), STAT_KawaiiPhysics_SimpleWorldCollision_Gather, STATGROUP_Anim);
 DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_UpdateTransforms"), STAT_KawaiiPhysics_SimpleWorldCollision_UpdateTransforms, STATGROUP_Anim);
 DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents"), STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, STATGROUP_Anim);
+DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies"), STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, STATGROUP_Anim);
 
 AActor* UKawaiiPhysicsSharedCollisionSubsystem::GetFamilyRoot(AActor* Actor)
 {
@@ -690,6 +810,10 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 	const int32 EffectiveMaxGatheredComponents = MaxComponentsCVarValue >= 0
 		? MaxComponentsCVarValue
 		: KawaiiSettings->SimpleWorldCollisionMaxGatheredComponents;
+	const int32 MaxPhysicsAssetBodiesCVarValue = CVarSimpleWorldCollisionMaxPhysicsAssetBodies.GetValueOnGameThread();
+	const int32 EffectiveMaxPhysicsAssetBodies = MaxPhysicsAssetBodiesCVarValue >= 0
+		? MaxPhysicsAssetBodiesCVarValue
+		: KawaiiSettings->SimpleWorldCollisionMaxPhysicsAssetBodies;
 #if ENABLE_DRAW_DEBUG
 	const bool bDebugDraw = CVarSimpleWorldCollisionDebugDraw.GetValueOnGameThread() != 0;
 #endif
@@ -845,9 +969,24 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 
 				NewComponent.LastComponentTM = ComponentTM;
 				if (!BuildLocalLimitsForSimpleWorldComponent(
-						*Component, NewComponent.LastComponentTM, Scale3D, Desc, NewComponent.LocalLimits))
+						*Component,
+						NewComponent.LastComponentTM,
+						Scale3D,
+						Desc,
+						EffectiveMaxPhysicsAssetBodies,
+						NewComponent.LocalLimits,
+						NewComponent.BodyBindings))
 				{
 					continue;
+				}
+
+				if (!NewComponent.BodyBindings.IsEmpty())
+				{
+					const USkeletalMeshComponent* GatheredSkelComp = Cast<const USkeletalMeshComponent>(Component);
+					NewComponent.SkeletalComponent = GatheredSkelComp;
+					NewComponent.GatheredSkinnedAsset = GatheredSkelComp ? GatheredSkelComp->GetSkinnedAsset() : nullptr;
+					NewComponent.GatheredPhysicsAsset = GatheredSkelComp ? GatheredSkelComp->GetPhysicsAsset() : nullptr;
+					NewComponent.bStatic = false;
 				}
 
 				NewGatheredComponents.Add(MoveTemp(NewComponent));
@@ -904,6 +1043,63 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 				bDirty = true;
 			}
 
+			if (!ComponentIt->BodyBindings.IsEmpty())
+			{
+				const USkeletalMeshComponent* SkeletalComponent = ComponentIt->SkeletalComponent.Get();
+				if (!SkeletalComponent)
+				{
+					ComponentIt.RemoveCurrent();
+					bDirty = true;
+					continue;
+				}
+
+				if (SkeletalComponent->GetSkinnedAsset() != ComponentIt->GatheredSkinnedAsset.Get()
+					|| SkeletalComponent->GetPhysicsAsset() != ComponentIt->GatheredPhysicsAsset.Get())
+				{
+					ComponentIt.RemoveCurrent();
+					Entry->TimeSinceLastGather = FLT_MAX;
+					bDirty = true;
+					continue;
+				}
+
+				// 相手SkelCompのPostAnimEvaluationとSubsystem Tickの順序次第で、ここで読むポーズは1フレーム前の可能性がある。
+				// Targetノード側ではPublish/Readの位相差も含めて最大2フレーム遅延し得る。
+				const TArray<FTransform>& ComponentSpaceTransforms = SkeletalComponent->GetComponentSpaceTransforms();
+				const int32 NumMissingBones = KawaiiPhysicsSimpleWorldCollision::UpdateSkeletalBodyWorldTransforms(
+					MakeArrayView(ComponentIt->BodyBindings),
+					MakeArrayView(ComponentSpaceTransforms),
+					SkeletalComponent->GetComponentTransform(),
+					ComponentIt->BodyWorldTMScratch);
+				if (NumMissingBones > 0)
+				{
+					ComponentIt.RemoveCurrent();
+					Entry->TimeSinceLastGather = FLT_MAX;
+					bDirty = true;
+					continue;
+				}
+
+				bool bBodyTransformsDirty = ComponentIt->LastBodyWorldTMs.Num() != ComponentIt->BodyWorldTMScratch.Num();
+				if (!bBodyTransformsDirty)
+				{
+					for (int32 BodyIndex = 0; BodyIndex < ComponentIt->LastBodyWorldTMs.Num(); ++BodyIndex)
+					{
+						if (!ComponentIt->LastBodyWorldTMs[BodyIndex].Equals(
+							ComponentIt->BodyWorldTMScratch[BodyIndex], KINDA_SMALL_NUMBER))
+						{
+							bBodyTransformsDirty = true;
+							break;
+						}
+					}
+				}
+
+				if (bBodyTransformsDirty)
+				{
+					Swap(ComponentIt->LastBodyWorldTMs, ComponentIt->BodyWorldTMScratch);
+					bDirty = true;
+				}
+				continue;
+			}
+
 			if (!ComponentIt->bStatic)
 			{
 				FTransform CurrentComponentTM = GetScaleStrippedComponentTransform(*Component);
@@ -947,12 +1143,25 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 			{
 				// フェード計算本体は KawaiiPhysicsSimpleWorldCollision 名前空間へ移設済み（単体テスト可能化のため）。
 				// しきい値定数はここ（Subsystem側）で保持したまま引数として渡す。
-				KawaiiPhysicsSimpleWorldCollision::AppendFadedLocalLimits(
-					Component.LocalLimits,
-					Component.FadeAlpha,
-					Component.LastComponentTM,
-					Entry->PublishScratch,
-					GSimpleWorldFadeBoxEnableThreshold);
+				if (!Component.BodyBindings.IsEmpty())
+				{
+					KawaiiPhysicsSimpleWorldCollision::AppendFadedSkeletalLocalLimits(
+						Component.LocalLimits,
+						MakeArrayView(Component.BodyBindings),
+						MakeArrayView(Component.LastBodyWorldTMs),
+						Component.FadeAlpha,
+						Entry->PublishScratch,
+						GSimpleWorldFadeBoxEnableThreshold);
+				}
+				else
+				{
+					KawaiiPhysicsSimpleWorldCollision::AppendFadedLocalLimits(
+						Component.LocalLimits,
+						Component.FadeAlpha,
+						Component.LastComponentTM,
+						Entry->PublishScratch,
+						GSimpleWorldFadeBoxEnableThreshold);
+				}
 			}
 
 			if (Entry->bHasGroundBox)
@@ -1040,6 +1249,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Tick(float DeltaTime)
 		const int32 SimpleWorldCleanupMaxAge = CVarSimpleWorldCollisionCleanupMaxAge.GetValueOnGameThread();
 
 		int32 TotalGatheredComponents = 0;
+		int32 TotalSkeletalBodies = 0;
 		for (auto It = SimpleWorldRegistry.CreateIterator(); It; ++It)
 		{
 			if (!It->Key.IsValid() || !It->Value.IsValid())
@@ -1056,8 +1266,14 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Tick(float DeltaTime)
 			}
 
 			TotalGatheredComponents += It->Value->GatheredComponents.Num();
+			for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent :
+				It->Value->GatheredComponents)
+			{
+				TotalSkeletalBodies += GatheredComponent.BodyBindings.Num();
+			}
 		}
 		SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, TotalGatheredComponents);
+		SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, TotalSkeletalBodies);
 	}
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
@@ -2,8 +2,14 @@
 
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 
+#include "Engine/EngineTypes.h"
+#include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
+
+#if !UE_VERSION_OLDER_THAN(5, 5, 0)
 #include "PhysicsEngine/SkeletalBodySetup.h"
+#endif
+
 #include "ReferenceSkeleton.h"
 
 namespace
@@ -66,6 +72,7 @@ namespace
 		int32 Offset,
 		int32 Num)
 	{
+		check(Offset >= 0 && Num >= 0 && Offset + Num <= Limits.Num());
 		return Num > 0
 			? TArrayView<const LimitType>(Limits.GetData() + Offset, Num)
 			: TArrayView<const LimitType>();
@@ -148,8 +155,14 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		FKawaiiPhysicsSharedCollisionData& OutLocalLimits)
 	{
 		OutLocalLimits.SphericalLimits.Reserve(OutLocalLimits.SphericalLimits.Num() + AggGeom.SphereElems.Num());
+		// Shape単位のQuery無効設定は静的コンポーネント経路でもここで除外する。
 		for (const auto& SphereElem : AggGeom.SphereElems)
 		{
+			if (!CollisionEnabledHasQuery(SphereElem.GetCollisionEnabled()))
+			{
+				continue;
+			}
+
 			const FKSphereElem ScaledElem = SphereElem.GetFinalScaled(Scale3D, FTransform::Identity);
 
 			FSphericalLimit NewLimit;
@@ -164,6 +177,11 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		OutLocalLimits.CapsuleLimits.Reserve(OutLocalLimits.CapsuleLimits.Num() + AggGeom.SphylElems.Num());
 		for (const auto& CapsuleElem : AggGeom.SphylElems)
 		{
+			if (!CollisionEnabledHasQuery(CapsuleElem.GetCollisionEnabled()))
+			{
+				continue;
+			}
+
 			const FKSphylElem ScaledElem = CapsuleElem.GetFinalScaled(Scale3D, FTransform::Identity);
 
 			FCapsuleLimit NewLimit;
@@ -178,6 +196,11 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		OutLocalLimits.TaperedCapsuleLimits.Reserve(OutLocalLimits.TaperedCapsuleLimits.Num() + AggGeom.TaperedCapsuleElems.Num());
 		for (const auto& TaperedCapsuleElem : AggGeom.TaperedCapsuleElems)
 		{
+			if (!CollisionEnabledHasQuery(TaperedCapsuleElem.GetCollisionEnabled()))
+			{
+				continue;
+			}
+
 			const FKTaperedCapsuleElem ScaledElem = TaperedCapsuleElem.GetFinalScaled(Scale3D, FTransform::Identity);
 
 			FTaperedCapsuleLimit NewLimit;
@@ -194,6 +217,11 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		OutLocalLimits.BoxLimits.Reserve(OutLocalLimits.BoxLimits.Num() + AggGeom.BoxElems.Num() + AggGeom.ConvexElems.Num());
 		for (const auto& BoxElem : AggGeom.BoxElems)
 		{
+			if (!CollisionEnabledHasQuery(BoxElem.GetCollisionEnabled()))
+			{
+				continue;
+			}
+
 			const FKBoxElem ScaledElem = BoxElem.GetFinalScaled(Scale3D, FTransform::Identity);
 
 			FBoxLimit NewLimit;
@@ -206,6 +234,11 @@ namespace KawaiiPhysicsSimpleWorldCollision
 
 		for (const auto& ConvexElem : AggGeom.ConvexElems)
 		{
+			if (!CollisionEnabledHasQuery(ConvexElem.GetCollisionEnabled()))
+			{
+				continue;
+			}
+
 			if (!ConvexElem.ElemBox.IsValid)
 			{
 				continue;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
@@ -2,6 +2,10 @@
 
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 
+#include "PhysicsEngine/PhysicsAsset.h"
+#include "PhysicsEngine/SkeletalBodySetup.h"
+#include "ReferenceSkeleton.h"
+
 namespace
 {
 	void InitializeSimpleWorldLimit(FCollisionLimitBase& Limit)
@@ -37,7 +41,7 @@ namespace
 
 	template <typename LimitType>
 	void AppendTransformedLimits(
-		const TArray<LimitType>& LocalLimits,
+		TArrayView<const LimitType> LocalLimits,
 		const FTransform& ComponentTM,
 		TArray<LimitType>& OutWorldLimits,
 		float RadiusScale = 1.0f)
@@ -54,6 +58,17 @@ namespace
 			ApplyRadiusScale(WorldLimit, RadiusScale);
 			OutWorldLimits.Add(WorldLimit);
 		}
+	}
+
+	template <typename LimitType>
+	TArrayView<const LimitType> MakeKawaiiPhysicsSimpleWorldLimitView(
+		const TArray<LimitType>& Limits,
+		int32 Offset,
+		int32 Num)
+	{
+		return Num > 0
+			? TArrayView<const LimitType>(Limits.GetData() + Offset, Num)
+			: TArrayView<const LimitType>();
 	}
 
 	void AppendTransformedPlanarLimits(
@@ -73,6 +88,22 @@ namespace
 			OutWorldLimits.Add(WorldLimit);
 		}
 	}
+
+	bool IsKawaiiPhysicsSimpleWorldCollisionAggGeomEmpty(const FKAggregateGeom& AggGeom)
+	{
+		return AggGeom.SphereElems.IsEmpty()
+			&& AggGeom.SphylElems.IsEmpty()
+			&& AggGeom.TaperedCapsuleElems.IsEmpty()
+			&& AggGeom.BoxElems.IsEmpty()
+			&& AggGeom.ConvexElems.IsEmpty();
+	}
+
+	struct FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate
+	{
+		const USkeletalBodySetup* BodySetup = nullptr;
+		int32 BoneIndex = INDEX_NONE;
+		int32 BodyIndex = INDEX_NONE;
+	};
 }
 
 namespace KawaiiPhysicsSimpleWorldCollision
@@ -222,11 +253,216 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		FKawaiiPhysicsSharedCollisionData& OutWorldLimits,
 		float RadiusScale)
 	{
-		AppendTransformedLimits(LocalLimits.SphericalLimits, ComponentTM, OutWorldLimits.SphericalLimits, RadiusScale);
-		AppendTransformedLimits(LocalLimits.CapsuleLimits, ComponentTM, OutWorldLimits.CapsuleLimits, RadiusScale);
-		AppendTransformedLimits(LocalLimits.TaperedCapsuleLimits, ComponentTM, OutWorldLimits.TaperedCapsuleLimits, RadiusScale);
-		AppendTransformedLimits(LocalLimits.BoxLimits, ComponentTM, OutWorldLimits.BoxLimits);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.SphericalLimits, 0, LocalLimits.SphericalLimits.Num()),
+			ComponentTM, OutWorldLimits.SphericalLimits, RadiusScale);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.CapsuleLimits, 0, LocalLimits.CapsuleLimits.Num()),
+			ComponentTM, OutWorldLimits.CapsuleLimits, RadiusScale);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(
+				LocalLimits.TaperedCapsuleLimits, 0, LocalLimits.TaperedCapsuleLimits.Num()),
+			ComponentTM, OutWorldLimits.TaperedCapsuleLimits, RadiusScale);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.BoxLimits, 0, LocalLimits.BoxLimits.Num()),
+			ComponentTM, OutWorldLimits.BoxLimits);
 		AppendTransformedPlanarLimits(LocalLimits.PlanarLimits, ComponentTM, OutWorldLimits.PlanarLimits);
+	}
+
+	bool AppendBodyLocalLimits(
+		const FKAggregateGeom& AggGeom,
+		int32 BoneIndex,
+		const FVector& Scale3D,
+		EKawaiiPhysicsComplexShapeApproximation ApproxMode,
+		int32 MaxBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding>& OutBindings)
+	{
+		if (BoneIndex == INDEX_NONE || MaxBodies <= 0 || OutBindings.Num() >= MaxBodies
+			|| IsKawaiiPhysicsSimpleWorldCollisionAggGeomEmpty(AggGeom))
+		{
+			return false;
+		}
+
+		const int32 SphereOffset = OutLocalLimits.SphericalLimits.Num();
+		const int32 CapsuleOffset = OutLocalLimits.CapsuleLimits.Num();
+		const int32 TaperedCapsuleOffset = OutLocalLimits.TaperedCapsuleLimits.Num();
+		const int32 BoxOffset = OutLocalLimits.BoxLimits.Num();
+
+		ConvertAggGeomToLocalLimits(AggGeom, Scale3D, ApproxMode, OutLocalLimits);
+
+		FKawaiiPhysicsSimpleWorldBodyBinding NewBinding;
+		NewBinding.BoneIndex = BoneIndex;
+		NewBinding.NumSphericalLimits = OutLocalLimits.SphericalLimits.Num() - SphereOffset;
+		NewBinding.NumCapsuleLimits = OutLocalLimits.CapsuleLimits.Num() - CapsuleOffset;
+		NewBinding.NumTaperedCapsuleLimits = OutLocalLimits.TaperedCapsuleLimits.Num() - TaperedCapsuleOffset;
+		NewBinding.NumBoxLimits = OutLocalLimits.BoxLimits.Num() - BoxOffset;
+
+		const int32 NumAddedLimits = NewBinding.NumSphericalLimits
+			+ NewBinding.NumCapsuleLimits
+			+ NewBinding.NumTaperedCapsuleLimits
+			+ NewBinding.NumBoxLimits;
+		if (NumAddedLimits == 0)
+		{
+			return false;
+		}
+
+		OutBindings.Add(NewBinding);
+		return true;
+	}
+
+	int32 AppendPhysicsAssetLocalLimits(
+		const UPhysicsAsset& PhysicsAsset,
+		const FReferenceSkeleton& RefSkeleton,
+		const FVector& Scale3D,
+		EKawaiiPhysicsComplexShapeApproximation ApproxMode,
+		int32 MaxBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding>& OutBindings)
+	{
+		if (MaxBodies <= 0)
+		{
+			return 0;
+		}
+
+		TArray<FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate> Candidates;
+		Candidates.Reserve(PhysicsAsset.SkeletalBodySetups.Num());
+
+		for (int32 BodyIndex = 0; BodyIndex < PhysicsAsset.SkeletalBodySetups.Num(); ++BodyIndex)
+		{
+			const USkeletalBodySetup* BodySetup = PhysicsAsset.SkeletalBodySetups[BodyIndex];
+			if (!BodySetup
+				|| BodySetup->CollisionReponse == EBodyCollisionResponse::BodyCollision_Disabled
+				|| IsKawaiiPhysicsSimpleWorldCollisionAggGeomEmpty(BodySetup->AggGeom))
+			{
+				continue;
+			}
+
+			const int32 BoneIndex = RefSkeleton.FindBoneIndex(BodySetup->BoneName);
+			if (BoneIndex == INDEX_NONE)
+			{
+				continue;
+			}
+
+			FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate Candidate;
+			Candidate.BodySetup = BodySetup;
+			Candidate.BoneIndex = BoneIndex;
+			Candidate.BodyIndex = BodyIndex;
+			Candidates.Add(Candidate);
+		}
+
+		Candidates.Sort([](
+			const FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate& Lhs,
+			const FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate& Rhs)
+		{
+			if (Lhs.BoneIndex != Rhs.BoneIndex)
+			{
+				return Lhs.BoneIndex < Rhs.BoneIndex;
+			}
+			return Lhs.BodyIndex < Rhs.BodyIndex;
+		});
+
+		const int32 InitialBindingCount = OutBindings.Num();
+		for (const FKawaiiPhysicsSimpleWorldPhysicsAssetBodyCandidate& Candidate : Candidates)
+		{
+			if (OutBindings.Num() >= MaxBodies)
+			{
+				break;
+			}
+
+			AppendBodyLocalLimits(
+				Candidate.BodySetup->AggGeom,
+				Candidate.BoneIndex,
+				Scale3D,
+				ApproxMode,
+				MaxBodies,
+				OutLocalLimits,
+				OutBindings);
+		}
+
+		return OutBindings.Num() - InitialBindingCount;
+	}
+
+	int32 UpdateSkeletalBodyWorldTransforms(
+		TArrayView<const FKawaiiPhysicsSimpleWorldBodyBinding> Bindings,
+		TArrayView<const FTransform> ComponentSpaceTransforms,
+		const FTransform& ComponentTM,
+		TArray<FTransform>& OutBodyWorldTMs)
+	{
+		OutBodyWorldTMs.SetNum(Bindings.Num());
+
+		int32 NumMissingBones = 0;
+		for (int32 BindingIndex = 0; BindingIndex < Bindings.Num(); ++BindingIndex)
+		{
+			const int32 BoneIndex = Bindings[BindingIndex].BoneIndex;
+			if (BoneIndex < 0 || BoneIndex >= ComponentSpaceTransforms.Num())
+			{
+				OutBodyWorldTMs[BindingIndex] = FTransform::Identity;
+				++NumMissingBones;
+				continue;
+			}
+
+			FTransform BodyWorldTM = ComponentSpaceTransforms[BoneIndex] * ComponentTM;
+			// コンポーネントスケールは収集時に形状サイズへ焼き込み、ここではbone平行移動へだけ反映する。
+			// アニメ由来のボーンスケールは形状サイズへ反映しない。
+			BodyWorldTM.SetScale3D(FVector::OneVector);
+			OutBodyWorldTMs[BindingIndex] = BodyWorldTM;
+		}
+
+		return NumMissingBones;
+	}
+
+	void AppendFadedSkeletalLocalLimits(
+		const FKawaiiPhysicsSharedCollisionData& LocalLimits,
+		TArrayView<const FKawaiiPhysicsSimpleWorldBodyBinding> Bindings,
+		TArrayView<const FTransform> BodyWorldTMs,
+		float FadeAlpha,
+		FKawaiiPhysicsSharedCollisionData& OutWorldLimits,
+		float BoxEnableThreshold)
+	{
+		int32 SphereOffset = 0;
+		int32 CapsuleOffset = 0;
+		int32 TaperedCapsuleOffset = 0;
+		int32 BoxOffset = 0;
+
+		const int32 NumBodies = FMath::Min(Bindings.Num(), BodyWorldTMs.Num());
+		for (int32 BodyIndex = 0; BodyIndex < NumBodies; ++BodyIndex)
+		{
+			const FKawaiiPhysicsSimpleWorldBodyBinding& Binding = Bindings[BodyIndex];
+			const FTransform& BodyWorldTM = BodyWorldTMs[BodyIndex];
+
+			AppendTransformedLimits(
+				MakeKawaiiPhysicsSimpleWorldLimitView(
+					LocalLimits.SphericalLimits, SphereOffset, Binding.NumSphericalLimits),
+				BodyWorldTM,
+				OutWorldLimits.SphericalLimits,
+				FadeAlpha);
+			AppendTransformedLimits(
+				MakeKawaiiPhysicsSimpleWorldLimitView(
+					LocalLimits.CapsuleLimits, CapsuleOffset, Binding.NumCapsuleLimits),
+				BodyWorldTM,
+				OutWorldLimits.CapsuleLimits,
+				FadeAlpha);
+			AppendTransformedLimits(
+				MakeKawaiiPhysicsSimpleWorldLimitView(
+					LocalLimits.TaperedCapsuleLimits, TaperedCapsuleOffset, Binding.NumTaperedCapsuleLimits),
+				BodyWorldTM,
+				OutWorldLimits.TaperedCapsuleLimits,
+				FadeAlpha);
+			if (FadeAlpha >= BoxEnableThreshold)
+			{
+				AppendTransformedLimits(
+					MakeKawaiiPhysicsSimpleWorldLimitView(
+						LocalLimits.BoxLimits, BoxOffset, Binding.NumBoxLimits),
+					BodyWorldTM,
+					OutWorldLimits.BoxLimits);
+			}
+
+			SphereOffset += Binding.NumSphericalLimits;
+			CapsuleOffset += Binding.NumCapsuleLimits;
+			TaperedCapsuleOffset += Binding.NumTaperedCapsuleLimits;
+			BoxOffset += Binding.NumBoxLimits;
+		}
 	}
 
 	void AppendFadedLocalLimits(
@@ -238,12 +474,21 @@ namespace KawaiiPhysicsSimpleWorldCollision
 	{
 		// フェード係数はワールドLimitへの追記時に適用し、ローカルLimit全体のコピーを避ける。
 		// Spheres/Capsules/TaperedCapsules は半径のみ縮小し、Boxes は一定Alphaまでpublishしない。
-		AppendTransformedLimits(LocalLimits.SphericalLimits, ComponentTM, OutWorldLimits.SphericalLimits, FadeAlpha);
-		AppendTransformedLimits(LocalLimits.CapsuleLimits, ComponentTM, OutWorldLimits.CapsuleLimits, FadeAlpha);
-		AppendTransformedLimits(LocalLimits.TaperedCapsuleLimits, ComponentTM, OutWorldLimits.TaperedCapsuleLimits, FadeAlpha);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.SphericalLimits, 0, LocalLimits.SphericalLimits.Num()),
+			ComponentTM, OutWorldLimits.SphericalLimits, FadeAlpha);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.CapsuleLimits, 0, LocalLimits.CapsuleLimits.Num()),
+			ComponentTM, OutWorldLimits.CapsuleLimits, FadeAlpha);
+		AppendTransformedLimits(
+			MakeKawaiiPhysicsSimpleWorldLimitView(
+				LocalLimits.TaperedCapsuleLimits, 0, LocalLimits.TaperedCapsuleLimits.Num()),
+			ComponentTM, OutWorldLimits.TaperedCapsuleLimits, FadeAlpha);
 		if (FadeAlpha >= BoxEnableThreshold)
 		{
-			AppendTransformedLimits(LocalLimits.BoxLimits, ComponentTM, OutWorldLimits.BoxLimits);
+			AppendTransformedLimits(
+				MakeKawaiiPhysicsSimpleWorldLimitView(LocalLimits.BoxLimits, 0, LocalLimits.BoxLimits.Num()),
+				ComponentTM, OutWorldLimits.BoxLimits);
 		}
 		AppendTransformedPlanarLimits(LocalLimits.PlanarLimits, ComponentTM, OutWorldLimits.PlanarLimits);
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -6,8 +6,8 @@
 #include "KawaiiPhysicsTestHarness.h"
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
-#include "Runtime/Launch/Resources/Version.h"
 
 #if !UE_VERSION_OLDER_THAN(5, 5, 0)
 #include "PhysicsEngine/SkeletalBodySetup.h"
@@ -246,6 +246,40 @@ bool FKawaiiPhysicsSimpleWorldConvertAggGeomTest::RunTest(const FString& Paramet
 
 			TestTrue(TEXT("Convex Ignore: produces no limits"), OutLimits.IsEmpty());
 		}
+	}
+
+	// --- Shape単位のQuery無効設定はSimpleWorldのOverlap対象から除外する ---
+	{
+		FKAggregateGeom AggGeom;
+
+		FKSphereElem NoCollisionSphere;
+		NoCollisionSphere.Radius = 5.0f;
+		NoCollisionSphere.SetCollisionEnabled(ECollisionEnabled::NoCollision);
+		AggGeom.SphereElems.Add(NoCollisionSphere);
+
+		FKSphereElem QueryOnlySphere;
+		QueryOnlySphere.Center = FVector(10.0f, 0.0f, 0.0f);
+		QueryOnlySphere.Radius = 7.0f;
+		QueryOnlySphere.SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+		AggGeom.SphereElems.Add(QueryOnlySphere);
+
+		FKBoxElem PhysicsOnlyBox;
+		PhysicsOnlyBox.X = 4.0f;
+		PhysicsOnlyBox.Y = 6.0f;
+		PhysicsOnlyBox.Z = 8.0f;
+		PhysicsOnlyBox.SetCollisionEnabled(ECollisionEnabled::PhysicsOnly);
+		AggGeom.BoxElems.Add(PhysicsOnlyBox);
+
+		FKawaiiPhysicsSharedCollisionData OutLimits;
+		KawaiiPhysicsSimpleWorldCollision::ConvertAggGeomToLocalLimits(
+			AggGeom, FVector::OneVector, EKawaiiPhysicsComplexShapeApproximation::BoxBounds, OutLimits);
+
+		TestTrue(TEXT("NoCollision sphere and PhysicsOnly box do not produce limits"),
+		         OutLimits.SphericalLimits.Num() == 1 && OutLimits.BoxLimits.Num() == 0);
+		TestTrue(TEXT("QueryOnly sphere produces a spherical limit"),
+		         OutLimits.SphericalLimits.Num() == 1 &&
+		         OutLimits.SphericalLimits[0].Location.Equals(FVector(10.0f, 0.0f, 0.0f), GSimpleWorldTol) &&
+		         FMath::IsNearlyEqual(OutLimits.SphericalLimits[0].Radius, 7.0f, GSimpleWorldTol));
 	}
 
 	return true;
@@ -934,6 +968,28 @@ bool FKawaiiPhysicsSimpleWorldUpdateSkeletalBodyWorldTransformsTest::RunTest(con
 		         OutBodyWorldTMs[2].Equals(FTransform::Identity, GSimpleWorldTol));
 	}
 
+	{
+		const FTransform ScaledComponentTM(
+			FQuat(FVector::ZAxisVector, PI / 2.0f),
+			FVector(100.0f, 0.0f, 0.0f),
+			FVector(2.0f, 2.0f, 2.0f));
+
+		TArray<FTransform> ScaledOutBodyWorldTMs;
+		const int32 NumMissingBonesWithScale = KawaiiPhysicsSimpleWorldCollision::UpdateSkeletalBodyWorldTransforms(
+			MakeArrayView(Bindings),
+			MakeArrayView(ComponentSpaceTransforms),
+			ScaledComponentTM,
+			ScaledOutBodyWorldTMs);
+
+		TestTrue(TEXT("Scaled component reports the same missing bone count"), NumMissingBonesWithScale == 1);
+		TestTrue(TEXT("Scaled component applies scale to bone translation"),
+		         ScaledOutBodyWorldTMs.Num() == 3 &&
+		         ScaledOutBodyWorldTMs[1].GetLocation().Equals(FVector(100.0f, 0.0f, 100.0f), GSimpleWorldTol));
+		TestTrue(TEXT("Scaled component strips final body scale"),
+		         ScaledOutBodyWorldTMs.Num() == 3 &&
+		         ScaledOutBodyWorldTMs[1].GetScale3D().Equals(FVector::OneVector, GSimpleWorldTol));
+	}
+
 	return true;
 }
 
@@ -950,10 +1006,20 @@ bool FKawaiiPhysicsSimpleWorldAppendFadedSkeletalLocalLimitsTest::RunTest(const 
 
 	FKawaiiPhysicsSharedCollisionData LocalLimits;
 
-	FSphericalLimit Sphere;
-	Sphere.Location = FVector(10.0f, 0.0f, 0.0f);
-	Sphere.Radius = 4.0f;
-	LocalLimits.SphericalLimits.Add(Sphere);
+	FSphericalLimit BodyASphere0;
+	BodyASphere0.Location = FVector(10.0f, 0.0f, 0.0f);
+	BodyASphere0.Radius = 4.0f;
+	LocalLimits.SphericalLimits.Add(BodyASphere0);
+
+	FSphericalLimit BodyASphere1;
+	BodyASphere1.Location = FVector(20.0f, 0.0f, 0.0f);
+	BodyASphere1.Radius = 6.0f;
+	LocalLimits.SphericalLimits.Add(BodyASphere1);
+
+	FSphericalLimit BodyBSphere;
+	BodyBSphere.Location = FVector::ZeroVector;
+	BodyBSphere.Radius = 8.0f;
+	LocalLimits.SphericalLimits.Add(BodyBSphere);
 
 	FCapsuleLimit Capsule;
 	Capsule.Location = FVector::ZeroVector;
@@ -971,17 +1037,18 @@ bool FKawaiiPhysicsSimpleWorldAppendFadedSkeletalLocalLimitsTest::RunTest(const 
 	TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
 	FKawaiiPhysicsSimpleWorldBodyBinding BodyA;
 	BodyA.BoneIndex = 0;
-	BodyA.NumSphericalLimits = 1;
+	BodyA.NumSphericalLimits = 2;
 	BodyA.NumBoxLimits = 1;
 	Bindings.Add(BodyA);
 	FKawaiiPhysicsSimpleWorldBodyBinding BodyB;
 	BodyB.BoneIndex = 1;
+	BodyB.NumSphericalLimits = 1;
 	BodyB.NumCapsuleLimits = 1;
 	Bindings.Add(BodyB);
 
 	TArray<FTransform> BodyWorldTMs;
 	BodyWorldTMs.Add(FTransform(FQuat::Identity, FVector(0.0f, 0.0f, 100.0f)));
-	BodyWorldTMs.Add(FTransform(FQuat(FVector::ZAxisVector, PI / 2.0f), FVector::ZeroVector));
+	BodyWorldTMs.Add(FTransform(FQuat(FVector::ZAxisVector, PI / 2.0f), FVector(5.0f, 0.0f, 0.0f)));
 
 	{
 		FKawaiiPhysicsSharedCollisionData OutWorldLimits;
@@ -993,11 +1060,17 @@ bool FKawaiiPhysicsSimpleWorldAppendFadedSkeletalLocalLimitsTest::RunTest(const 
 			OutWorldLimits,
 			0.5f);
 
-		TestTrue(TEXT("FadeAlpha=0.5: sphere location follows body A"),
-		         OutWorldLimits.SphericalLimits.Num() == 1 &&
+		TestTrue(TEXT("FadeAlpha=0.5: first body A sphere location follows body A"),
+		         OutWorldLimits.SphericalLimits.Num() == 3 &&
 		         OutWorldLimits.SphericalLimits[0].Location.Equals(FVector(10.0f, 0.0f, 100.0f), GSimpleWorldTol));
+		TestTrue(TEXT("FadeAlpha=0.5: second body A sphere location follows body A"),
+		         OutWorldLimits.SphericalLimits.Num() == 3 &&
+		         OutWorldLimits.SphericalLimits[1].Location.Equals(FVector(20.0f, 0.0f, 100.0f), GSimpleWorldTol));
+		TestTrue(TEXT("FadeAlpha=0.5: body B sphere uses accumulated offset and follows body B"),
+		         OutWorldLimits.SphericalLimits.Num() == 3 &&
+		         OutWorldLimits.SphericalLimits[2].Location.Equals(FVector(5.0f, 0.0f, 0.0f), GSimpleWorldTol));
 		TestTrue(TEXT("FadeAlpha=0.5: sphere radius is halved"),
-		         OutWorldLimits.SphericalLimits.Num() == 1 &&
+		         OutWorldLimits.SphericalLimits.Num() == 3 &&
 		         FMath::IsNearlyEqual(OutWorldLimits.SphericalLimits[0].Radius, 2.0f, GSimpleWorldTol));
 		TestTrue(TEXT("FadeAlpha=0.5: box is kept at full extent"),
 		         OutWorldLimits.BoxLimits.Num() == 1 &&
@@ -1158,6 +1231,10 @@ bool FKawaiiPhysicsSimpleWorldAppendPhysicsAssetLocalLimitsTest::RunTest(const F
 	HandCapsule.Radius = 3.0f;
 	HandCapsule.Length = 12.0f;
 	HandBody->AggGeom.SphylElems.Add(HandCapsule);
+	FKSphereElem HandNoCollisionSphere;
+	HandNoCollisionSphere.Radius = 6.0f;
+	HandNoCollisionSphere.SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	HandBody->AggGeom.SphereElems.Add(HandNoCollisionSphere);
 	PhysicsAsset->SkeletalBodySetups.Add(HandBody);
 
 	USkeletalBodySetup* UnknownBody = NewObject<USkeletalBodySetup>(PhysicsAsset);
@@ -1207,6 +1284,8 @@ bool FKawaiiPhysicsSimpleWorldAppendPhysicsAssetLocalLimitsTest::RunTest(const F
 			         Bindings[0].NumSphericalLimits == 1 && Bindings[0].NumCapsuleLimits == 0);
 			TestTrue(TEXT("Hand contributes one capsule"),
 			         Bindings[1].NumCapsuleLimits == 1 && Bindings[1].NumSphericalLimits == 0);
+			TestTrue(TEXT("Hand NoCollision sphere is ignored"),
+			         Bindings[1].NumSphericalLimits == 0 && OutLimits.SphericalLimits.Num() == 1);
 		}
 	}
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -1306,6 +1306,78 @@ bool FKawaiiPhysicsSimpleWorldAppendPhysicsAssetLocalLimitsTest::RunTest(const F
 		         Bindings.Num() == 1 && Bindings[0].BoneIndex == 1);
 	}
 
+	{
+		UPhysicsAsset* DisabledBodyPhysicsAsset = NewObject<UPhysicsAsset>(GetTransientPackage());
+
+		USkeletalBodySetup* DisabledSpineBody = NewObject<USkeletalBodySetup>(DisabledBodyPhysicsAsset);
+		DisabledSpineBody->BoneName = TEXT("spine");
+		DisabledSpineBody->CollisionReponse = EBodyCollisionResponse::BodyCollision_Disabled;
+		FKSphereElem DisabledSpineSphere;
+		DisabledSpineSphere.Radius = 8.0f;
+		DisabledSpineBody->AggGeom.SphereElems.Add(DisabledSpineSphere);
+		DisabledBodyPhysicsAsset->SkeletalBodySetups.Add(DisabledSpineBody);
+
+		USkeletalBodySetup* DisabledHandBody = NewObject<USkeletalBodySetup>(DisabledBodyPhysicsAsset);
+		DisabledHandBody->BoneName = TEXT("hand_l");
+		DisabledHandBody->CollisionReponse = EBodyCollisionResponse::BodyCollision_Disabled;
+		FKSphylElem DisabledHandCapsule;
+		DisabledHandCapsule.Radius = 3.0f;
+		DisabledHandCapsule.Length = 12.0f;
+		DisabledHandBody->AggGeom.SphylElems.Add(DisabledHandCapsule);
+		DisabledBodyPhysicsAsset->SkeletalBodySetups.Add(DisabledHandBody);
+
+		FKawaiiPhysicsSharedCollisionData OutLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
+			*DisabledBodyPhysicsAsset,
+			RefSkeleton,
+			FVector::OneVector,
+			EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+			32,
+			OutLimits,
+			Bindings);
+
+		TestTrue(TEXT("All disabled bodies accept no bodies"), NumBodies == 0);
+		TestTrue(TEXT("All disabled bodies leave bindings empty"), Bindings.IsEmpty());
+		TestTrue(TEXT("All disabled bodies leave limits empty"), OutLimits.IsEmpty());
+	}
+
+	{
+		UPhysicsAsset* NoCollisionShapePhysicsAsset = NewObject<UPhysicsAsset>(GetTransientPackage());
+
+		USkeletalBodySetup* NoCollisionSpineBody = NewObject<USkeletalBodySetup>(NoCollisionShapePhysicsAsset);
+		NoCollisionSpineBody->BoneName = TEXT("spine");
+		FKSphereElem NoCollisionSpineSphere;
+		NoCollisionSpineSphere.Radius = 8.0f;
+		NoCollisionSpineSphere.SetCollisionEnabled(ECollisionEnabled::NoCollision);
+		NoCollisionSpineBody->AggGeom.SphereElems.Add(NoCollisionSpineSphere);
+		NoCollisionShapePhysicsAsset->SkeletalBodySetups.Add(NoCollisionSpineBody);
+
+		USkeletalBodySetup* NoCollisionHandBody = NewObject<USkeletalBodySetup>(NoCollisionShapePhysicsAsset);
+		NoCollisionHandBody->BoneName = TEXT("hand_l");
+		FKSphylElem NoCollisionHandCapsule;
+		NoCollisionHandCapsule.Radius = 3.0f;
+		NoCollisionHandCapsule.Length = 12.0f;
+		NoCollisionHandCapsule.SetCollisionEnabled(ECollisionEnabled::NoCollision);
+		NoCollisionHandBody->AggGeom.SphylElems.Add(NoCollisionHandCapsule);
+		NoCollisionShapePhysicsAsset->SkeletalBodySetups.Add(NoCollisionHandBody);
+
+		FKawaiiPhysicsSharedCollisionData OutLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
+			*NoCollisionShapePhysicsAsset,
+			RefSkeleton,
+			FVector::OneVector,
+			EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+			32,
+			OutLimits,
+			Bindings);
+
+		TestTrue(TEXT("All NoCollision shapes accept no bodies"), NumBodies == 0);
+		TestTrue(TEXT("All NoCollision shapes leave bindings empty"), Bindings.IsEmpty());
+		TestTrue(TEXT("All NoCollision shapes leave limits empty"), OutLimits.IsEmpty());
+	}
+
 	return true;
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -6,6 +6,13 @@
 #include "KawaiiPhysicsTestHarness.h"
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "PhysicsEngine/PhysicsAsset.h"
+#include "Runtime/Launch/Resources/Version.h"
+
+#if !UE_VERSION_OLDER_THAN(5, 5, 0)
+#include "PhysicsEngine/SkeletalBodySetup.h"
+#endif
+#include "ReferenceSkeleton.h"
 
 // シンプルワールドコリジョン（KawaiiPhysicsSimpleWorldCollision namespace / SharedCollisionSubsystem の関連構造体）の単体テスト。
 // AggGeom→Limit変換、ローカル→ワールド変換、フェード、Desc Merge、Entryのライフサイクル、ハーネス経由のpush-out統合を検証する。
@@ -867,6 +874,357 @@ bool FKawaiiPhysicsSimpleWorldCollisionPushOutTest::RunTest(const FString& Param
 		TestTrue(FString::Printf(TEXT("SimpleWorld capsule push-out position: got %s expected %s"),
 		                         *A.Bone(1).Location.ToString(), *ExpectedPushedOut.ToString()),
 		         A.Bone(1).Location.Equals(ExpectedPushedOut, GSimpleWorldPushOutTol));
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+//  UpdateSkeletalBodyWorldTransforms
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldUpdateSkeletalBodyWorldTransformsTest,
+                                 "KawaiiPhysics.SimpleWorld.UpdateSkeletalBodyWorldTransforms",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldUpdateSkeletalBodyWorldTransformsTest::RunTest(const FString& Parameters)
+{
+	using KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding;
+
+	TArray<FTransform> ComponentSpaceTransforms;
+	ComponentSpaceTransforms.SetNum(3);
+	ComponentSpaceTransforms[0] = FTransform::Identity;
+	ComponentSpaceTransforms[1] = FTransform::Identity;
+	ComponentSpaceTransforms[2] = FTransform(
+		FQuat(FVector::ZAxisVector, PI / 2.0f),
+		FVector(0.0f, 0.0f, 50.0f));
+
+	const FTransform ComponentTM(
+		FQuat(FVector::ZAxisVector, PI / 2.0f),
+		FVector(100.0f, 0.0f, 0.0f));
+
+	TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+	FKawaiiPhysicsSimpleWorldBodyBinding RootBinding;
+	RootBinding.BoneIndex = 0;
+	Bindings.Add(RootBinding);
+	FKawaiiPhysicsSimpleWorldBodyBinding Bone2Binding;
+	Bone2Binding.BoneIndex = 2;
+	Bindings.Add(Bone2Binding);
+	FKawaiiPhysicsSimpleWorldBodyBinding MissingBinding;
+	MissingBinding.BoneIndex = 5;
+	Bindings.Add(MissingBinding);
+
+	TArray<FTransform> OutBodyWorldTMs;
+	const int32 NumMissingBones = KawaiiPhysicsSimpleWorldCollision::UpdateSkeletalBodyWorldTransforms(
+		MakeArrayView(Bindings),
+		MakeArrayView(ComponentSpaceTransforms),
+		ComponentTM,
+		OutBodyWorldTMs);
+
+	TestTrue(TEXT("Out transform count matches binding count"), OutBodyWorldTMs.Num() == 3);
+	TestTrue(TEXT("One missing bone is reported"), NumMissingBones == 1);
+	if (OutBodyWorldTMs.Num() == 3)
+	{
+		TestTrue(TEXT("Bone2 world location composes bone and component transforms"),
+		         OutBodyWorldTMs[1].GetLocation().Equals(FVector(100.0f, 0.0f, 50.0f), GSimpleWorldTol));
+		TestTrue(TEXT("Bone2 world rotation is Z180"),
+		         OutBodyWorldTMs[1].GetRotation().Equals(FQuat(FVector::ZAxisVector, PI), GSimpleWorldTol));
+		TestTrue(TEXT("Bone2 world scale is stripped"),
+		         OutBodyWorldTMs[1].GetScale3D().Equals(FVector::OneVector, GSimpleWorldTol));
+		TestTrue(TEXT("Missing bone leaves identity transform"),
+		         OutBodyWorldTMs[2].Equals(FTransform::Identity, GSimpleWorldTol));
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+//  AppendFadedSkeletalLocalLimits
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldAppendFadedSkeletalLocalLimitsTest,
+                                 "KawaiiPhysics.SimpleWorld.AppendFadedSkeletalLocalLimits",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldAppendFadedSkeletalLocalLimitsTest::RunTest(const FString& Parameters)
+{
+	using KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding;
+
+	FKawaiiPhysicsSharedCollisionData LocalLimits;
+
+	FSphericalLimit Sphere;
+	Sphere.Location = FVector(10.0f, 0.0f, 0.0f);
+	Sphere.Radius = 4.0f;
+	LocalLimits.SphericalLimits.Add(Sphere);
+
+	FCapsuleLimit Capsule;
+	Capsule.Location = FVector::ZeroVector;
+	Capsule.Rotation = FQuat::Identity;
+	Capsule.Radius = 3.0f;
+	Capsule.Length = 20.0f;
+	LocalLimits.CapsuleLimits.Add(Capsule);
+
+	FBoxLimit Box;
+	Box.Location = FVector::ZeroVector;
+	Box.Rotation = FQuat::Identity;
+	Box.Extent = FVector(2.0f, 3.0f, 4.0f);
+	LocalLimits.BoxLimits.Add(Box);
+
+	TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+	FKawaiiPhysicsSimpleWorldBodyBinding BodyA;
+	BodyA.BoneIndex = 0;
+	BodyA.NumSphericalLimits = 1;
+	BodyA.NumBoxLimits = 1;
+	Bindings.Add(BodyA);
+	FKawaiiPhysicsSimpleWorldBodyBinding BodyB;
+	BodyB.BoneIndex = 1;
+	BodyB.NumCapsuleLimits = 1;
+	Bindings.Add(BodyB);
+
+	TArray<FTransform> BodyWorldTMs;
+	BodyWorldTMs.Add(FTransform(FQuat::Identity, FVector(0.0f, 0.0f, 100.0f)));
+	BodyWorldTMs.Add(FTransform(FQuat(FVector::ZAxisVector, PI / 2.0f), FVector::ZeroVector));
+
+	{
+		FKawaiiPhysicsSharedCollisionData OutWorldLimits;
+		KawaiiPhysicsSimpleWorldCollision::AppendFadedSkeletalLocalLimits(
+			LocalLimits,
+			MakeArrayView(Bindings),
+			MakeArrayView(BodyWorldTMs),
+			0.5f,
+			OutWorldLimits,
+			0.5f);
+
+		TestTrue(TEXT("FadeAlpha=0.5: sphere location follows body A"),
+		         OutWorldLimits.SphericalLimits.Num() == 1 &&
+		         OutWorldLimits.SphericalLimits[0].Location.Equals(FVector(10.0f, 0.0f, 100.0f), GSimpleWorldTol));
+		TestTrue(TEXT("FadeAlpha=0.5: sphere radius is halved"),
+		         OutWorldLimits.SphericalLimits.Num() == 1 &&
+		         FMath::IsNearlyEqual(OutWorldLimits.SphericalLimits[0].Radius, 2.0f, GSimpleWorldTol));
+		TestTrue(TEXT("FadeAlpha=0.5: box is kept at full extent"),
+		         OutWorldLimits.BoxLimits.Num() == 1 &&
+		         OutWorldLimits.BoxLimits[0].Extent.Equals(FVector(2.0f, 3.0f, 4.0f), GSimpleWorldTol));
+		TestTrue(TEXT("FadeAlpha=0.5: capsule rotation follows body B"),
+		         OutWorldLimits.CapsuleLimits.Num() == 1 &&
+		         OutWorldLimits.CapsuleLimits[0].Rotation.Equals(
+			         FQuat(FVector::ZAxisVector, PI / 2.0f), GSimpleWorldTol));
+	}
+
+	{
+		FKawaiiPhysicsSharedCollisionData OutWorldLimits;
+		KawaiiPhysicsSimpleWorldCollision::AppendFadedSkeletalLocalLimits(
+			LocalLimits,
+			MakeArrayView(Bindings),
+			MakeArrayView(BodyWorldTMs),
+			0.4f,
+			OutWorldLimits,
+			0.5f);
+
+		TestTrue(TEXT("FadeAlpha=0.4: box is withheld"), OutWorldLimits.BoxLimits.Num() == 0);
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+//  AppendBodyLocalLimitsGuard
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldAppendBodyLocalLimitsGuardTest,
+                                 "KawaiiPhysics.SimpleWorld.AppendBodyLocalLimitsGuard",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldAppendBodyLocalLimitsGuardTest::RunTest(const FString& Parameters)
+{
+	using KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding;
+
+	FKAggregateGeom SphereAggGeom;
+	FKSphereElem SphereElem;
+	SphereElem.Radius = 5.0f;
+	SphereAggGeom.SphereElems.Add(SphereElem);
+
+	FKawaiiPhysicsSharedCollisionData OutLimits;
+	TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+	TestTrue(TEXT("First body is accepted"),
+	         KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+		         SphereAggGeom,
+		         0,
+		         FVector::OneVector,
+		         EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+		         2,
+		         OutLimits,
+		         Bindings));
+	TestTrue(TEXT("Second body is accepted"),
+	         KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+		         SphereAggGeom,
+		         1,
+		         FVector::OneVector,
+		         EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+		         2,
+		         OutLimits,
+		         Bindings));
+
+	const int32 SphereCountBeforeRejectedBody = OutLimits.SphericalLimits.Num();
+	const int32 BindingCountBeforeRejectedBody = Bindings.Num();
+	TestTrue(TEXT("Third body is rejected by MaxBodies"),
+	         !KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+		         SphereAggGeom,
+		         2,
+		         FVector::OneVector,
+		         EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+		         2,
+		         OutLimits,
+		         Bindings));
+	TestTrue(TEXT("Rejected body does not mutate arrays"),
+	         OutLimits.SphericalLimits.Num() == SphereCountBeforeRejectedBody &&
+	         Bindings.Num() == BindingCountBeforeRejectedBody);
+
+	FKAggregateGeom EmptyAggGeom;
+	TestTrue(TEXT("Empty AggGeom is rejected"),
+	         !KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+		         EmptyAggGeom,
+		         3,
+		         FVector::OneVector,
+		         EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+		         10,
+		         OutLimits,
+		         Bindings));
+	TestTrue(TEXT("Empty AggGeom does not add a binding"), Bindings.Num() == BindingCountBeforeRejectedBody);
+
+	FKConvexElem ConvexElem;
+	ConvexElem.ElemBox = FBox(FVector(-1.0f, -2.0f, -3.0f), FVector(1.0f, 2.0f, 3.0f));
+	FKAggregateGeom ConvexAggGeom;
+	ConvexAggGeom.ConvexElems.Add(ConvexElem);
+
+	{
+		FKawaiiPhysicsSharedCollisionData ConvexLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> ConvexBindings;
+		TestTrue(TEXT("Convex BoxBounds body is accepted"),
+		         KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+			         ConvexAggGeom,
+			         0,
+			         FVector::OneVector,
+			         EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+			         10,
+			         ConvexLimits,
+			         ConvexBindings));
+		TestTrue(TEXT("Convex BoxBounds binding records one box"),
+		         ConvexBindings.Num() == 1 &&
+		         ConvexBindings[0].NumBoxLimits == 1 &&
+		         ConvexBindings[0].NumSphericalLimits == 0);
+	}
+
+	{
+		FKawaiiPhysicsSharedCollisionData ConvexLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> ConvexBindings;
+		TestTrue(TEXT("Convex SphereBounds body is accepted"),
+		         KawaiiPhysicsSimpleWorldCollision::AppendBodyLocalLimits(
+			         ConvexAggGeom,
+			         0,
+			         FVector::OneVector,
+			         EKawaiiPhysicsComplexShapeApproximation::SphereBounds,
+			         10,
+			         ConvexLimits,
+			         ConvexBindings));
+		TestTrue(TEXT("Convex SphereBounds binding records one sphere"),
+		         ConvexBindings.Num() == 1 &&
+		         ConvexBindings[0].NumSphericalLimits == 1 &&
+		         ConvexBindings[0].NumBoxLimits == 0);
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+//  AppendPhysicsAssetLocalLimits
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldAppendPhysicsAssetLocalLimitsTest,
+                                 "KawaiiPhysics.SimpleWorld.AppendPhysicsAssetLocalLimits",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldAppendPhysicsAssetLocalLimitsTest::RunTest(const FString& Parameters)
+{
+	using KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding;
+
+	UPhysicsAsset* PhysicsAsset = NewObject<UPhysicsAsset>(GetTransientPackage());
+
+	USkeletalBodySetup* SpineBody = NewObject<USkeletalBodySetup>(PhysicsAsset);
+	SpineBody->BoneName = TEXT("spine");
+	FKSphereElem SpineSphere;
+	SpineSphere.Radius = 8.0f;
+	SpineBody->AggGeom.SphereElems.Add(SpineSphere);
+	PhysicsAsset->SkeletalBodySetups.Add(SpineBody);
+
+	USkeletalBodySetup* HandBody = NewObject<USkeletalBodySetup>(PhysicsAsset);
+	HandBody->BoneName = TEXT("hand_l");
+	FKSphylElem HandCapsule;
+	HandCapsule.Radius = 3.0f;
+	HandCapsule.Length = 12.0f;
+	HandBody->AggGeom.SphylElems.Add(HandCapsule);
+	PhysicsAsset->SkeletalBodySetups.Add(HandBody);
+
+	USkeletalBodySetup* UnknownBody = NewObject<USkeletalBodySetup>(PhysicsAsset);
+	UnknownBody->BoneName = TEXT("unknown");
+	FKBoxElem UnknownBox;
+	UnknownBox.X = 4.0f;
+	UnknownBox.Y = 4.0f;
+	UnknownBox.Z = 4.0f;
+	UnknownBody->AggGeom.BoxElems.Add(UnknownBox);
+	PhysicsAsset->SkeletalBodySetups.Add(UnknownBody);
+
+	USkeletalBodySetup* HeadBody = NewObject<USkeletalBodySetup>(PhysicsAsset);
+	HeadBody->BoneName = TEXT("head");
+	HeadBody->CollisionReponse = EBodyCollisionResponse::BodyCollision_Disabled;
+	FKSphereElem HeadSphere;
+	HeadSphere.Radius = 5.0f;
+	HeadBody->AggGeom.SphereElems.Add(HeadSphere);
+	PhysicsAsset->SkeletalBodySetups.Add(HeadBody);
+
+	FReferenceSkeleton RefSkeleton;
+	{
+		FReferenceSkeletonModifier Modifier(RefSkeleton, nullptr);
+		Modifier.Add(FMeshBoneInfo(TEXT("root"), TEXT("root"), INDEX_NONE), FTransform::Identity);
+		Modifier.Add(FMeshBoneInfo(TEXT("spine"), TEXT("spine"), 0), FTransform::Identity);
+		Modifier.Add(FMeshBoneInfo(TEXT("head"), TEXT("head"), 1), FTransform::Identity);
+		Modifier.Add(FMeshBoneInfo(TEXT("hand_l"), TEXT("hand_l"), 1), FTransform::Identity);
+	}
+
+	{
+		FKawaiiPhysicsSharedCollisionData OutLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
+			*PhysicsAsset,
+			RefSkeleton,
+			FVector::OneVector,
+			EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+			32,
+			OutLimits,
+			Bindings);
+
+		TestTrue(TEXT("Only known and enabled bodies are accepted"), NumBodies == 2 && Bindings.Num() == 2);
+		if (Bindings.Num() == 2)
+		{
+			TestTrue(TEXT("Bindings are sorted by bone index"),
+			         Bindings[0].BoneIndex == 1 && Bindings[1].BoneIndex == 3);
+			TestTrue(TEXT("Spine contributes one sphere"),
+			         Bindings[0].NumSphericalLimits == 1 && Bindings[0].NumCapsuleLimits == 0);
+			TestTrue(TEXT("Hand contributes one capsule"),
+			         Bindings[1].NumCapsuleLimits == 1 && Bindings[1].NumSphericalLimits == 0);
+		}
+	}
+
+	{
+		FKawaiiPhysicsSharedCollisionData OutLimits;
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding> Bindings;
+		const int32 NumBodies = KawaiiPhysicsSimpleWorldCollision::AppendPhysicsAssetLocalLimits(
+			*PhysicsAsset,
+			RefSkeleton,
+			FVector::OneVector,
+			EKawaiiPhysicsComplexShapeApproximation::BoxBounds,
+			1,
+			OutLimits,
+			Bindings);
+
+		TestTrue(TEXT("MaxBodies=1 accepts only spine"), NumBodies == 1 && Bindings.Num() == 1);
+		TestTrue(TEXT("MaxBodies=1 keeps the lowest bone index body"),
+		         Bindings.Num() == 1 && Bindings[0].BoneIndex == 1);
 	}
 
 	return true;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
@@ -103,6 +103,15 @@ public:
 		meta = (DisplayName = "Max PhysicsAsset Bodies", ClampMin = "1", UIMin = "1"))
 	int32 SimpleWorldCollisionMaxPhysicsAssetBodies = 32;
 
+	/**
+	* 収集済みコンポーネントのスケールが変化したら次 Tick で再収集する（既定 OFF。ISM はインスタンススケール、PhysicsAsset モードは bone-local に焼き込んだスケールを対象）。
+	* Re-gather a gathered component on the next tick when its scale changes (default OFF; instance scale for ISM,
+	* the baked bone-local scale for PhysicsAsset mode).
+	*/
+	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",
+		meta = (DisplayName = "Regather On Scale Change"))
+	bool bSimpleWorldCollisionRegatherOnScaleChange = false;
+
 #if WITH_EDITORONLY_DATA
 	/**
 	* MCPコメント枠のタイトルに付与するプレフィックス。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
@@ -93,6 +93,16 @@ public:
 		meta = (DisplayName = "Max Gathered Components", ClampMin = "1", UIMin = "1"))
 	int32 SimpleWorldCollisionMaxGatheredComponents = 64;
 
+	/**
+	* PhysicsAsset モードで SkeletalMeshComponent 1つから採用する最大 body 数。bone index 昇順でこの数まで採用される。
+	* a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies CVar が 0 以上の場合はそちらが優先される。
+	* Maximum number of bodies gathered from one SkeletalMeshComponent in PhysicsAsset mode. Bodies are taken in bone-index order up to this count.
+	* Overridden by the a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies CVar when it is >= 0.
+	*/
+	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",
+		meta = (DisplayName = "Max PhysicsAsset Bodies", ClampMin = "1", UIMin = "1"))
+	int32 SimpleWorldCollisionMaxPhysicsAssetBodies = 32;
+
 #if WITH_EDITORONLY_DATA
 	/**
 	* MCPコメント枠のタイトルに付与するプレフィックス。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -17,7 +17,9 @@
 #include "KawaiiPhysicsSharedCollisionSubsystem.generated.h"
 
 class UPrimitiveComponent;
+class UPhysicsAsset;
 class USkeletalMeshComponent;
+class USkinnedAsset;
 
 /**
  * Source1つ分の共有コリジョンスロット
@@ -161,6 +163,21 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	{
 		TWeakObjectPtr<const UPrimitiveComponent> Component;
 		/**
+		 * PhysicsAsset 厳密モード用の SkeletalMeshComponent キャッシュ。未設定なら通常/Bounds 収集。
+		 * Cached SkeletalMeshComponent for exact PhysicsAsset mode. Unset for regular/bounds gathering.
+		 */
+		TWeakObjectPtr<const USkeletalMeshComponent> SkeletalComponent;
+		/**
+		 * 収集時の SkinnedAsset。差し替え検知に使う。
+		 * SkinnedAsset at gather time, used for replacement detection.
+		 */
+		TWeakObjectPtr<const USkinnedAsset> GatheredSkinnedAsset;
+		/**
+		 * 収集時の PhysicsAsset。Override を含む差し替え検知に使う。
+		 * PhysicsAsset at gather time, including overrides, used for replacement detection.
+		 */
+		TWeakObjectPtr<const UPhysicsAsset> GatheredPhysicsAsset;
+		/**
 		 * ISM/HISM のインスタンス index。非 ISM は INDEX_NONE
 		 * ISM/HISM instance index. INDEX_NONE for non-ISM.
 		 */
@@ -169,6 +186,21 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 		float FadeAlpha = 1.0f;
 		FTransform LastComponentTM;
 		FKawaiiPhysicsSharedCollisionData LocalLimits;
+		/**
+		 * PhysicsAsset 厳密モードの body binding。空なら通常コンポーネント扱い。
+		 * Body bindings for exact PhysicsAsset mode. Empty means regular component handling.
+		 */
+		TArray<KawaiiPhysicsSimpleWorldCollision::FKawaiiPhysicsSimpleWorldBodyBinding> BodyBindings;
+		/**
+		 * 前回 publish 対象にした body world transform。デバッグ描画にも使う。
+		 * Last body world transforms used for publish. Also used for debug drawing.
+		 */
+		TArray<FTransform> LastBodyWorldTMs;
+		/**
+		 * 毎フレーム body world transform 更新用の一時配列。
+		 * Scratch array for per-frame body world transform updates.
+		 */
+		TArray<FTransform> BodyWorldTMScratch;
 	};
 
 	// Tick スレッド専有・ロック不要 / Tick-thread only; no lock required.

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -178,6 +178,11 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 		 */
 		TWeakObjectPtr<const UPhysicsAsset> GatheredPhysicsAsset;
 		/**
+		 * 収集時に Limit へ焼き込んだスケール。ISM はインスタンススケール、PhysicsAsset モードは bone-local に焼き込んだスケール。
+		 * Scale baked into limits at gather time. Instance scale for ISM; the baked bone-local scale for PhysicsAsset mode.
+		 */
+		FVector GatheredScale3D = FVector::OneVector;
+		/**
 		 * ISM/HISM のインスタンス index。非 ISM は INDEX_NONE
 		 * ISM/HISM instance index. INDEX_NONE for non-ISM.
 		 */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
@@ -7,6 +7,9 @@
 
 #include "KawaiiPhysicsSimpleWorldCollision.generated.h"
 
+class UPhysicsAsset;
+struct FReferenceSkeleton;
+
 /**
  * シンプルワールドコリジョンで未対応の複雑形状を近似する方法（Phase 1 では Convex に適用）
  * simple collision を持たないコンポーネント（Landscape / Complex のみのメッシュ）は収集対象外です。
@@ -35,12 +38,21 @@ enum class EKawaiiPhysicsSimpleWorldSkeletalMeshMode : uint8
 	Ignore UMETA(ToolTip = "無視します（既定） / Skip skeletal meshes (default)."),
 	/** Bounds から単一の Box として安価に近似します / Cheaply approximate Bounds as a single Box. */
 	BoundsBox UMETA(ToolTip = "Bounds から単一の Box として安価に近似します / Cheaply approximate Bounds as a single Box."),
-	/** PhysicsAsset の Body をボーン変換込みで正確に変換します（毎フレーム高コスト） / Convert PhysicsAsset bodies exactly, including per-bone transforms (expensive per frame). */
-	PhysicsAsset UMETA(ToolTip = "PhysicsAsset の Body をボーン変換込みで正確に変換します（毎フレーム高コスト） / Convert PhysicsAsset bodies exactly, including per-bone transforms (expensive per frame)."),
+	/** PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当になります。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; falls back to BoundsBox when no PhysicsAsset is available. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes. */
+	PhysicsAsset UMETA(ToolTip = "PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当になります。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; falls back to BoundsBox when no PhysicsAsset is available. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes."),
 };
 
 namespace KawaiiPhysicsSimpleWorldCollision
 {
+	struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldBodyBinding
+	{
+		int32 BoneIndex = INDEX_NONE;
+		int32 NumSphericalLimits = 0;
+		int32 NumCapsuleLimits = 0;
+		int32 NumTaperedCapsuleLimits = 0;
+		int32 NumBoxLimits = 0;
+	};
+
 	/**
 	 * ワールドAABBをコンポーネントローカル空間の Limit 配列へ変換して追記します。Box はワールドで軸平行になるよう ComponentTM の逆回転を持ちます。
 	 * Converts world AABB into component-local-space limits and appends them. Boxes keep ComponentTM inverse rotation so they remain axis-aligned in world space.
@@ -60,6 +72,54 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		const FVector& Scale3D,
 		EKawaiiPhysicsComplexShapeApproximation ApproxMode,
 		FKawaiiPhysicsSharedCollisionData& OutLocalLimits);
+
+	/**
+	 * 1 body 分の AggGeom をボーンローカル Limit として追記し、各配列内の連続要素数を Binding に記録します。
+	 * Appends one body's AggGeom as bone-local limits and records contiguous element counts in the binding.
+	 */
+	KAWAIIPHYSICS_API bool AppendBodyLocalLimits(
+		const FKAggregateGeom& AggGeom,
+		int32 BoneIndex,
+		const FVector& Scale3D,
+		EKawaiiPhysicsComplexShapeApproximation ApproxMode,
+		int32 MaxBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding>& OutBindings);
+
+	/**
+	 * PhysicsAsset の Body を RefSkeleton で解決し、ボーン index 昇順で上限までボーンローカル Limit として追記します。
+	 * Resolves PhysicsAsset bodies against the RefSkeleton and appends them as bone-local limits, sorted by bone index and capped by MaxBodies.
+	 */
+	KAWAIIPHYSICS_API int32 AppendPhysicsAssetLocalLimits(
+		const UPhysicsAsset& PhysicsAsset,
+		const FReferenceSkeleton& RefSkeleton,
+		const FVector& Scale3D,
+		EKawaiiPhysicsComplexShapeApproximation ApproxMode,
+		int32 MaxBodies,
+		FKawaiiPhysicsSharedCollisionData& OutLocalLimits,
+		TArray<FKawaiiPhysicsSimpleWorldBodyBinding>& OutBindings);
+
+	/**
+	 * BodyBinding ごとの bone component-space transform と ComponentTM を合成し、スケールを除去した World Transform を更新します。
+	 * Updates scale-stripped world transforms by composing each binding's bone component-space transform with ComponentTM.
+	 */
+	KAWAIIPHYSICS_API int32 UpdateSkeletalBodyWorldTransforms(
+		TArrayView<const FKawaiiPhysicsSimpleWorldBodyBinding> Bindings,
+		TArrayView<const FTransform> ComponentSpaceTransforms,
+		const FTransform& ComponentTM,
+		TArray<FTransform>& OutBodyWorldTMs);
+
+	/**
+	 * Binding ごとの LocalLimits スライスを BodyWorldTMs でワールド空間へ変換し、FadeAlpha を適用して追記します。
+	 * Transforms each binding's LocalLimits slice by BodyWorldTMs, applies FadeAlpha, and appends into OutWorldLimits.
+	 */
+	KAWAIIPHYSICS_API void AppendFadedSkeletalLocalLimits(
+		const FKawaiiPhysicsSharedCollisionData& LocalLimits,
+		TArrayView<const FKawaiiPhysicsSimpleWorldBodyBinding> Bindings,
+		TArrayView<const FTransform> BodyWorldTMs,
+		float FadeAlpha,
+		FKawaiiPhysicsSharedCollisionData& OutWorldLimits,
+		float BoxEnableThreshold = 0.5f);
 
 	/**
 	 * ローカル空間の Limit 配列を ComponentTM でワールド空間へ変換し、OutWorldLimits へ追記します。ComponentTM はスケール除去済みとして扱います。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
@@ -38,8 +38,8 @@ enum class EKawaiiPhysicsSimpleWorldSkeletalMeshMode : uint8
 	Ignore UMETA(ToolTip = "無視します（既定） / Skip skeletal meshes (default)."),
 	/** Bounds から単一の Box として安価に近似します / Cheaply approximate Bounds as a single Box. */
 	BoundsBox UMETA(ToolTip = "Bounds から単一の Box として安価に近似します / Cheaply approximate Bounds as a single Box."),
-	/** PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当になります。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; falls back to BoundsBox when no PhysicsAsset is available. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes. */
-	PhysicsAsset UMETA(ToolTip = "PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当になります。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; falls back to BoundsBox when no PhysicsAsset is available. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes."),
+	/** PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当、PhysicsAsset があって有効な body が無い場合は収集しません。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; no PhysicsAsset behaves like BoundsBox, and when a PhysicsAsset exists but has no valid body, it is not gathered. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes. */
+	PhysicsAsset UMETA(ToolTip = "PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは BoundsBox 相当、PhysicsAsset があって有効な body が無い場合は収集しません。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; no PhysicsAsset behaves like BoundsBox, and when a PhysicsAsset exists but has no valid body, it is not gathered. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes."),
 };
 
 namespace KawaiiPhysicsSimpleWorldCollision

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
@@ -75,7 +75,9 @@ namespace KawaiiPhysicsSimpleWorldCollision
 
 	/**
 	 * 1 body 分の AggGeom をボーンローカル Limit として追記し、各配列内の連続要素数を Binding に記録します。
+	 * Binding は開始 offset を持たず先頭からの累積で解決するため、OutLocalLimits と OutBindings は同時に空の状態から使い始めてください。
 	 * Appends one body's AggGeom as bone-local limits and records contiguous element counts in the binding.
+	 * Bindings do not store start offsets and are resolved by accumulation from the beginning, so start using OutLocalLimits and OutBindings when both are empty.
 	 */
 	KAWAIIPHYSICS_API bool AppendBodyLocalLimits(
 		const FKAggregateGeom& AggGeom,
@@ -88,7 +90,9 @@ namespace KawaiiPhysicsSimpleWorldCollision
 
 	/**
 	 * PhysicsAsset の Body を RefSkeleton で解決し、ボーン index 昇順で上限までボーンローカル Limit として追記します。
+	 * Binding は開始 offset を持たず先頭からの累積で解決するため、OutLocalLimits と OutBindings は同時に空の状態から使い始めてください。
 	 * Resolves PhysicsAsset bodies against the RefSkeleton and appends them as bone-local limits, sorted by bone index and capped by MaxBodies.
+	 * Bindings do not store start offsets and are resolved by accumulation from the beginning, so start using OutLocalLimits and OutBindings when both are empty.
 	 */
 	KAWAIIPHYSICS_API int32 AppendPhysicsAssetLocalLimits(
 		const UPhysicsAsset& PhysicsAsset,


### PR DESCRIPTION
## 概要

Simple World Collision（#260）の `SkeletalMeshMode = PhysicsAsset` を、これまでの「BoundsBox 相当」から **相手キャラの PhysicsAsset の各 body を bone に追従させる厳密モード**に実装しました。周辺の NPC の体（頭・胴・腕・脚のカプセル等）に髪やスカートが正しく押されるようになります。

## 変更内容

- **収集時**: 相手 `SkeletalMeshComponent` の PhysicsAsset（Override 込み）の各 body の AggGeom を bone-local の Limit に変換し、既存の `LocalLimits` キャッシュに body 順で連続追記。body ごとの bone index と各配列内の要素数を `FKawaiiPhysicsSimpleWorldBodyBinding` に記録（Planar は持たない）。コンポーネントスケールは bone-local に焼き込み
- **毎フレーム**: `GetComponentSpaceTransforms()[BoneIndex] * ComponentTM`（スケール除去）を body ごとに合成し、前フレームと変化があった場合だけ Publish。Fade・Box の閾値ゲートは body 範囲ごとに適用
- **差し替え検知**: SkinnedAsset / PhysicsAsset（Override 含む）の入れ替え、bone index の無効化を検出して次 Tick に再収集
- **フォールバック規則**: PhysicsAsset / SkinnedAsset / ComponentSpaceTransforms が無い場合は BoundsBox 相当。PhysicsAsset はあるが全 body が無効（`BodyCollision_Disabled`、shape の query 無効、bone 未解決）の場合は「意図的にコリジョン無し」とみなして収集しない
- **shape 単位の CollisionEnabled を尊重**: `NoCollision` / `PhysicsOnly` / `ProbeOnly` の primitive は Limit 化しない（静的コンポーネント経路にも適用）
- **上限**: `Project Settings > Kawaii Physics > Simple World Collision > Max PhysicsAsset Bodies`（既定 32）で SkeletalMesh 1 体あたりの body 数を制限（bone index 昇順＝胴体優先）。CVar `a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxPhysicsAssetBodies`（−1 = 設定値、0 = PhysicsAsset モードの SkeletalMesh を収集しない、1 以上で上書き）
- **スケール変化での再収集（オプトイン）**: `Project Settings > Kawaii Physics > Simple World Collision > Regather On Scale Change`（既定 OFF）または CVar `a.AnimNode.KawaiiPhysics.SimpleWorldCollision.RegatherOnScaleChange`（−1 = 設定値 / 0 / 1）を有効にすると、収集済みコンポーネント（PhysicsAsset モードの SkeletalMesh・Movable 全般・ISM インスタンス）のスケールが変わった時に次 Tick で再収集する。既定 OFF では従来どおり次回の収集で反映
- **可視化・計測**: DebugDraw を body ごとの world TM で描画。STAT `KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies` を追加し、`NumGatheredComponents` と併せて毎 Tick 集計に変更（従来は cleanup 間隔でしか更新されず `stat anim` で 0 表示だった）
- **版分岐**: `SkeletalBodySetup.h` の include を他ファイルと同じ `UE_VERSION_OLDER_THAN(5, 5, 0)` ガードに
- **テスト**: `KawaiiPhysics.SimpleWorld.*` に 4 本追加（bone TM 合成・スケール除去 / body 範囲ごとのフェード適用と offset 累積 / body 上限と Convex 近似 / transient PhysicsAsset＋参照骨格による列挙・無効 body・無効 shape・bone 昇順）

## 確認

- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: `Automation RunTests KawaiiPhysics` **236/236 pass**（`KawaiiPhysics.SimpleWorld.*` 12 本）
- 規約リンタ: `Tools/lint-kp.ps1 -Base master` 0 error / 0 warning
- PIE: `docs/pie/SimpleWorldCollision_PIE_Checklist.md` §7（近接 NPC の追従・ポーズ追従・PhysicsAsset 無しのフォールバック・Override / メッシュ差し替え・body 上限 CVar・LeaderPose follower・複数 Pawn 近接時の STAT・Ragdoll）は未実施
- 性能: Subsystem の GameThread Tick 側の変更のため AnimNode 単体のヘッドレスベンチでは観測できない。PIE で複数 Pawn 近接時の `SimpleWorldCollision_UpdateTransforms` / `NumSkeletalBodies` を記録する
- 既知の制約: LOD で除外された bone の ComponentSpaceTransforms は更新されないため、その body はコンポーネント TM 追従のみ（胴体側が優先されるため影響は小さい）。非一様スケール・アニメ由来の bone scale は近似。Entry 単位の総 body 上限は設けていない（MaxGatheredComponents × Max PhysicsAsset Bodies で有界）
