### PR TITLE
[add] Add Simple World Collision diagnostics API and extend the MCP toolset

### DIFF
--- a/Plugins/KawaiiPhysics/Content/Python/kawaii_physics_toolset/tests/test_toolset.py
+++ b/Plugins/KawaiiPhysics/Content/Python/kawaii_physics_toolset/tests/test_toolset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 
 import unreal
@@ -8,6 +9,7 @@ from kawaii_physics_toolset.toolset import KawaiiPhysicsToolset
 from toolset_registry.tests.toolset_testcase import ToolCallTestCase
 
 
+UNKNOWN_ACTOR_LABEL = '__KP_NO_SUCH_ACTOR__'
 TEST_FOLDER = '/Game/Test/PyToolset/'
 GRAYCHAN_SKELETON_PATH = '/Game/KawaiiPhysicsSample/GrayChan/Mesh/GrayChan_Skeleton'
 HAIR_PRESET_PATH = '/Game/KawaiiPhysicsSample/Presets/KPP_Hair_Soft'
@@ -139,6 +141,15 @@ class KawaiiPhysicsToolsetTestCase(ToolCallTestCase):
             value,
         ))
 
+    def _require_world(self) -> None:
+        # ヘッドレス実行ではワールドを取得できないことがあり、その場合ランタイム系ツールは検証できない
+        editor_subsystem = unreal.get_editor_subsystem(unreal.UnrealEditorSubsystem)
+        world = editor_subsystem.get_game_world() if editor_subsystem else None
+        if world is None and editor_subsystem is not None:
+            world = editor_subsystem.get_editor_world()
+        if world is None:
+            self.skipTest('No world is available in this environment.')
+
     def _save_asset(self, asset: unreal.Object) -> None:
         self.assertTrue(unreal.EditorAssetLibrary.save_loaded_asset(asset, False))
 
@@ -251,6 +262,112 @@ class KawaiiPhysicsToolsetTestCase(ToolCallTestCase):
                 '()',
             )
         self.assertIn('ExternalForces', str(cm.exception))
+
+    def test_set_graph_nodes_property_updates_all_nodes(self):
+        anim_blueprint = self._create_anim_blueprint()
+        first_handle = self._place_test_node(
+            anim_blueprint,
+            _make_request('TwintailA_L'),
+        )
+        second_handle = self._place_test_node(
+            anim_blueprint,
+            _make_request('TwintailB_L'),
+        )
+
+        updated_count = KawaiiPhysicsToolset.set_graph_nodes_property(
+            anim_blueprint,
+            'bUseSimpleWorldCollision',
+            'true',
+        )
+
+        self.assertGreaterEqual(updated_count, 2)
+        self.assertEqual(
+            KawaiiPhysicsToolset.get_graph_node_property(
+                first_handle,
+                'bUseSimpleWorldCollision',
+            ),
+            'True',
+        )
+        self.assertEqual(
+            KawaiiPhysicsToolset.get_graph_node_property(
+                second_handle,
+                'bUseSimpleWorldCollision',
+            ),
+            'True',
+        )
+
+    def test_set_graph_nodes_property_with_unmatched_tag_updates_nothing(self):
+        anim_blueprint = self._create_anim_blueprint()
+        handle = self._place_test_node(anim_blueprint, _make_request('TwintailA_L'))
+
+        updated_count = KawaiiPhysicsToolset.set_graph_nodes_property(
+            anim_blueprint,
+            'bUseSimpleWorldCollision',
+            'true',
+            [HAIR_TAG],
+            True,
+        )
+
+        self.assertEqual(updated_count, 0)
+        self.assertEqual(
+            KawaiiPhysicsToolset.get_graph_node_property(
+                handle,
+                'bUseSimpleWorldCollision',
+            ),
+            'False',
+        )
+
+    def test_set_graph_nodes_property_empty_property_name_raises(self):
+        anim_blueprint = self._create_anim_blueprint()
+
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.set_graph_nodes_property(anim_blueprint, '', 'true')
+        self.assertIn('property_name must not be empty', str(cm.exception))
+
+    def test_get_graph_nodes_property_returns_every_node_value(self):
+        anim_blueprint = self._create_anim_blueprint()
+        self._place_test_node(anim_blueprint, _make_request('TwintailA_L'))
+        self._place_test_node(anim_blueprint, _make_request('TwintailB_L'))
+        KawaiiPhysicsToolset.set_graph_nodes_property(
+            anim_blueprint,
+            'bUseSimpleWorldCollision',
+            'true',
+        )
+
+        values = KawaiiPhysicsToolset.get_graph_nodes_property(
+            anim_blueprint,
+            'bUseSimpleWorldCollision',
+        )
+
+        self.assertEqual(len(values), 2)
+        for key in values.keys():
+            self.assertEqual(str(values[key]), 'True')
+
+    def test_get_graph_nodes_property_empty_property_name_raises(self):
+        anim_blueprint = self._create_anim_blueprint()
+
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.get_graph_nodes_property(anim_blueprint, '')
+        self.assertIn('property_name must not be empty', str(cm.exception))
+
+    def test_describe_graph_nodes_returns_json_array(self):
+        anim_blueprint = self._create_anim_blueprint()
+        self._place_test_node(anim_blueprint, _make_request('TwintailA_L'))
+        self._place_test_node(anim_blueprint, _make_request('TwintailB_L'))
+
+        descriptions = json.loads(
+            KawaiiPhysicsToolset.describe_graph_nodes(anim_blueprint))
+
+        self.assertEqual(len(descriptions), 2)
+        root_bone_names = sorted(
+            description['root_bone'] for description in descriptions)
+        self.assertEqual(root_bone_names, ['TwintailA_L', 'TwintailB_L'])
+        self.assertEqual(
+            descriptions[0]['bUseSimpleWorldCollision'],
+            'False',
+        )
+        self.assertIn('bAllowWorldCollision', descriptions[0])
+        self.assertIn('SimpleWorldCollisionSkeletalMeshCollision', descriptions[0])
 
     def test_set_get_preset_node_property_round_trip(self):
         handle = self._place_test_node()
@@ -739,6 +856,188 @@ class KawaiiPhysicsToolsetTestCase(ToolCallTestCase):
         self.assertTrue(any(error.startswith('Warning:') for error in errors))
         self.assertTrue(any('Skeleton does not match' in error for error in errors))
         self.assertEqual(len(handles), 1)
+
+    def test_get_simple_world_collision_debug_info_without_entry(self):
+        skeletal_mesh_component = unreal.new_object(unreal.SkeletalMeshComponent)
+        self.assertIsInstance(skeletal_mesh_component, unreal.SkeletalMeshComponent)
+
+        debug_info = KawaiiPhysicsToolset.get_simple_world_collision_debug_info(
+            skeletal_mesh_component,
+        )
+
+        self.assertFalse(debug_info.get_editor_property('has_entry'))
+
+    def test_get_simple_world_collision_debug_info_none_raises(self):
+        with self.assertToolRaisesRuntimeError():
+            KawaiiPhysicsToolset.get_simple_world_collision_debug_info(None)
+
+    def test_find_simple_world_collision_debug_info_unknown_label_returns_empty(self):
+        try:
+            debug_infos = KawaiiPhysicsToolset.find_simple_world_collision_debug_info(
+                '__KP_NO_SUCH_ACTOR__',
+            )
+        except RuntimeError as error:
+            # ヘッドレス実行ではエディタワールドを取得できないことがある
+            self.skipTest(f'No world is available for the debug info lookup: {error}')
+
+        self.assertEqual(list(debug_infos), [])
+
+    def test_find_simple_world_collision_debug_info_empty_label_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.find_simple_world_collision_debug_info('')
+        self.assertIn('actor_label must not be empty', str(cm.exception))
+
+    def test_execute_console_command_succeeds(self):
+        self._require_world()
+
+        self.assertTrue(KawaiiPhysicsToolset.execute_console_command('stat none'))
+
+    def test_execute_console_command_empty_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.execute_console_command('')
+        self.assertIn('command must not be empty', str(cm.exception))
+
+    def test_find_kawaii_physics_actors_unknown_label_returns_empty(self):
+        self._require_world()
+
+        entries = KawaiiPhysicsToolset.find_kawaii_physics_actors(UNKNOWN_ACTOR_LABEL)
+
+        self.assertEqual(list(entries), [])
+
+    def test_start_bone_sampler_unknown_label_raises(self):
+        self._require_world()
+
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.start_bone_sampler(UNKNOWN_ACTOR_LABEL, '.*')
+        self.assertIn('No bone matches pattern', str(cm.exception))
+
+    def test_start_bone_sampler_empty_pattern_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.start_bone_sampler(UNKNOWN_ACTOR_LABEL, '')
+        self.assertIn('bone_pattern must not be empty', str(cm.exception))
+
+    def test_get_bone_sampler_result_without_start_reports_not_started(self):
+        # 失敗した start はサンプラ状態を作らないため、未開始のまま結果を問い合わせられる
+        result = json.loads(KawaiiPhysicsToolset.get_bone_sampler_result())
+
+        self.assertFalse(result['done'])
+        self.assertEqual(result.get('error'), 'not started')
+
+    def test_stop_bone_sampler_without_start_returns_true(self):
+        self.assertTrue(KawaiiPhysicsToolset.stop_bone_sampler())
+
+    def test_start_physics_settings_multiplier_unknown_label_returns_empty(self):
+        self._require_world()
+
+        result = json.loads(
+            KawaiiPhysicsToolset.start_physics_settings_multiplier_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                '{"Damping": 2.0}',
+                1.0,
+            ))
+
+        self.assertEqual(result, [])
+
+    def test_start_physics_settings_multiplier_invalid_json_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.start_physics_settings_multiplier_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                'not json',
+                1.0,
+            )
+        self.assertIn('settings_json is not valid JSON', str(cm.exception))
+
+    def test_start_physics_settings_multiplier_unknown_field_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.start_physics_settings_multiplier_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                '{"NotAField": 2.0}',
+                1.0,
+            )
+        self.assertIn('Unknown FKawaiiPhysicsSettingsMultiplier field', str(cm.exception))
+
+    def test_stop_physics_settings_multiplier_unknown_label_returns_zero(self):
+        self._require_world()
+
+        stopped_count = KawaiiPhysicsToolset.stop_physics_settings_multiplier_on_actor(
+            UNKNOWN_ACTOR_LABEL,
+            '{"id": 1}',
+        )
+
+        self.assertEqual(stopped_count, 0)
+
+    def test_stop_physics_settings_multiplier_invalid_handle_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.stop_physics_settings_multiplier_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                '',
+            )
+        self.assertIn('handle_json must not be empty', str(cm.exception))
+
+    def test_start_procedural_wind_gust_unknown_label_returns_empty(self):
+        self._require_world()
+
+        result = json.loads(
+            KawaiiPhysicsToolset.start_procedural_wind_gust_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                1.0,
+                1.0,
+            ))
+
+        self.assertEqual(result, [])
+
+    def test_start_procedural_wind_gust_invalid_direction_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.start_procedural_wind_gust_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+                1.0,
+                1.0,
+                0.1,
+                0.3,
+                [1.0, 0.0],
+            )
+        self.assertIn('direction must have 3 elements', str(cm.exception))
+
+    def test_stop_transient_external_force_unknown_label_returns_zero(self):
+        self._require_world()
+
+        stopped_count = KawaiiPhysicsToolset.stop_transient_external_force_on_actor(
+            UNKNOWN_ACTOR_LABEL,
+            '{"id": 1}',
+        )
+
+        self.assertEqual(stopped_count, 0)
+
+    def test_set_alpha_on_actor_unknown_label_returns_zero(self):
+        self._require_world()
+
+        self.assertEqual(
+            KawaiiPhysicsToolset.set_alpha_on_actor(UNKNOWN_ACTOR_LABEL, 1.0),
+            0,
+        )
+
+    def test_set_alpha_on_actor_empty_label_raises(self):
+        with self.assertToolRaisesRuntimeError() as cm:
+            KawaiiPhysicsToolset.set_alpha_on_actor('', 1.0)
+        self.assertIn('actor_label must not be empty', str(cm.exception))
+
+    def test_get_alpha_on_actor_unknown_label_returns_negative(self):
+        self._require_world()
+
+        self.assertEqual(
+            KawaiiPhysicsToolset.get_alpha_on_actor(UNKNOWN_ACTOR_LABEL),
+            -1.0,
+        )
+
+    def test_get_simple_world_collider_count_unknown_label_returns_zero(self):
+        self._require_world()
+
+        self.assertEqual(
+            KawaiiPhysicsToolset.get_simple_world_collider_count_on_actor(
+                UNKNOWN_ACTOR_LABEL,
+            ),
+            0,
+        )
 
 
 if __name__ == '__main__':

--- a/Plugins/KawaiiPhysics/Content/Python/kawaii_physics_toolset/toolset.py
+++ b/Plugins/KawaiiPhysics/Content/Python/kawaii_physics_toolset/toolset.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
+import json
+import math
 import os
+import re
 
 import unreal
 
 import toolset_registry
+
+
+# FKawaiiPhysicsSettingsMultiplier の C++ フィールド名 -> Python プロパティ名
+_SETTINGS_MULTIPLIER_FIELDS = {
+    'Damping': 'damping',
+    'Stiffness': 'stiffness',
+    'WorldDampingLocation': 'world_damping_location',
+    'WorldDampingRotation': 'world_damping_rotation',
+    'Radius': 'radius',
+    'LimitAngle': 'limit_angle',
+}
+
+# start_bone_sampler / get_bone_sampler_result / stop_bone_sampler が共有する採取状態
+_BONE_SAMPLER: dict | None = None
 
 
 def _make_preset_apply_options(
@@ -56,10 +73,41 @@ def _make_tag_container(filter_tag_names: list[str]) -> unreal.GameplayTagContai
     return result
 
 
+def _collect_graph_nodes_impl(
+        anim_blueprint: unreal.AnimBlueprint,
+        filter_tag_names: list[str],
+        filter_exact_match: bool) -> list[unreal.KawaiiPhysicsGraphNodeHandle]:
+    # tool_call ラッパは例外を握って既定値を返すため、ツール同士の呼び合いはこの素の関数を経由する
+    _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+    filter_tags = _make_tag_container(filter_tag_names)
+    handles = unreal.KawaiiPhysicsEditorLibrary.collect_kawaii_physics_graph_nodes(
+        anim_blueprint,
+        filter_tags,
+        filter_exact_match,
+    )
+    if handles is None:
+        raise RuntimeError('Unable to collect KawaiiPhysics graph nodes.')
+    return list(handles)
+
+
+def _validate_placement_requests_impl(
+        anim_blueprint: unreal.AnimBlueprint,
+        requests: list[unreal.KawaiiPhysicsNodePlacementRequest]) -> list[str]:
+    _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+    result = unreal.KawaiiPhysicsEditorLibrary.validate_placement_requests(
+        anim_blueprint,
+        requests,
+    )
+    if result is None:
+        raise RuntimeError(
+            'Unexpected return value from validate_placement_requests.')
+    return [str(error) for error in result]
+
+
 def _validate_requests_or_raise(
         anim_blueprint: unreal.AnimBlueprint,
         requests: list[unreal.KawaiiPhysicsNodePlacementRequest]) -> list[str]:
-    errors = KawaiiPhysicsToolset.validate_placement_requests(anim_blueprint, requests)
+    errors = _validate_placement_requests_impl(anim_blueprint, requests)
     blocking_errors = [
         error for error in errors
         if not str(error).startswith('Warning:')
@@ -71,12 +119,302 @@ def _validate_requests_or_raise(
     return errors
 
 
+def _unpack_bool_out(result: object, default: object) -> object:
+    # C++ の bool 戻り値 + out 引数は (bool, out) のタプルで返るが、
+    # グルーが bool を剥がして out 単体（失敗時は None）を返す場合もあるため両対応する。
+    if isinstance(result, tuple):
+        if len(result) != 2:
+            raise RuntimeError(f'Unexpected return value: {result}')
+        return result[1]
+    if result is None:
+        return default
+    return result
+
+
+def _unpack_count_and_out(result: object) -> tuple[int, object]:
+    # int32 戻り値 + out 引数は (count, out) のタプルで返る。
+    if not isinstance(result, tuple) or len(result) != 2:
+        raise RuntimeError(f'Unexpected return value: {result}')
+    return int(result[0]), result[1]
+
+
+def _resolve_world(prefer_pie: bool) -> unreal.World:
+    editor_subsystem = unreal.get_editor_subsystem(unreal.UnrealEditorSubsystem)
+    if editor_subsystem is None:
+        raise RuntimeError('No world available.')
+
+    world = editor_subsystem.get_game_world() if prefer_pie else None
+    if world is None:
+        # get_editor_world() は PIE 中に None を返してログを出すため、PIE ワールドが取れたときは呼ばない
+        world = editor_subsystem.get_editor_world()
+    if world is None:
+        raise RuntimeError('No world available.')
+    return world
+
+
+def _actor_label(actor: unreal.Actor) -> str:
+    try:
+        return str(actor.get_actor_label())
+    except Exception:
+        # ランタイムワールドの Actor では get_actor_label() が使えないことがある
+        return str(actor.get_name())
+
+
+def _does_actor_match_label(actor: unreal.Actor, actor_label: str) -> bool:
+    if actor is None:
+        return False
+    if _actor_label(actor) == actor_label:
+        return True
+    # PIE の get_name() は UEDPIE_0_ 接頭辞や連番が付くため完全一致だけを見る
+    return str(actor.get_name()) == actor_label
+
+
+def _find_actors_by_label(
+        world: unreal.World,
+        actor_label: str) -> list[unreal.Actor]:
+    return [
+        actor
+        for actor in unreal.GameplayStatics.get_all_actors_of_class(world, unreal.Actor)
+        if _does_actor_match_label(actor, actor_label)
+    ]
+
+
+def _skeletal_mesh_components(
+        actor: unreal.Actor) -> list[unreal.SkeletalMeshComponent]:
+    if actor is None:
+        return []
+    return list(actor.get_components_by_class(unreal.SkeletalMeshComponent))
+
+
+def _find_skeletal_mesh_components_by_label(
+        actor_label: str,
+        prefer_pie: bool) -> list[unreal.SkeletalMeshComponent]:
+    if not actor_label:
+        raise ValueError('actor_label must not be empty.')
+
+    world = _resolve_world(prefer_pie)
+    components = []
+    for actor in _find_actors_by_label(world, actor_label):
+        components.extend(_skeletal_mesh_components(actor))
+    return components
+
+
+def _anim_class_name(component: unreal.SkeletalMeshComponent) -> str:
+    anim_class = None
+    try:
+        anim_class = component.get_editor_property('anim_class')
+    except Exception:
+        anim_class = None
+    if anim_class is None:
+        anim_instance = component.get_anim_instance()
+        if anim_instance is not None:
+            anim_class = anim_instance.get_class()
+    return '' if anim_class is None else str(anim_class.get_name())
+
+
+def _handle_to_dict(handle: unreal.KawaiiPhysicsTransientHandle) -> dict[str, int]:
+    if handle is None:
+        return {'id': 0}
+    return {'id': int(handle.get_editor_property('id'))}
+
+
+def _handle_to_json(handle: unreal.KawaiiPhysicsTransientHandle) -> str:
+    return json.dumps(_handle_to_dict(handle))
+
+
+def _handle_from_json(text: str) -> unreal.KawaiiPhysicsTransientHandle:
+    if not text:
+        raise ValueError('handle_json must not be empty.')
+    try:
+        value = json.loads(text)
+    except ValueError as error:
+        raise ValueError(f'handle_json is not valid JSON: {error}')
+
+    # {"id": 123} と素の 123 のどちらも受け付ける
+    if isinstance(value, dict):
+        value = value.get('id')
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError('handle_json must be {"id": <int>} or an integer.')
+
+    handle = unreal.KawaiiPhysicsTransientHandle()
+    handle.set_editor_property('id', value)
+    return handle
+
+
+def _graph_node_key(
+        handle: unreal.KawaiiPhysicsGraphNodeHandle,
+        index: int) -> str:
+    # NodeGuid が読めればそれをキーにし、読めない環境では安定な代替キーへフォールバックする
+    try:
+        node = handle.get_editor_property('node')
+        if node is not None:
+            try:
+                guid = node.get_editor_property('node_guid')
+                parts = [
+                    int(guid.get_editor_property(name)) & 0xFFFFFFFF
+                    for name in ('a', 'b', 'c', 'd')
+                ]
+                return ''.join(f'{part:08X}' for part in parts)
+            except Exception:
+                return str(node.get_name())
+    except Exception:
+        pass
+    return f'node{index}'
+
+
+def _graph_node_property_or_none(
+        handle: unreal.KawaiiPhysicsGraphNodeHandle,
+        property_name: str) -> str | None:
+    value = unreal.KawaiiPhysicsEditorLibrary.get_graph_node_property_as_string(
+        handle,
+        unreal.Name(property_name),
+    )
+    return None if value is None else str(value)
+
+
+def _make_settings_multiplier(
+        settings_json: str) -> unreal.KawaiiPhysicsSettingsMultiplier:
+    if not settings_json:
+        raise ValueError('settings_json must not be empty.')
+    try:
+        values = json.loads(settings_json)
+    except ValueError as error:
+        raise ValueError(f'settings_json is not valid JSON: {error}')
+    if not isinstance(values, dict):
+        raise ValueError('settings_json must be a JSON object.')
+
+    settings_scale = unreal.KawaiiPhysicsSettingsMultiplier()
+    for name, value in values.items():
+        property_name = _SETTINGS_MULTIPLIER_FIELDS.get(name)
+        if property_name is None and name in _SETTINGS_MULTIPLIER_FIELDS.values():
+            property_name = name
+        if property_name is None:
+            raise ValueError(
+                f'Unknown FKawaiiPhysicsSettingsMultiplier field: {name}. '
+                f'Valid fields: {", ".join(_SETTINGS_MULTIPLIER_FIELDS)}')
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f'{name} must be a number.')
+        settings_scale.set_editor_property(property_name, float(value))
+    return settings_scale
+
+
+def _make_gust_direction(direction: list[float]) -> unreal.Vector:
+    if not direction:
+        # ゼロベクトルは既存 ProceduralWind の風向き・空間・ボーンフィルタを継承する
+        return unreal.Vector(0.0, 0.0, 0.0)
+    if len(direction) != 3:
+        raise ValueError('direction must have 3 elements or be empty.')
+    return unreal.Vector(
+        float(direction[0]),
+        float(direction[1]),
+        float(direction[2]),
+    )
+
+
+def _make_bone_sampler_targets(
+        components: list[unreal.SkeletalMeshComponent],
+        bone_pattern: str) -> list[tuple[str, unreal.SkeletalMeshComponent, str]]:
+    pattern = re.compile(bone_pattern)
+    matches = []
+    for component in components:
+        for socket_name in component.get_all_socket_names():
+            bone_name = str(socket_name)
+            if pattern.search(bone_name):
+                matches.append((component, bone_name))
+
+    # ボーン名が複数コンポーネントで重複する場合だけコンポーネント名で修飾する
+    name_counts: dict[str, int] = {}
+    for _component, bone_name in matches:
+        name_counts[bone_name] = name_counts.get(bone_name, 0) + 1
+    targets = []
+    for component, bone_name in matches:
+        key = bone_name if name_counts[bone_name] == 1 else f'{component.get_name()}.{bone_name}'
+        targets.append((key, component, bone_name))
+    return targets
+
+
+def _make_bone_sample_accumulator() -> dict:
+    return {
+        'min': [0.0, 0.0, 0.0],
+        'max': [0.0, 0.0, 0.0],
+        'sum': [0.0, 0.0, 0.0],
+        'count': 0,
+        'prev': None,
+        'step_square_sum': 0.0,
+        'step_count': 0,
+        'nan': False,
+    }
+
+
+def _accumulate_bone_sample(accumulator: dict, location: list[float]) -> None:
+    if any(not math.isfinite(value) for value in location):
+        accumulator['nan'] = True
+        return
+
+    if accumulator['count'] == 0:
+        accumulator['min'] = list(location)
+        accumulator['max'] = list(location)
+    else:
+        accumulator['min'] = [min(a, b) for a, b in zip(accumulator['min'], location)]
+        accumulator['max'] = [max(a, b) for a, b in zip(accumulator['max'], location)]
+    accumulator['sum'] = [a + b for a, b in zip(accumulator['sum'], location)]
+    accumulator['count'] += 1
+
+    previous = accumulator['prev']
+    if previous is not None:
+        accumulator['step_square_sum'] += sum(
+            (a - b) ** 2 for a, b in zip(location, previous))
+        accumulator['step_count'] += 1
+    accumulator['prev'] = list(location)
+
+
+def _stop_bone_sampler_impl() -> None:
+    state = _BONE_SAMPLER
+    if state is None:
+        return
+    tick_handle = state.get('tick_handle')
+    if tick_handle is not None:
+        state['tick_handle'] = None
+        unreal.unregister_slate_post_tick_callback(tick_handle)
+    state['done'] = True
+
+
+def _bone_sampler_tick(delta_seconds: float) -> None:
+    state = _BONE_SAMPLER
+    if state is None or state['done']:
+        return
+
+    try:
+        for key, component, bone_name in state['targets']:
+            transform = component.get_socket_transform(
+                unreal.Name(bone_name),
+                unreal.RelativeTransformSpace.RTS_WORLD,
+            )
+            location = transform.translation
+            _accumulate_bone_sample(
+                state['bones'][key],
+                [location.x, location.y, location.z],
+            )
+        state['frames_collected'] += 1
+    except Exception as error:
+        # PIE 終了などでコンポーネントが失効した場合は採取を止めて理由を残す
+        state['error'] = str(error)
+        state['done'] = True
+
+    if state['frames_collected'] >= state['frames']:
+        state['done'] = True
+    if state['done']:
+        _stop_bone_sampler_impl()
+
+
 @unreal.uclass()
 class KawaiiPhysicsToolset(unreal.ToolsetDefinition):
     """Sets up, applies presets to, and audits KawaiiPhysics AnimGraph nodes.
 
     Tools wrap KawaiiPhysics editor scripting APIs for automation agents.
     """
+
+    # ===== Editor: AnimBlueprint / preset / audit =====
 
     @toolset_registry.tool_call
     @staticmethod
@@ -150,11 +488,9 @@ class KawaiiPhysicsToolset(unreal.ToolsetDefinition):
             filter_tag_names: list[str],
             filter_exact_match: bool) -> list[unreal.KawaiiPhysicsGraphNodeHandle]:
         """Collects KawaiiPhysics graph nodes; empty tag names collect all nodes."""
-        _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
-        filter_tags = _make_tag_container(filter_tag_names)
-        return unreal.KawaiiPhysicsEditorLibrary.collect_kawaii_physics_graph_nodes(
+        return _collect_graph_nodes_impl(
             anim_blueprint,
-            filter_tags,
+            filter_tag_names,
             filter_exact_match,
         )
 
@@ -208,6 +544,105 @@ class KawaiiPhysicsToolset(unreal.ToolsetDefinition):
             raise RuntimeError(
                 f'Unable to get KawaiiPhysics graph node property: {property_name}')
         return str(value)
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def set_graph_nodes_property(
+            anim_blueprint: unreal.AnimBlueprint,
+            property_name: str,
+            value: str,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False) -> int:
+        """Sets a FAnimNode_KawaiiPhysics property from a string on every KawaiiPhysics node in the AnimBlueprint (optionally filtered by tags).
+
+        Returns the number of nodes updated.
+        """
+        _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+        if not property_name:
+            raise ValueError('property_name must not be empty.')
+        if value is None:
+            raise ValueError('value must not be None.')
+
+        handles = _collect_graph_nodes_impl(
+            anim_blueprint,
+            filter_tag_names,
+            filter_exact_match,
+        )
+        for index, handle in enumerate(handles):
+            ok = unreal.KawaiiPhysicsEditorLibrary.set_graph_node_property_from_string(
+                handle,
+                unreal.Name(property_name),
+                value,
+            )
+            if not ok:
+                raise RuntimeError(
+                    f'Unable to set {property_name} on node '
+                    f'{index + 1}/{len(handles)}')
+        return len(handles)
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def get_graph_nodes_property(
+            anim_blueprint: unreal.AnimBlueprint,
+            property_name: str,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False) -> dict[str, str]:
+        """Gets a FAnimNode_KawaiiPhysics property as a string from every KawaiiPhysics node in the AnimBlueprint (optionally filtered by tags).
+
+        Keys are the node GUID when it can be read, otherwise a stable
+        node name or "node<index>" fallback.
+        """
+        _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+        if not property_name:
+            raise ValueError('property_name must not be empty.')
+
+        handles = _collect_graph_nodes_impl(
+            anim_blueprint,
+            filter_tag_names,
+            filter_exact_match,
+        )
+        values = {}
+        for index, handle in enumerate(handles):
+            value = _graph_node_property_or_none(handle, property_name)
+            if value is None:
+                raise RuntimeError(
+                    f'Unable to get {property_name} on node '
+                    f'{index + 1}/{len(handles)}')
+            values[_graph_node_key(handle, index)] = value
+        return values
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def describe_graph_nodes(anim_blueprint: unreal.AnimBlueprint) -> str:
+        """Returns a JSON array describing every KawaiiPhysics node in the AnimBlueprint.
+
+        Each element holds the node index/key, RootBone, tag and the world
+        collision switches; a property that cannot be read is null.
+        """
+        _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+
+        handles = _collect_graph_nodes_impl(anim_blueprint, [], False)
+        descriptions = []
+        for index, handle in enumerate(handles):
+            root_bone = unreal.KawaiiPhysicsEditorLibrary.get_graph_node_root_bone_name(
+                handle)
+            tag = unreal.KawaiiPhysicsEditorLibrary.get_graph_node_tag(handle)
+            description = {
+                'index': index,
+                'key': _graph_node_key(handle, index),
+                'root_bone': None if root_bone is None else str(root_bone),
+                'tag': None if tag is None else str(
+                    tag.get_editor_property('tag_name')),
+            }
+            for name in (
+                    'bAllowWorldCollision',
+                    'bUseSimpleWorldCollision',
+                    'SimpleWorldCollisionSkeletalMeshCollision',
+                    'bUseSharedCollision',
+            ):
+                description[name] = _graph_node_property_or_none(handle, name)
+            descriptions.append(description)
+        return json.dumps(descriptions)
 
     @toolset_registry.tool_call
     @staticmethod
@@ -551,13 +986,398 @@ class KawaiiPhysicsToolset(unreal.ToolsetDefinition):
             anim_blueprint: unreal.AnimBlueprint,
             requests: list[unreal.KawaiiPhysicsNodePlacementRequest]) -> list[str]:
         """Returns placement errors and warnings; an empty list means no issues."""
-        _raise_for_invalid_object(anim_blueprint, 'anim_blueprint')
+        return _validate_placement_requests_impl(anim_blueprint, requests)
 
-        result = unreal.KawaiiPhysicsEditorLibrary.validate_placement_requests(
-            anim_blueprint,
-            requests,
+    # ===== Runtime (PIE): actors / console / multiplier / gust / alpha / sampler =====
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def execute_console_command(
+            command: str,
+            prefer_pie: bool = True) -> bool:
+        """Executes a console command in the PIE world when available, otherwise the editor world.
+
+        Also usable for CVars, stat commands and `py "<file>"`; returns True
+        because the console reports failures only through the log.
+        """
+        if not command:
+            raise ValueError('command must not be empty.')
+
+        world = _resolve_world(prefer_pie)
+        unreal.SystemLibrary.execute_console_command(world, command)
+        return True
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def find_kawaii_physics_actors(
+            actor_label: str = '',
+            prefer_pie: bool = True) -> list[str]:
+        """Lists SkeletalMeshComponents that run an AnimBlueprint as "<actor_label>|<component_name>|<anim_class_name>".
+
+        An empty actor_label scans every actor; components without an
+        AnimClass are skipped.
+        """
+        world = _resolve_world(prefer_pie)
+        entries = []
+        for actor in unreal.GameplayStatics.get_all_actors_of_class(world, unreal.Actor):
+            if actor_label and not _does_actor_match_label(actor, actor_label):
+                continue
+            label = _actor_label(actor)
+            for component in _skeletal_mesh_components(actor):
+                anim_class_name = _anim_class_name(component)
+                if not anim_class_name:
+                    continue
+                entries.append(
+                    f'{label}|{component.get_name()}|{anim_class_name}')
+        return entries
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def start_bone_sampler(
+            actor_label: str,
+            bone_pattern: str,
+            frames: int = 120,
+            prefer_pie: bool = True) -> str:
+        """Records world positions of matching bones for the next frames via a Slate post-tick callback.
+
+        bone_pattern is a regular expression matched against socket and bone
+        names; a running sampler is stopped first.
+        """
+        global _BONE_SAMPLER
+
+        if not bone_pattern:
+            raise ValueError('bone_pattern must not be empty.')
+        if frames < 1:
+            raise ValueError('frames must be 1 or greater.')
+
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        targets = _make_bone_sampler_targets(components, bone_pattern)
+        if not targets:
+            raise ValueError(
+                f'No bone matches pattern "{bone_pattern}" on actor: {actor_label}')
+
+        _stop_bone_sampler_impl()
+        _BONE_SAMPLER = {
+            'actor': actor_label,
+            'targets': targets,
+            'bones': {key: _make_bone_sample_accumulator() for key, _, _ in targets},
+            'frames': frames,
+            'frames_collected': 0,
+            'done': False,
+            'error': '',
+            'tick_handle': None,
+        }
+        _BONE_SAMPLER['tick_handle'] = unreal.register_slate_post_tick_callback(
+            _bone_sampler_tick)
+        return json.dumps({
+            'started': True,
+            'actor': actor_label,
+            'bones': [key for key, _, _ in targets],
+            'frames': frames,
+        })
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def get_bone_sampler_result() -> str:
+        """Returns the bone sampler result as JSON with per-bone min/max/mean, frame-to-frame RMS displacement and a NaN flag."""
+        state = _BONE_SAMPLER
+        if state is None:
+            return json.dumps({'done': False, 'error': 'not started'})
+
+        bones = {}
+        for key, accumulator in state['bones'].items():
+            sample_count = max(accumulator['count'], 1)
+            step_count = max(accumulator['step_count'], 1)
+            bones[key] = {
+                'min': accumulator['min'],
+                'max': accumulator['max'],
+                'mean': [value / sample_count for value in accumulator['sum']],
+                'rms_step': math.sqrt(accumulator['step_square_sum'] / step_count),
+                'nan': accumulator['nan'],
+            }
+
+        result = {
+            'done': state['done'],
+            'frames_collected': state['frames_collected'],
+            'bones': bones,
+        }
+        if state['error']:
+            result['error'] = state['error']
+        return json.dumps(result)
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def stop_bone_sampler() -> bool:
+        """Stops the bone sampler; the collected result stays readable and stopping an idle sampler is not an error."""
+        _stop_bone_sampler_impl()
+        return True
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def start_physics_settings_multiplier_on_actor(
+            actor_label: str,
+            settings_json: str,
+            duration: float,
+            blend_in_time: float = 0.2,
+            blend_out_time: float = 0.5,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> str:
+        """Starts a temporary physics settings multiplier on every SkeletalMeshComponent of the matching actors.
+
+        settings_json holds FKawaiiPhysicsSettingsMultiplier fields (Damping,
+        Stiffness, WorldDampingLocation, WorldDampingRotation, Radius,
+        LimitAngle); the JSON array result carries the stop handles.
+        """
+        settings_scale = _make_settings_multiplier(settings_json)
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        results = []
+        for component in components:
+            count, handle = _unpack_count_and_out(
+                unreal.KawaiiPhysicsLibrary.start_physics_settings_multiplier_on_component(
+                    component,
+                    settings_scale,
+                    duration,
+                    blend_in_time,
+                    blend_out_time,
+                    filter_tags,
+                    filter_exact_match,
+                )
+            )
+            results.append({
+                'component': component.get_name(),
+                'nodes': count,
+                'handle': _handle_to_dict(handle),
+            })
+        return json.dumps(results)
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def stop_physics_settings_multiplier_on_actor(
+            actor_label: str,
+            handle_json: str,
+            blend_out_time: float = 0.5,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> int:
+        """Stops the physics settings multiplier matching the handle and returns the total number of stopped nodes.
+
+        handle_json is the handle from start_physics_settings_multiplier_on_actor
+        ({"id": <int>} or a bare integer).
+        """
+        handle = _handle_from_json(handle_json)
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        stopped_count = 0
+        for component in components:
+            stopped_count += int(
+                unreal.KawaiiPhysicsLibrary.stop_physics_settings_multiplier_on_component(
+                    component,
+                    handle,
+                    filter_tags,
+                    filter_exact_match,
+                    blend_out_time,
+                )
+            )
+        return stopped_count
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def start_procedural_wind_gust_on_actor(
+            actor_label: str,
+            strength: float,
+            duration: float,
+            rise_time: float = 0.1,
+            decay_time: float = 0.3,
+            direction: list[float] = [1.0, 0.0, 0.0],
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> str:
+        """Starts a runtime ProceduralWind gust on every SkeletalMeshComponent of the matching actors.
+
+        direction is a world space vector; an empty list inherits the authored
+        ProceduralWind direction. The JSON array result carries the stop handles.
+        """
+        gust_direction = _make_gust_direction(direction)
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        results = []
+        for component in components:
+            count, handle = _unpack_count_and_out(
+                unreal.KawaiiPhysicsLibrary.start_procedural_wind_gust_on_component(
+                    component,
+                    strength,
+                    duration,
+                    rise_time,
+                    decay_time,
+                    filter_tags,
+                    filter_exact_match,
+                    gust_direction,
+                )
+            )
+            results.append({
+                'component': component.get_name(),
+                'nodes': count,
+                'handle': _handle_to_dict(handle),
+            })
+        return json.dumps(results)
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def stop_transient_external_force_on_actor(
+            actor_label: str,
+            handle_json: str,
+            blend_out_time: float = 0.5,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> int:
+        """Stops the transient external force matching the handle and returns the total number of stopped nodes.
+
+        handle_json is the handle from start_procedural_wind_gust_on_actor
+        ({"id": <int>} or a bare integer).
+        """
+        handle = _handle_from_json(handle_json)
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        stopped_count = 0
+        for component in components:
+            stopped_count += int(
+                unreal.KawaiiPhysicsLibrary.stop_transient_external_force_on_component(
+                    component,
+                    handle,
+                    filter_tags,
+                    filter_exact_match,
+                    blend_out_time,
+                )
+            )
+        return stopped_count
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def set_alpha_on_actor(
+            actor_label: str,
+            alpha: float,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> int:
+        """Sets the KawaiiPhysics alpha on every SkeletalMeshComponent of the matching actors and returns the number of updated components."""
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        updated_count = 0
+        for component in components:
+            if unreal.KawaiiPhysicsLibrary.set_alpha_on_component(
+                    component,
+                    alpha,
+                    filter_tags,
+                    filter_exact_match,
+            ):
+                updated_count += 1
+        return updated_count
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def get_alpha_on_actor(
+            actor_label: str,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> float:
+        """Gets the KawaiiPhysics alpha from the first matching SkeletalMeshComponent; returns -1.0 when no value is available."""
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        for component in components:
+            alpha = _unpack_bool_out(
+                unreal.KawaiiPhysicsLibrary.get_alpha_on_component(
+                    component,
+                    filter_tags,
+                    filter_exact_match,
+                ),
+                None,
+            )
+            if alpha is not None:
+                return float(alpha)
+        return -1.0
+
+    # ===== Diagnostics: Simple World Collision =====
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def get_simple_world_collision_debug_info(
+            skeletal_mesh_component: unreal.SkeletalMeshComponent
+    ) -> unreal.KawaiiPhysicsSimpleWorldCollisionDebugInfo:
+        """Returns Simple World Collision diagnostics for a SkeletalMeshComponent.
+
+        Thin wrapper over a GameThread-only diagnostics API. While PIE/SIE is
+        running, pass a component that belongs to the PIE world. An unregistered
+        component is not an error and returns has_entry == False.
+        """
+        _raise_for_invalid_object(
+            skeletal_mesh_component,
+            'skeletal_mesh_component',
         )
-        if result is None:
-            raise RuntimeError(
-                'Unexpected return value from validate_placement_requests.')
-        return [str(error) for error in result]
+
+        result = unreal.KawaiiPhysicsLibrary.get_simple_world_collision_debug_info(
+            skeletal_mesh_component)
+        # Entry が無いだけならエラーにせず has_entry == False の既定値を返す
+        return _unpack_bool_out(
+            result,
+            unreal.KawaiiPhysicsSimpleWorldCollisionDebugInfo(),
+        )
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def find_simple_world_collision_debug_info(
+            actor_label: str,
+            prefer_pie: bool = True
+    ) -> list[unreal.KawaiiPhysicsSimpleWorldCollisionDebugInfo]:
+        """Finds actors by label (PIE world first when prefer_pie) and returns Simple World Collision diagnostics for each SkeletalMeshComponent.
+
+        Lets MCP clients read gather state without injecting Python.
+        """
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        debug_infos = []
+        for component in components:
+            result = (
+                unreal.KawaiiPhysicsLibrary
+                .get_simple_world_collision_debug_info(component)
+            )
+            debug_infos.append(_unpack_bool_out(
+                result,
+                unreal.KawaiiPhysicsSimpleWorldCollisionDebugInfo(),
+            ))
+        return debug_infos
+
+    @toolset_registry.tool_call
+    @staticmethod
+    def get_simple_world_collider_count_on_actor(
+            actor_label: str,
+            filter_tag_names: list[str] = [],
+            filter_exact_match: bool = False,
+            prefer_pie: bool = True) -> int:
+        """Returns the total number of Simple World Collision colliders across every SkeletalMeshComponent of the matching actors."""
+        components = _find_skeletal_mesh_components_by_label(actor_label, prefer_pie)
+        filter_tags = _make_tag_container(filter_tag_names)
+
+        collider_count = 0
+        for component in components:
+            get_collider_count = getattr(
+                unreal.KawaiiPhysicsLibrary,
+                'get_simple_world_collider_count_on_component',
+                None,
+            )
+            if get_collider_count is None:
+                raise RuntimeError(
+                    'GetSimpleWorldColliderCountOnComponent is not available '
+                    'in this build.')
+            collider_count += int(get_collider_count(
+                component,
+                filter_tags,
+                filter_exact_match,
+            ))
+        return collider_count

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -758,10 +758,11 @@ bool UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(const FAnimNode_KawaiiP
 	if (const void* NodeValuePtr = Property->ContainerPtrToValuePtr<void>(&Node))
 	{
 		OutValueText.Reset();
+		constexpr int32 ExportPortFlags = PPF_ExternalEditor;
 #if UE_VERSION_OLDER_THAN(5, 1, 0)
-		Property->ExportTextItem(OutValueText, NodeValuePtr, nullptr, nullptr, PPF_None);
+		Property->ExportTextItem(OutValueText, NodeValuePtr, NodeValuePtr, nullptr, ExportPortFlags);
 #else
-		Property->ExportText_Direct(OutValueText, NodeValuePtr, nullptr, nullptr, PPF_None);
+		Property->ExportTextItem_Direct(OutValueText, NodeValuePtr, NodeValuePtr, nullptr, ExportPortFlags);
 #endif
 		return true;
 	}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsLibrary.cpp
@@ -17,6 +17,7 @@
 #include "GameFramework/Actor.h"
 #include "HAL/IConsoleManager.h"
 #include "KawaiiPhysics.h"
+#include "KawaiiPhysicsSharedCollisionSubsystem.h"
 #include "KawaiiPhysicsWindPresetDataAsset.h"
 #include "UObject/ScriptInterface.h"
 #include "UObject/UObjectIterator.h"
@@ -558,6 +559,59 @@ bool UKawaiiPhysicsLibrary::CollectKawaiiPhysicsNodesFromComponent(TArray<FKawai
                                                                    bool bFilterExactMatch)
 {
 	return CollectKawaiiPhysicsNodes(Nodes, MeshComp, FilterTags, bFilterExactMatch);
+}
+
+bool UKawaiiPhysicsLibrary::GetSimpleWorldCollisionDebugInfo(
+	const USkeletalMeshComponent* SkelComp,
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo)
+{
+	OutInfo = FKawaiiPhysicsSimpleWorldCollisionDebugInfo();
+	if (!SkelComp)
+	{
+		return false;
+	}
+
+	UWorld* World = SkelComp->GetWorld();
+	if (!World)
+	{
+		return false;
+	}
+
+	UKawaiiPhysicsSharedCollisionSubsystem* Subsystem =
+		World->GetSubsystem<UKawaiiPhysicsSharedCollisionSubsystem>();
+	if (!Subsystem)
+	{
+		return false;
+	}
+
+	return Subsystem->BuildSimpleWorldCollisionDebugInfo(SkelComp, OutInfo);
+}
+
+int32 UKawaiiPhysicsLibrary::GetSimpleWorldColliderCountOnComponent(
+	USkeletalMeshComponent* MeshComp,
+	const FGameplayTagContainer& FilterTags,
+	const bool bFilterExactMatch)
+{
+	if (!MeshComp)
+	{
+		return 0;
+	}
+
+	int32 Count = 0;
+
+	TArray<FKawaiiPhysicsReference> KawaiiPhysicsReferences;
+	CollectKawaiiPhysicsNodes(KawaiiPhysicsReferences, MeshComp, FilterTags, bFilterExactMatch);
+	for (auto& KawaiiPhysicsReference : KawaiiPhysicsReferences)
+	{
+		KawaiiPhysicsReference.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+			TEXT("GetSimpleWorldColliderCountOnComponent"),
+			[&Count](FAnimNode_KawaiiPhysics& InKawaiiPhysics)
+			{
+				Count += InKawaiiPhysics.GetNumSimpleWorldColliders();
+			});
+	}
+
+	return Count;
 }
 
 bool UKawaiiPhysicsLibrary::IsNodePropertyAccessible(const FProperty* Property)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -833,6 +833,12 @@ bool FKawaiiPhysicsSimpleWorldCollisionEntry::HasAnyDesc() const
 	return !DescSlots.IsEmpty();
 }
 
+int32 FKawaiiPhysicsSimpleWorldCollisionEntry::GetNumDescs() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	return DescSlots.Num();
+}
+
 bool FKawaiiPhysicsSimpleWorldCollisionEntry::BuildMergedDesc(
 	FKawaiiPhysicsSimpleWorldCollisionDesc& OutMerged) const
 {
@@ -964,6 +970,93 @@ TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> UKawaiiPhysicsSharedCollisionSubs
 		return nullptr;
 	}
 	return FindEntryByKey(Key);
+}
+
+void UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(
+	const FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo)
+{
+	OutInfo = FKawaiiPhysicsSimpleWorldCollisionDebugInfo();
+	OutInfo.bHasEntry = true;
+	OutInfo.NumDescs = Entry.GetNumDescs();
+	OutInfo.NumGatheredComponents = Entry.GatheredComponents.Num();
+	OutInfo.bHasGroundBox = Entry.bHasGroundBox;
+	OutInfo.GroundSource = Entry.GroundSource;
+	OutInfo.GroundBoxSource = Entry.GroundBoxSource;
+	OutInfo.GroundBoxLocation = Entry.GroundBox.Location;
+	OutInfo.GroundBoxRotation = Entry.GroundBox.Rotation.Rotator();
+	OutInfo.GroundBoxExtent = Entry.GroundBox.Extent;
+	OutInfo.GatherRadius = Entry.LastGatherRadius;
+	OutInfo.TimeSinceLastGather = Entry.TimeSinceLastGather == FLT_MAX ? -1.0f : Entry.TimeSinceLastGather;
+	OutInfo.bHasGatheredOnce = Entry.bHasGatheredOnce;
+
+	OutInfo.GatheredComponentNames.Reserve(Entry.GatheredComponents.Num());
+	for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent : Entry.GatheredComponents)
+	{
+		if (GatheredComponent.bStatic)
+		{
+			++OutInfo.NumStaticComponents;
+		}
+		else
+		{
+			++OutInfo.NumMovableComponents;
+		}
+
+		OutInfo.NumSkeletalBodies += GatheredComponent.BodyBindings.Num();
+		OutInfo.MinFadeAlpha = FMath::Min(OutInfo.MinFadeAlpha, GatheredComponent.FadeAlpha);
+
+		FString ComponentName;
+		if (const UPrimitiveComponent* Component = GatheredComponent.Component.Get())
+		{
+			const AActor* OwnerActor = Component->GetOwner();
+			const FString OwnerName = OwnerActor ? OwnerActor->GetActorNameOrLabel() : FString(TEXT("<no owner>"));
+			ComponentName = FString::Printf(TEXT("%s:%s"), *OwnerName, *Component->GetName());
+		}
+		else
+		{
+			ComponentName = TEXT("<invalid>");
+		}
+
+		if (GatheredComponent.InstanceIndex != INDEX_NONE)
+		{
+			ComponentName += FString::Printf(TEXT("[%d]"), GatheredComponent.InstanceIndex);
+		}
+		OutInfo.GatheredComponentNames.Add(MoveTemp(ComponentName));
+	}
+}
+
+bool UKawaiiPhysicsSharedCollisionSubsystem::BuildSimpleWorldCollisionDebugInfo(
+	const USkeletalMeshComponent* SkelComp,
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo) const
+{
+	OutInfo = FKawaiiPhysicsSimpleWorldCollisionDebugInfo();
+
+#if !UE_BUILD_SHIPPING
+	if (!ensure(IsInGameThread()) || !SkelComp)
+	{
+		return false;
+	}
+
+	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry;
+	{
+		FReadScopeLock ReadLock(SimpleWorldRegistryLock);
+		if (const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Found =
+			SimpleWorldRegistry.Find(TWeakObjectPtr<const USkeletalMeshComponent>(SkelComp)))
+		{
+			Entry = *Found;
+		}
+	}
+
+	if (!Entry.IsValid())
+	{
+		return false;
+	}
+
+	FillSimpleWorldCollisionDebugInfo(*Entry, OutInfo);
+	return true;
+#else
+	return false;
+#endif
 }
 
 void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float DeltaTime)
@@ -1100,6 +1193,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 		if (bShouldGather)
 		{
 			SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Gather);
+			Entry->LastGatherRadius = Radius;
 
 			const FCollisionObjectQueryParams ObjectQueryParams = BuildSimpleWorldObjectQueryParams(Desc.ObjectTypes);
 			FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(KawaiiPhysicsSimpleWorldCollision), false);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsLibraryTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsLibraryTest.cpp
@@ -1,0 +1,104 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "KawaiiPhysicsLibrary.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsLibraryPropertyStringRoundTripTest,
+                                 "KawaiiPhysics.Library.PropertyStringRoundTrip",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsLibraryPropertyStringRoundTripTest::RunTest(const FString& Parameters)
+{
+	bool bOk = true;
+	FString ValueText;
+
+	FAnimNode_KawaiiPhysics Node;
+	bOk &= TestTrue(TEXT("Set bool false"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, bUseSimpleWorldCollision),
+		                TEXT("False")));
+	bOk &= TestTrue(TEXT("Get bool false"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, bUseSimpleWorldCollision),
+		                ValueText));
+	bOk &= TestEqual(TEXT("Bool false string"), ValueText, FString(TEXT("False")));
+
+	bOk &= TestTrue(TEXT("Set bool true"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, bUseSimpleWorldCollision),
+		                TEXT("True")));
+	bOk &= TestTrue(TEXT("Get bool true"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, bUseSimpleWorldCollision),
+		                ValueText));
+	bOk &= TestEqual(TEXT("Bool true string"), ValueText, FString(TEXT("True")));
+
+	bOk &= TestTrue(TEXT("Set skeletal mesh collision enum"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionSkeletalMeshCollision),
+		                TEXT("None")));
+	bOk &= TestTrue(TEXT("Get skeletal mesh collision enum"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionSkeletalMeshCollision),
+		                ValueText));
+	bOk &= TestEqual(TEXT("Enum None string"), ValueText, FString(TEXT("None")));
+
+	bOk &= TestTrue(TEXT("Set convex fallback enum"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionConvexFallbackShape),
+		                TEXT("BoundingBox")));
+	bOk &= TestTrue(TEXT("Get convex fallback enum"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionConvexFallbackShape),
+		                ValueText));
+	bOk &= TestEqual(TEXT("Enum BoundingBox string"), ValueText, FString(TEXT("BoundingBox")));
+
+	bOk &= TestTrue(TEXT("Set float"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionGatherInterval),
+		                TEXT("0.125")));
+	bOk &= TestTrue(TEXT("Get float"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionGatherInterval),
+		                ValueText));
+	FAnimNode_KawaiiPhysics FloatRoundTripNode;
+	bOk &= TestTrue(TEXT("Import float round-trip string"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                FloatRoundTripNode,
+		                GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, SimpleWorldCollisionGatherInterval),
+		                ValueText));
+	bOk &= TestTrue(TEXT("Float string round-trips"),
+	                FMath::IsNearlyEqual(FloatRoundTripNode.SimpleWorldCollisionGatherInterval,
+	                                     Node.SimpleWorldCollisionGatherInterval));
+
+	bOk &= TestTrue(TEXT("Set FName array"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, IgnoreBoneNamePrefix),
+		                TEXT("(KP_Left,KP_Right)")));
+	bOk &= TestTrue(TEXT("Get FName array"),
+	                UKawaiiPhysicsLibrary::GetNodePropertyValueAsString(
+		                Node, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, IgnoreBoneNamePrefix),
+		                ValueText));
+	FAnimNode_KawaiiPhysics NameRoundTripNode;
+	bOk &= TestTrue(TEXT("Import FName round-trip string"),
+	                UKawaiiPhysicsLibrary::SetNodePropertyValueFromString(
+		                NameRoundTripNode, GET_MEMBER_NAME_CHECKED(FAnimNode_KawaiiPhysics, IgnoreBoneNamePrefix),
+		                ValueText));
+	bOk &= TestEqual(TEXT("FName array count round-trips"),
+	                 NameRoundTripNode.IgnoreBoneNamePrefix.Num(),
+	                 Node.IgnoreBoneNamePrefix.Num());
+	for (int32 NameIndex = 0;
+	     NameIndex < NameRoundTripNode.IgnoreBoneNamePrefix.Num() && NameIndex < Node.IgnoreBoneNamePrefix.Num();
+	     ++NameIndex)
+	{
+		bOk &= TestEqual(FString::Printf(TEXT("FName array element %d round-trips"), NameIndex),
+		                 NameRoundTripNode.IgnoreBoneNamePrefix[NameIndex],
+		                 Node.IgnoreBoneNamePrefix[NameIndex]);
+	}
+
+	return bOk;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -6,6 +6,7 @@
 #include "KawaiiPhysicsTestHarness.h"
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "Components/StaticMeshComponent.h"
 #include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
 
@@ -863,6 +864,110 @@ bool FKawaiiPhysicsSimpleWorldEntryLifecycleTest::RunTest(const FString& Paramet
 }
 
 // ---------------------------------------------------------------------------
+//  DebugInfo
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldDebugInfoTest,
+                                 "KawaiiPhysics.SimpleWorld.DebugInfo",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldDebugInfoTest::RunTest(const FString& Parameters)
+{
+	{
+		FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+		FKawaiiPhysicsSimpleWorldCollisionDebugInfo Info;
+		UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(Entry, Info);
+
+		TestTrue(TEXT("Empty entry sets bHasEntry"), Info.bHasEntry);
+		TestEqual(TEXT("Empty entry NumDescs"), Info.NumDescs, 0);
+		TestEqual(TEXT("Empty entry NumGatheredComponents"), Info.NumGatheredComponents, 0);
+		TestEqual(TEXT("Empty entry NumStaticComponents"), Info.NumStaticComponents, 0);
+		TestEqual(TEXT("Empty entry NumMovableComponents"), Info.NumMovableComponents, 0);
+		TestEqual(TEXT("Empty entry NumSkeletalBodies"), Info.NumSkeletalBodies, 0);
+		TestEqual(TEXT("Empty entry gathered names"), Info.GatheredComponentNames.Num(), 0);
+		TestTrue(TEXT("Empty entry MinFadeAlpha"),
+		         FMath::IsNearlyEqual(Info.MinFadeAlpha, 1.0f, GSimpleWorldTol));
+		TestFalse(TEXT("Empty entry has no ground box"), Info.bHasGroundBox);
+		TestTrue(TEXT("Empty entry GroundSource is None"),
+		         Info.GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::None);
+		TestTrue(TEXT("Empty entry GroundBoxSource is None"),
+		         Info.GroundBoxSource == EKawaiiPhysicsSimpleWorldGroundSource::None);
+		TestTrue(TEXT("Empty entry TimeSinceLastGather is sentinel"),
+		         FMath::IsNearlyEqual(Info.TimeSinceLastGather, -1.0f, GSimpleWorldTol));
+	}
+
+	{
+		FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+
+		FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& StaticComponent =
+			Entry.GatheredComponents.AddDefaulted_GetRef();
+		StaticComponent.Component = NewObject<UStaticMeshComponent>(GetTransientPackage());
+		StaticComponent.bStatic = true;
+		StaticComponent.FadeAlpha = 1.0f;
+
+		FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& InvalidInstanceComponent =
+			Entry.GatheredComponents.AddDefaulted_GetRef();
+		InvalidInstanceComponent.bStatic = false;
+		InvalidInstanceComponent.FadeAlpha = 0.25f;
+		InvalidInstanceComponent.InstanceIndex = 2;
+
+		FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& SkeletalBodyComponent =
+			Entry.GatheredComponents.AddDefaulted_GetRef();
+		SkeletalBodyComponent.bStatic = false;
+		SkeletalBodyComponent.BodyBindings.SetNum(2);
+
+		Entry.bHasGroundBox = true;
+		Entry.GroundBox.Location = FVector(1.0f, 2.0f, 3.0f);
+		Entry.GroundBox.Extent = FVector(10.0f, 20.0f, 30.0f);
+		Entry.GroundSource = EKawaiiPhysicsSimpleWorldGroundSource::Provider;
+		Entry.GroundBoxSource = EKawaiiPhysicsSimpleWorldGroundSource::CharacterMovement;
+		Entry.LastGatherRadius = 123.0f;
+		Entry.TimeSinceLastGather = 0.05f;
+
+		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+		Entry.SetDesc(1, Desc);
+		Entry.SetDesc(2, Desc);
+
+		FKawaiiPhysicsSimpleWorldCollisionDebugInfo Info;
+		UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(Entry, Info);
+
+		TestTrue(TEXT("Filled entry sets bHasEntry"), Info.bHasEntry);
+		TestEqual(TEXT("Filled entry NumGatheredComponents"), Info.NumGatheredComponents, 3);
+		TestEqual(TEXT("Filled entry NumStaticComponents"), Info.NumStaticComponents, 1);
+		TestEqual(TEXT("Filled entry NumMovableComponents"), Info.NumMovableComponents, 2);
+		TestEqual(TEXT("Filled entry NumSkeletalBodies"), Info.NumSkeletalBodies, 2);
+		TestEqual(TEXT("Filled entry GatheredComponentNames"), Info.GatheredComponentNames.Num(), 3);
+		if (Info.GatheredComponentNames.Num() == 3)
+		{
+			TestTrue(TEXT("Valid component name uses no-owner prefix"),
+			         Info.GatheredComponentNames[0].StartsWith(TEXT("<no owner>:")));
+			TestTrue(TEXT("Valid component name includes component name"),
+			         Info.GatheredComponentNames[0].Contains(TEXT(":StaticMeshComponent")));
+			TestEqual(TEXT("Invalid ISM name keeps instance index"),
+			          Info.GatheredComponentNames[1], FString(TEXT("<invalid>[2]")));
+			TestEqual(TEXT("Invalid component name"), Info.GatheredComponentNames[2], FString(TEXT("<invalid>")));
+		}
+		TestTrue(TEXT("Filled entry MinFadeAlpha"),
+		         FMath::IsNearlyEqual(Info.MinFadeAlpha, 0.25f, GSimpleWorldTol));
+		TestEqual(TEXT("Filled entry NumDescs"), Info.NumDescs, 2);
+		TestTrue(TEXT("Filled entry GatherRadius"),
+		         FMath::IsNearlyEqual(Info.GatherRadius, 123.0f, GSimpleWorldTol));
+		TestTrue(TEXT("Filled entry TimeSinceLastGather"),
+		         FMath::IsNearlyEqual(Info.TimeSinceLastGather, 0.05f, GSimpleWorldTol));
+		TestTrue(TEXT("Filled entry GroundBoxLocation"),
+		         Info.GroundBoxLocation.Equals(FVector(1.0f, 2.0f, 3.0f), GSimpleWorldTol));
+		TestTrue(TEXT("Filled entry GroundBoxExtent"),
+		         Info.GroundBoxExtent.Equals(FVector(10.0f, 20.0f, 30.0f), GSimpleWorldTol));
+		TestTrue(TEXT("Filled entry has ground box"), Info.bHasGroundBox);
+		TestTrue(TEXT("Filled entry GroundSource"),
+		         Info.GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::Provider);
+		TestTrue(TEXT("Filled entry GroundBoxSource"),
+		         Info.GroundBoxSource == EKawaiiPhysicsSimpleWorldGroundSource::CharacterMovement);
+	}
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
 //  FKawaiiPhysicsSimpleWorldCollisionEntry の即時cleanup回帰
 // ---------------------------------------------------------------------------
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldEntrySetDescSurvivesImmediateCleanupTest,
@@ -950,6 +1055,10 @@ bool FKawaiiPhysicsSimpleWorldCollisionPushOutTest::RunTest(const FString& Param
 		FKawaiiPhysicsTestAccessor A;
 		BuildChain(A);
 		A.SetSimpleWorldLimits(SphereLimits, EmptyCapsules, EmptyTaperedCapsules, EmptyBoxes);
+
+		TestEqual(TEXT("Injected SimpleWorld collider count"),
+		          A.Node.GetNumSimpleWorldColliders(),
+		          SphereLimits.Num() + EmptyCapsules.Num() + EmptyTaperedCapsules.Num() + EmptyBoxes.Num());
 
 		A.StepFrame(1.0f / 60.0f);
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -1163,6 +1163,18 @@ public:
 	}
 
 	/**
+	 * 現在読み込んでいるシンプルワールドコリジョン形状数を返す。
+	 * Returns the number of Simple World Collision shapes currently read by this node.
+	 */
+	int32 GetNumSimpleWorldColliders() const
+	{
+		return SimpleWorldSphericalLimits.Num()
+			+ SimpleWorldCapsuleLimits.Num()
+			+ SimpleWorldTaperedCapsuleLimits.Num()
+			+ SimpleWorldBoxLimits.Num();
+	}
+
+	/**
 	 * Get Transform from BaseBoneSpace to ComponentSpace.
 	 */
 	FTransform GetBaseBoneSpace2ComponentSpace() const

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsLibrary.h
@@ -1138,6 +1138,44 @@ public:
 		KAWAIIPHYSICS_VALUE_GETTER(float, SimpleWorldCollisionGatherInterval);
 	}
 
+	/**
+	 * シンプルワールドコリジョンの診断情報（収集件数・地面ソース等）を取得。GameThread 専用（BlueprintThreadSafe ではない）。
+	 * Entry が無い（ノード未初期化・機能 OFF・Shipping ビルド）場合は false。
+	 * Get Simple World Collision diagnostics (gathered counts, ground source, etc.). GameThread only (not BlueprintThreadSafe).
+	 * Returns false when no entry exists (node not initialized, feature off, or Shipping build).
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics|Simple World Collision", meta = (DevelopmentOnly))
+	static bool GetSimpleWorldCollisionDebugInfo(const USkeletalMeshComponent* SkelComp,
+	                                             FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo);
+
+	/**
+	 * ノードが現在読み込んでいるシンプルワールドコリジョン形状の総数（Sphere+Capsule+TaperedCapsule+Box）
+	 * Total number of Simple World Collision shapes currently read by the node (Sphere+Capsule+TaperedCapsule+Box)
+	 */
+	UFUNCTION(BlueprintPure, Category = "Kawaii Physics|Simple World Collision", meta=(BlueprintThreadSafe))
+	static int32 GetSimpleWorldColliderCount(const FKawaiiPhysicsReference& KawaiiPhysics)
+	{
+		int32 Count = 0;
+		KawaiiPhysics.CallAnimNodeFunction<FAnimNode_KawaiiPhysics>(
+			TEXT("GetSimpleWorldColliderCount"),
+			[&Count](FAnimNode_KawaiiPhysics& Node)
+			{
+				Count = Node.GetNumSimpleWorldColliders();
+			});
+		return Count;
+	}
+
+	/**
+	 * コンポーネント内の（タグ一致する）全 KawaiiPhysics ノードが現在読み込んでいるシンプルワールドコリジョン形状数の合計。
+	 * ノードが無い／一致しない場合は 0。GameThread 専用。
+	 * Total number of Simple World Collision shapes currently read by all (tag-matched) KawaiiPhysics nodes in the component.
+	 * Returns 0 when no node matches. GameThread only.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Kawaii Physics|Simple World Collision", meta = (AutoCreateRefTerm = "FilterTags"))
+	static int32 GetSimpleWorldColliderCountOnComponent(USkeletalMeshComponent* MeshComp,
+	                                                    const FGameplayTagContainer& FilterTags,
+	                                                    bool bFilterExactMatch = false);
+
 	static bool IsNodePropertyAccessible(const FProperty* Property);
 	static bool IsNodePropertyAccessible(FName PropertyName);
 	static bool DoesNodePropertyRequireModifyBonesReinit(FName PropertyName);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -24,12 +24,13 @@ class USkinnedAsset;
 class UCharacterMovementComponent;
 
 // 地面ソースの種類（DebugDraw の色分けにも使う） / Ground source kind (also used for debug draw colors)
+UENUM(BlueprintType)
 enum class EKawaiiPhysicsSimpleWorldGroundSource : uint8
 {
-	None,
-	Provider,
-	CharacterMovement,
-	Trace,
+	None UMETA(DisplayName = "None"),
+	Provider UMETA(DisplayName = "Provider"),
+	CharacterMovement UMETA(DisplayName = "Character Movement"),
+	Trace UMETA(DisplayName = "Trace"),
 };
 
 /**
@@ -161,6 +162,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	void RemoveExpiredDescs(uint64 CurrentFrame, uint64 MaxAge);
 	bool HasAnyDesc() const;
 	bool BuildMergedDesc(FKawaiiPhysicsSimpleWorldCollisionDesc& OutMerged) const;
+	int32 GetNumDescs() const;
 
 	void RequestRegather();
 	bool ConsumeRegatherRequested();
@@ -169,6 +171,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 
 	// Tick スレッド専有・ロック不要 / Tick-thread only; no lock required.
 	float TimeSinceLastGather = FLT_MAX;
+	// 直近の収集で使った実効半径 / Effective radius used by the latest gather
+	float LastGatherRadius = 0.0f;
 
 	struct FGatheredComponent
 	{
@@ -250,6 +254,80 @@ private:
 	std::atomic<bool> bRegatherRequested{false};
 };
 
+USTRUCT(BlueprintType)
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDebugInfo
+{
+	GENERATED_BODY()
+
+	// SkelComp に対応する SimpleWorld Entry が存在したか / Whether a SimpleWorld entry exists for SkelComp
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	bool bHasEntry = false;
+
+	// Entry に登録されている Desc 数（ノード数） / Number of descs registered to the entry (node count)
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumDescs = 0;
+
+	// GatheredComponents.Num() / GatheredComponents.Num()
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumGatheredComponents = 0;
+
+	// bStatic == true の件数 / Number of entries with bStatic == true
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumStaticComponents = 0;
+
+	// bStatic == false の件数 / Number of entries with bStatic == false
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumMovableComponents = 0;
+
+	// 全 GatheredComponents の BodyBindings.Num() 合計 / Sum of BodyBindings.Num() across all GatheredComponents
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumSkeletalBodies = 0;
+
+	// 収集順のコンポーネント名 / Component names in gathered order
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	TArray<FString> GatheredComponentNames;
+
+	// 収集コンポーネントの FadeAlpha の最小値（0 件なら 1.0） / Minimum FadeAlpha of gathered components (1.0 when empty)
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	float MinFadeAlpha = 1.0f;
+
+	// Entry.bHasGroundBox / Entry.bHasGroundBox
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	bool bHasGroundBox = false;
+
+	// Entry.GroundSource / Entry.GroundSource
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	EKawaiiPhysicsSimpleWorldGroundSource GroundSource = EKawaiiPhysicsSimpleWorldGroundSource::None;
+
+	// Entry.GroundBoxSource / Entry.GroundBoxSource
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	EKawaiiPhysicsSimpleWorldGroundSource GroundBoxSource = EKawaiiPhysicsSimpleWorldGroundSource::None;
+
+	// Entry.GroundBox.Location（bHasGroundBox 時のみ意味あり） / Entry.GroundBox.Location (meaningful only when bHasGroundBox)
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	FVector GroundBoxLocation = FVector::ZeroVector;
+
+	// Entry.GroundBox.Rotation.Rotator() / Entry.GroundBox.Rotation.Rotator()
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	FRotator GroundBoxRotation = FRotator::ZeroRotator;
+
+	// Entry.GroundBox.Extent / Entry.GroundBox.Extent
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	FVector GroundBoxExtent = FVector::ZeroVector;
+
+	// 直近の収集で使った実効半径 / Effective radius used by the latest gather
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	float GatherRadius = 0.0f;
+
+	// Entry.TimeSinceLastGather（FLT_MAX のときは -1.0） / Entry.TimeSinceLastGather (-1.0 when FLT_MAX)
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	float TimeSinceLastGather = 0.0f;
+
+	// Entry.bHasGatheredOnce / Entry.bHasGatheredOnce
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	bool bHasGatheredOnce = false;
+};
+
 /**
  * KawaiiPhysics AnimNode間でコリジョンデータを共有するためのWorldSubsystem
  * WorldSubsystem for sharing collision data between KawaiiPhysics AnimNodes in an attached actor family
@@ -290,6 +368,22 @@ public:
 	 * For targets: Find an entry for the actor family root. Thread-safe via RegistryLock; callable from any thread.
 	 */
 	TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> FindEntry(AActor* Actor, const FGameplayTag& Tag) const;
+
+	/**
+	 * Entry の Tick 専有データから診断情報を詰める（GameThread 専用。テストから直接呼べるよう static）
+	 * Fill diagnostics from an entry's tick-owned data (GameThread only; static so tests can call it directly)
+	 */
+	static void FillSimpleWorldCollisionDebugInfo(const FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	                                              FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo);
+
+	/**
+	 * SkelComp の SimpleWorld Entry を検索し診断情報を返す。Entry が無ければ false（OutInfo は既定値＋bHasEntry=false）。
+	 * GameThread 専用。Shipping では常に false。
+	 * Look up the SimpleWorld entry for SkelComp and return diagnostics. Returns false when no entry exists
+	 * (OutInfo is reset with bHasEntry=false). GameThread only. Always false in Shipping builds.
+	 */
+	bool BuildSimpleWorldCollisionDebugInfo(const USkeletalMeshComponent* SkelComp,
+	                                        FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo) const;
 
 	// USubsystem interface
 	virtual void Deinitialize() override;


### PR DESCRIPTION
## 概要

Simple World Collision の内部状態（収集件数・収集コンポーネント名・地面ソース・地面 Box 等）を Blueprint / Python から読める診断 API を追加し、
Python MCP toolset（`kawaii_physics_toolset`）をエディタ系 / ランタイム検証系 / 診断系の 3 節に整理して汎用ツールを拡充しました。
あわせて、名前指定プロパティ取得（`GetGraphNodePropertyAsString` 等）が bool の false と enum で空文字を返していた不具合を修正しています。

## 変更内容

- 診断 API（本体は `#if !UE_BUILD_SHIPPING`、Shipping では常に false）
  - `EKawaiiPhysicsSimpleWorldGroundSource` を `UENUM(BlueprintType)` 化
  - `FKawaiiPhysicsSimpleWorldCollisionDebugInfo`（Entry 有無・Desc 数・収集件数（Static / Movable / SkeletalBodies）・収集コンポーネント名・最小 FadeAlpha・地面 Box の有無 / ソース / 位置 / 回転 / Extent・収集半径・最終収集からの経過時間）
  - `UKawaiiPhysicsLibrary::GetSimpleWorldCollisionDebugInfo(SkelComp, OutInfo)`（`DevelopmentOnly`）、`GetSimpleWorldColliderCount(ref)`、`GetSimpleWorldColliderCountOnComponent(MeshComp, FilterTags, bExact)`
  - `FKawaiiPhysicsSimpleWorldCollisionEntry::LastGatherRadius` / `GetNumDescs()`、`FAnimNode_KawaiiPhysics::GetNumSimpleWorldColliders()`
- 不具合修正: `UKawaiiPhysicsLibrary::GetNodePropertyValueAsString` が `ExportText_Direct(Delta=nullptr)` で既定値との差分 export になっており、bool false / 列挙値 0 が空文字になっていた → `ExportTextItem_Direct(Data, Data, nullptr, PPF_ExternalEditor)` で常時 export。回帰テスト `KawaiiPhysics.Library.PropertyStringRoundTrip` を追加
- Python MCP toolset（26 → 43 ツール）
  - エディタ: `set_graph_nodes_property` / `get_graph_nodes_property` / `describe_graph_nodes`
  - ランタイム（PIE）: `execute_console_command` / `find_kawaii_physics_actors` / `start_bone_sampler` / `get_bone_sampler_result` / `stop_bone_sampler` / `start_physics_settings_multiplier_on_actor` / `stop_physics_settings_multiplier_on_actor` / `start_procedural_wind_gust_on_actor` / `stop_transient_external_force_on_actor` / `set_alpha_on_actor` / `get_alpha_on_actor`
  - 診断: `get_simple_world_collision_debug_info` / `find_simple_world_collision_debug_info` / `get_simple_world_collider_count_on_actor`
  - ツール同士の内部呼び出しを素の関数へ切り出し（ラッパが例外を握って既定値を返す問題の回避）。テスト 29 ケース追加

## 確認

- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 239/239（フィルタ: KawaiiPhysics。新規 `SimpleWorld.DebugInfo`、`Library.PropertyStringRoundTrip`）
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件（WARN 0 件）
- Python toolset テスト: 65 本中 62 pass（`test_apply_preset_*` 3 本は master 時点から失敗している既知の Asset Registry 反映待ち問題で本 PR とは無関係）
- 実機（UE 5.8、SIE）: 検証用レベルで Simple World Collision を数値検証（Twintail ボーンの貫入深さ cm と新 API の収集件数 / 地面ソース）
  - 基本押し出し（Sphere への貫入 29cm → 0cm）、除外タグ付き Actor が未収集、`MaxComponents 0` で収集 0 件、`Enable 0/1` の停止と復帰、Movable 追従、障害物 Destroy 後に旧形状で押さないこと
  - 地面 Box: `Ground Collision` OFF で床下 15.5cm → ON で 0cm、Character は `CharacterMovement` ソース、SkeletalMeshActor は `Trace`、`UseMovementGround 0` で `Trace` へ切替
  - Skeletal Mesh Collision: `None` → 未収集 / `BoundingBox` → 収集して押し出し（軸平行 Box）/ `PhysicsAsset` → 32 body 収集（DebugDraw で形状確認）
  - Convex Fallback Shape: `BoundingBox` / `BoundingSphere` / `None`（未収集）
  - エディタ内自動テスト（AutomationTestToolset）: `KawaiiPhysics.SimpleWorld.*` 14/14
- PIE: docs/pie/SimpleWorldCollision_PIE_Checklist.md「MCP 実機検証結果」に 13 項目記録済、残り目視 約 30 項目（INDEX.md 更新済）
- 性能: ホットパス変更なし（診断 API は読み取り専用、収集フレームで float 1 個の代入のみ）
