### PR TITLE
[test] Lengthen perf trials and add per-trial calibration to the benchmarks

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
@@ -4,6 +4,7 @@
 
 #include "Misc/AutomationTest.h"
 #include "HAL/PlatformTime.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Templates/Function.h"
 #include "Curves/CurveFloat.h"
 #include "ExternalForces/KawaiiPhysicsExternalForce.h"
@@ -17,6 +18,53 @@ namespace
 	constexpr int32 GTrials = 5;
 	constexpr float GFrameDt = 1.0f / 90.0f;
 	constexpr double GAverageSubsteps = 60.0 / 90.0; // 1/90秒を1/60秒固定ステップへ蓄積する理論平均。
+	constexpr int32 GKawaiiPhysicsPerfCalibrationIterations = 47000; // 開発機 Ryzen 9 3950X / Development Editor で約30〜45ms。
+	static volatile double GKawaiiPhysicsPerfCalibrationSink = 0.0;
+#ifdef _MSC_FULL_VER
+	constexpr int32 KawaiiPerfMscFullVer = _MSC_FULL_VER;
+#else
+	constexpr int32 KawaiiPerfMscFullVer = 0;
+#endif
+
+	// 較正ループはベンチ本体とは別の固定計算を試行ごとに走らせ、実行時の機械状態を見るための指標にする。
+	// 合否判定や過去ログ比較への使い方は compare-perf.ps1 側に任せ、このテストでは calib_ms として記録だけ行う。
+	FORCENOINLINE double RunKawaiiPhysicsPerfCalibrationLoop()
+	{
+		constexpr int32 PointCount = 256;
+		constexpr double Dt = 1.0 / 60.0;
+		constexpr double DtSquared = Dt * Dt;
+		FVector Positions[PointCount];
+		FVector PreviousPositions[PointCount];
+
+		for (int32 Index = 0; Index < PointCount; ++Index)
+		{
+			const double Scale = static_cast<double>(Index + 1);
+			Positions[Index] = FVector(Scale * 0.25, Scale * -0.125, Scale * 0.0625);
+			PreviousPositions[Index] = Positions[Index] - FVector(0.01 * Scale, -0.02 * Scale, 0.015 * Scale);
+		}
+
+		for (int32 Iteration = 0; Iteration < GKawaiiPhysicsPerfCalibrationIterations; ++Iteration)
+		{
+			for (int32 Index = 0; Index < PointCount; ++Index)
+			{
+				const double AccelScale = static_cast<double>((Index % 17) + 1);
+				const FVector Accel(AccelScale * 0.001, AccelScale * -0.002, -0.01 - AccelScale * 0.0005);
+				const FVector Current = Positions[Index];
+				const FVector Next = Current + (Current - PreviousPositions[Index]) * 0.99 + Accel * DtSquared;
+				PreviousPositions[Index] = Current;
+				Positions[Index] = Next;
+			}
+		}
+
+		double Sum = 0.0;
+		for (int32 Index = 0; Index < PointCount; ++Index)
+		{
+			Sum += Positions[Index].X + Positions[Index].Y + Positions[Index].Z;
+		}
+
+		GKawaiiPhysicsPerfCalibrationSink = GKawaiiPhysicsPerfCalibrationSink + Sum;
+		return Sum;
+	}
 
 	FKawaiiPhysicsSettings MakePerfSettings(const float Radius = 2.0f)
 	{
@@ -85,8 +133,12 @@ namespace
 		}
 	}
 
+	// シミュレーション系ベンチはベンチごとのフレーム数で1試行の実時間を伸ばす。
+	// 較正ループの直後にwarmupを挟んでから計測し、中央値・最小値・tip座標checksumを記録する。
 	bool RunSimulationPerf(FAutomationTestBase& Test, const TCHAR* TestName,
-	                       const TFunction<void(FKawaiiPhysicsTestAccessor&)>& Setup)
+	                       const TFunction<void(FKawaiiPhysicsTestAccessor&)>& Setup,
+	                       const int32 MeasureFrames = GMeasureFrames,
+	                       const double StepsPerFrame = GAverageSubsteps)
 	{
 		TArray<double> MsPerFrameValues;
 		MsPerFrameValues.Reserve(GTrials);
@@ -100,6 +152,10 @@ namespace
 			Setup(A);
 			BoneCount = A.Num();
 
+			const double CalibrationStartSeconds = FPlatformTime::Seconds();
+			RunKawaiiPhysicsPerfCalibrationLoop();
+			const double CalibMs = (FPlatformTime::Seconds() - CalibrationStartSeconds) * 1000.0;
+
 			for (int32 Frame = 0; Frame < GWarmupFrames; ++Frame)
 			{
 				A.StepFrame(GFrameDt);
@@ -107,16 +163,18 @@ namespace
 
 			const double StartSeconds = FPlatformTime::Seconds();
 			double TrialChecksum = 0.0;
-			for (int32 Frame = 0; Frame < GMeasureFrames; ++Frame)
+			for (int32 Frame = 0; Frame < MeasureFrames; ++Frame)
 			{
 				A.StepFrame(GFrameDt);
 				const FVector Tip = A.TipLocation();
 				TrialChecksum += Tip.X + Tip.Y + Tip.Z;
 			}
 			const double ElapsedSeconds = FPlatformTime::Seconds() - StartSeconds;
-			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(GMeasureFrames);
+			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(MeasureFrames);
 
-			Test.AddInfo(FString::Printf(TEXT("PERF_RAW %s trial=%d ms=%.6f"), TestName, Trial, MsPerFrame));
+			Test.AddInfo(FString::Printf(
+				TEXT("PERF_RAW %s trial=%d ms=%.6f calib_ms=%.6f"),
+				TestName, Trial, MsPerFrame, CalibMs));
 			MsPerFrameValues.Add(MsPerFrame);
 			Checksum += TrialChecksum;
 
@@ -128,12 +186,13 @@ namespace
 		}
 
 		MsPerFrameValues.Sort();
+		const double MinMsPerFrame = MsPerFrameValues[0];
 		const double MedianMsPerFrame = MsPerFrameValues[GTrials / 2];
 		const double NsPerBoneStep = MedianMsPerFrame * 1000000.0 /
-			FMath::Max(1.0, static_cast<double>(BoneCount) * GAverageSubsteps);
+			FMath::Max(1.0, static_cast<double>(BoneCount) * StepsPerFrame);
 		Test.AddInfo(FString::Printf(
-			TEXT("PERF %s median_ms_per_frame=%.6f ns_per_bone_step=%.3f checksum=%.6f"),
-			TestName, MedianMsPerFrame, NsPerBoneStep, Checksum));
+			TEXT("PERF %s median_ms_per_frame=%.6f min_ms_per_frame=%.6f ns_per_bone_step=%.3f checksum=%.6f"),
+			TestName, MedianMsPerFrame, MinMsPerFrame, NsPerBoneStep, Checksum));
 		return bFinite;
 	}
 
@@ -164,9 +223,12 @@ namespace
 		return true;
 	}
 
-	bool RunPhysicsSettingsPerf(FAutomationTestBase& Test, const TCHAR* TestName, const bool bSetDampingCurve)
+	// PhysicsSettings更新ベンチは曲線有無ごとの呼び出し回数で試行長を揃える。
+	// 較正ループの直後に未計測warmupでベンチ経路のキャッシュを温め直してから計測し、
+	// 200ボーン基準の ns_per_bone_step と、試行ごとの較正時間を同じログへ出す。
+	bool RunPhysicsSettingsPerf(FAutomationTestBase& Test, const TCHAR* TestName, const bool bSetDampingCurve,
+	                            const int32 Calls)
 	{
-		constexpr int32 Calls = 20000;
 		TArray<double> MsPerCallValues;
 		MsPerCallValues.Reserve(GTrials);
 		double Checksum = 0.0;
@@ -186,6 +248,16 @@ namespace
 				Curve->AddKey(1.0f, 1.5f);
 			}
 
+			const double CalibrationStartSeconds = FPlatformTime::Seconds();
+			RunKawaiiPhysicsPerfCalibrationLoop();
+			const double CalibMs = (FPlatformTime::Seconds() - CalibrationStartSeconds) * 1000.0;
+
+			// 較正後にベンチ経路のキャッシュを温め直す（計測に含めないwarmup呼び出し）。
+			for (int32 WarmupCall = 0; WarmupCall < GWarmupFrames; ++WarmupCall)
+			{
+				A.CallUpdatePhysicsSettings();
+			}
+
 			const double StartSeconds = FPlatformTime::Seconds();
 			double TrialChecksum = 0.0;
 			for (int32 Call = 0; Call < Calls; ++Call)
@@ -199,7 +271,9 @@ namespace
 			const double ElapsedSeconds = FPlatformTime::Seconds() - StartSeconds;
 			const double MsPerCall = ElapsedSeconds * 1000.0 / static_cast<double>(Calls);
 
-			Test.AddInfo(FString::Printf(TEXT("PERF_RAW %s trial=%d ms=%.6f"), TestName, Trial, MsPerCall));
+			Test.AddInfo(FString::Printf(
+				TEXT("PERF_RAW %s trial=%d ms=%.6f calib_ms=%.6f"),
+				TestName, Trial, MsPerCall, CalibMs));
 			MsPerCallValues.Add(MsPerCall);
 			Checksum += TrialChecksum;
 
@@ -211,11 +285,12 @@ namespace
 		}
 
 		MsPerCallValues.Sort();
+		const double MinMsPerCall = MsPerCallValues[0];
 		const double MedianMsPerCall = MsPerCallValues[GTrials / 2];
 		const double NsPerBone = MedianMsPerCall * 1000000.0 / 200.0;
 		Test.AddInfo(FString::Printf(
-			TEXT("PERF %s median_ms_per_frame=%.6f ns_per_bone_step=%.3f checksum=%.6f"),
-			TestName, MedianMsPerCall, NsPerBone, Checksum));
+			TEXT("PERF %s median_ms_per_frame=%.6f min_ms_per_frame=%.6f ns_per_bone_step=%.3f checksum=%.6f"),
+			TestName, MedianMsPerCall, MinMsPerCall, NsPerBone, Checksum));
 		return bFinite;
 	}
 
@@ -345,6 +420,7 @@ namespace
 
 	bool RunSharedCollisionCopyPerf(FAutomationTestBase& Test)
 	{
+		constexpr int32 MeasureFrames = 100000;
 		FKawaiiPhysicsSharedCollisionData SourceTemplates[GSharedCollisionSourceCount];
 		for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
 		{
@@ -375,6 +451,10 @@ namespace
 			FKawaiiPhysicsSharedCollisionData MergedData;
 			FKawaiiPhysicsSharedCollisionData SharedStore;
 
+			const double CalibrationStartSeconds = FPlatformTime::Seconds();
+			RunKawaiiPhysicsPerfCalibrationLoop();
+			const double CalibMs = (FPlatformTime::Seconds() - CalibrationStartSeconds) * 1000.0;
+
 			for (int32 Frame = 0; Frame < GWarmupFrames; ++Frame)
 			{
 				for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
@@ -387,7 +467,7 @@ namespace
 			}
 
 			const double StartSeconds = FPlatformTime::Seconds();
-			for (int32 Frame = 0; Frame < GMeasureFrames; ++Frame)
+			for (int32 Frame = 0; Frame < MeasureFrames; ++Frame)
 			{
 				for (int32 SourceIndex = 0; SourceIndex < GSharedCollisionSourceCount; ++SourceIndex)
 				{
@@ -398,10 +478,11 @@ namespace
 				LastMergedLimitCount = StoreSharedCollisionLimits(MergedData, SharedStore);
 			}
 			const double ElapsedSeconds = FPlatformTime::Seconds() - StartSeconds;
-			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(GMeasureFrames);
+			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(MeasureFrames);
 
-			Test.AddInfo(FString::Printf(TEXT("PERF_RAW KawaiiPhysics.Perf.SharedCollisionCopy trial=%d ms=%.6f"),
-				Trial, MsPerFrame));
+			Test.AddInfo(FString::Printf(
+				TEXT("PERF_RAW KawaiiPhysics.Perf.SharedCollisionCopy trial=%d ms=%.6f calib_ms=%.6f"),
+				Trial, MsPerFrame, CalibMs));
 			MsPerFrameValues.Add(MsPerFrame);
 		}
 
@@ -411,10 +492,11 @@ namespace
 			LastMergedLimitCount, GSharedCollisionLimitsPerFrame);
 
 		MsPerFrameValues.Sort();
+		const double MinMsPerFrame = MsPerFrameValues[0];
 		const double MedianMsPerFrame = MsPerFrameValues[GTrials / 2];
 		Test.AddInfo(FString::Printf(
-			TEXT("PERF KawaiiPhysics.Perf.SharedCollisionCopy median_ms_per_frame=%.6f limits_per_frame=%d"),
-			MedianMsPerFrame, GSharedCollisionLimitsPerFrame));
+			TEXT("PERF KawaiiPhysics.Perf.SharedCollisionCopy median_ms_per_frame=%.6f min_ms_per_frame=%.6f limits_per_frame=%d"),
+			MedianMsPerFrame, MinMsPerFrame, GSharedCollisionLimitsPerFrame));
 
 		return bCountOk;
 	}
@@ -431,7 +513,8 @@ bool FKawaiiPhysicsPerfChainTest::RunTest(const FString& Parameters)
 		{
 			A.BuildVerticalChain(200, 5.0f);
 			ConfigureBaseSimulation(A);
-		});
+		},
+		12000);
 }
 
 // legacy（サブステップOFF）。Exponent = TargetFramerate * DeltaTime となり 1.0f にならないため、
@@ -451,7 +534,9 @@ bool FKawaiiPhysicsPerfChainLegacyTest::RunTest(const FString& Parameters)
 			A.SetGravityInSimSpace(FVector(0.0, 0.0, -980.0));
 			A.SetFixedSubstepping(false, 60, 4);
 			A.SetSkelCompMove(FVector(0.3f, 0.0f, 0.0f), FQuat::Identity);
-		});
+		},
+		12000,
+		1.0);
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfCollisionTest,
@@ -466,7 +551,8 @@ bool FKawaiiPhysicsPerfCollisionTest::RunTest(const FString& Parameters)
 			A.BuildVerticalChain(200, 5.0f);
 			ConfigureBaseSimulation(A, 3.0f);
 			AddPerfCollisionLimits(A);
-		});
+		},
+		5000);
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfConstraintTest,
@@ -487,7 +573,8 @@ bool FKawaiiPhysicsPerfConstraintTest::RunTest(const FString& Parameters)
 			{
 				A.AddRuntimeBoneConstraint(Depth, 100 + Depth, 6.0f);
 			}
-		});
+		},
+		12000);
 }
 
 // 拘束計算そのものを支配的にした重量ベンチ。1000ボーン / 999拘束 / 反復16+16。
@@ -515,7 +602,8 @@ bool FKawaiiPhysicsPerfConstraintHeavyTest::RunTest(const FString& Parameters)
 			{
 				A.AddRuntimeBoneConstraint(Depth, PerChain + Depth + 1, 7.0f);
 			}
-		});
+		},
+		1000);
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfPhysicsSettingsTest,
@@ -525,14 +613,14 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfPhysicsSettingsTest,
 bool FKawaiiPhysicsPerfPhysicsSettingsTest::RunTest(const FString& Parameters)
 {
 	bool bOk = true;
-	bOk &= RunPhysicsSettingsPerf(*this, TEXT("KawaiiPhysics.Perf.PhysicsSettings.CurvesEmpty"), false);
-	bOk &= RunPhysicsSettingsPerf(*this, TEXT("KawaiiPhysics.Perf.PhysicsSettings.CurvesSet"), true);
+	bOk &= RunPhysicsSettingsPerf(*this, TEXT("KawaiiPhysics.Perf.PhysicsSettings.CurvesEmpty"), false, 500000);
+	bOk &= RunPhysicsSettingsPerf(*this, TEXT("KawaiiPhysics.Perf.PhysicsSettings.CurvesSet"), true, 30000);
 	return bOk;
 }
 
 // Shared コリジョン経路（Publish→ReadMerged→格納）の構造体コピー帯域を計測する。
-// ソース2つ×(Sphere8+Capsule8+TaperedCapsule8+Box8+Planar4) = 72limit/frame を毎フレーム
-// Publish→ReadMerged→要素毎コピーし、その所要時間を中央値で報告する。
+// ソース2つ×(Sphere8+Capsule8+TaperedCapsule8+Box8+Planar4) = 72limit/frame を100000フレーム
+// Publish→ReadMerged→要素毎コピーし、その所要時間を中央値と最小値で報告する。
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSharedCollisionCopyTest,
                                  "KawaiiPhysics.Perf.SharedCollisionCopy",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -548,6 +636,8 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSizeofTest,
 
 bool FKawaiiPhysicsPerfSizeofTest::RunTest(const FString& Parameters)
 {
+	AddInfo(FString::Printf(TEXT("TOOLCHAIN msc_full_ver=%d engine=%s"),
+	                        KawaiiPerfMscFullVer, ENGINE_VERSION_STRING));
 	AddInfo(FString::Printf(TEXT("SIZEOF FKawaiiPhysicsModifyBone = %d"),
 	                        static_cast<int32>(sizeof(FKawaiiPhysicsModifyBone))));
 	AddInfo(FString::Printf(TEXT("SIZEOF FKawaiiPhysicsSettings = %d"),


### PR DESCRIPTION
## 概要
ヘッドレス性能ベンチ `KawaiiPhysics.Perf.*` が 1 試行 7〜30 ms と短く、他プロセスの負荷やブースト周波数の変動で ±10〜40% ぶれて回帰判定が毎回 WARN になっていた。試行長を bench ごとに伸ばし、機械状態を示す較正値を試行ごとに記録して、外部の比較スクリプトが「回帰」と「環境ノイズ」を区別できるようにする。

## 変更内容
- 計測フレーム数（呼び出し回数）を bench ごとに指定し、1 試行を 150 ms 以上にする（Chain / ChainLegacy / Constraint 12000 フレーム、Collision 5000、ConstraintHeavy 1000、CurvesEmpty 500000 calls、CurvesSet 30000 calls、SharedCollisionCopy 100000 フレーム）
- 各試行の warmup 前に固定の較正ループ（256 FVector の Verlet 風更新、`FORCENOINLINE`、`volatile` sink で最適化除去を防止）を走らせ、所要時間を `PERF_RAW … calib_ms=` として記録（較正 → warmup → 計測の順で、較正がベンチ経路のキャッシュ状態を乱さないようにする）
- `PERF` 行に `min_ms_per_frame=` を追加。ChainLegacy はサブステップ OFF のため `ns_per_bone_step` を 1 step/frame で算出
- Sizeof テストで `TOOLCHAIN msc_full_ver=… engine=…` を出力（コンパイラ／エンジン差の注意喚起用）
- テスト名・フラグ・`SIZEOF` 行・checksum の意味は変更なし（checksum の値は試行長変更で変わる）

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 237/237（フィルタ: KawaiiPhysics）、`KawaiiPhysics.Perf` 8/8 × 静音 3 run で checksum 一致
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件 / WARN 0 件
- PIE: 対象なし（ヘッドレステストのみの変更）
- 性能: 1 試行 159〜293 ms、較正値 29.5〜31.2 ms（3 run 全試行で平坦）、ConstraintHeavy の試行内ドリフト（0.31→0.42 ms）が解消し 0.291〜0.300 ms に収束。新ベースライン取得後の再比較は全 bench OK
