### PR TITLE
[improve] Add Units meta to unit-bearing UPROPERTYs

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -171,7 +171,7 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	* 0より大きい場合は、制御ボーンの末端にダミーボーンを追加。ダミーボーンを追加することで、末端のボーンの物理制御を改善
 	* Add a dummy bone to the end bone if it's above 0. It affects end bone rotation. 
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bones", meta = (PinHiddenByDefault, ClampMin = "0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Bones", meta = (PinHiddenByDefault, ClampMin = "0", Units = "cm"))
 	float DummyBoneLength = 0.0f;
 
 	/**
@@ -286,14 +286,14 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	* 1フレームにおけるSkeletalMeshComponentの移動量が設定値を超えた場合、その移動量を物理制御に反映しない
 	* If the amount of movement of a SkeletalMeshComponent in one frame exceeds the set value, that amount of movement will not be reflected in the physics control.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault, Units = "cm"))
 	float TeleportDistanceThreshold = 300.0f;
 
 	/** 
 	* 1フレームにおけるSkeletalMeshComponentの回転量が設定値を超えた場合、その回転量を物理制御に反映しない
 	* If the rotation amount of SkeletalMeshComponent in one frame exceeds the set value, the rotation amount will not be reflected in the physics control.
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Physics Settings", meta = (PinHiddenByDefault, Units = "Degrees"))
 	float TeleportRotationThreshold = 10.0f;
 
 	/** 
@@ -811,7 +811,7 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Collision|Simple World Collision",
 		meta = (PinHiddenByDefault, EditCondition = "bUseSimpleWorldCollision", ClampMin = "0.0", ClampMax = "10.0",
-		DisplayName = "Gather Interval"))
+		DisplayName = "Gather Interval", Units = "s"))
 	float SimpleWorldCollisionGatherInterval = 0.2f;
 
 	/**
@@ -842,7 +842,7 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Collision|Simple World Collision",
 		meta = (PinHiddenByDefault, EditCondition = "bOverrideSimpleWorldCollisionGatherRadius", ClampMin = "0",
-		DisplayName = "Gather Radius"))
+		DisplayName = "Gather Radius", Units = "cm"))
 	float SimpleWorldCollisionGatherRadius = 200.0f;
 
 	/**

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotifyState_KawaiiPhysicsSettingsMultiplier.h
@@ -60,11 +60,11 @@ public:
 	/** 区間先頭からの立ち上がり秒 / Rise time from the start of the section, in seconds. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weight",
 		meta=(ClampMin="0.0", UIMin="0.0",
-			EditCondition="WeightSource == EKawaiiPhysicsSettingsMultiplierWeightSource::Envelope", EditConditionHides))
+			EditCondition="WeightSource == EKawaiiPhysicsSettingsMultiplierWeightSource::Envelope", EditConditionHides, Units="s"))
 	float BlendInTime = 0.2f;
 
 	/** Envelope では区間末尾の減衰秒。区間が途中で終了した場合（Montage 中断など）と Curve モードでは、NotifyEnd 時にこの秒数で現在の重みから 0 へフェードする / In Envelope mode, decay seconds at the end of the section. If the section ends early (for example, Montage interruption) and in Curve mode, NotifyEnd fades from the current weight to 0 over this duration. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weight", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weight", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float BlendOutTime = 0.2f;
 
 	/** WeightSource=Curve の時に参照するカーブ名 / Curve name used when WeightSource is Curve. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsSettingsMultiplier.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsSettingsMultiplier.h
@@ -34,15 +34,15 @@ public:
 	FKawaiiPhysicsSettingsMultiplier SettingsScale;
 
 	/** BlendIn/BlendOut 込みの合計秒。0 以下は何もしない / Total seconds including BlendIn and BlendOut. 0 or less does nothing. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float Duration = 1.0f;
 
 	/** 立ち上がり時間（秒） / Blend-in time, in seconds. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float BlendInTime = 0.2f;
 
 	/** 減衰時間（秒） / Blend-out time, in seconds. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings Multiplier", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float BlendOutTime = 0.5f;
 
 	/** 適用するノードを Tag でフィルタ（空なら全ノード対象） / Tags used to filter target nodes; empty targets all nodes. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNotifies/AnimNotify_KawaiiPhysicsTriggerGust.h
@@ -32,15 +32,15 @@ public:
 	float Strength = 0.0f;
 
 	/** 立ち上がり時間（秒） / Rise time, in seconds. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float RiseTime = 0.0f;
 
 	/** ピーク強度を保持する時間（秒）。0で従来の三角形エンベロープ / Hold time at peak strength, in seconds. 0 keeps the legacy triangular envelope. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float HoldTime = 0.0f;
 
 	/** 減衰時間（秒） / Decay time, in seconds. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Wind", meta=(ClampMin="0.0", UIMin="0.0", Units="s"))
 	float DecayTime = 0.0f;
 
 	/** 突風の方向（ワールド空間・非正規化可）。ゼロなら既存 ProceduralWind の風向き等を継承 / Gust direction (world space; may be non-normalized). Zero inherits from an authored ProceduralWind. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_Basic.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_Basic.h
@@ -28,7 +28,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysics_ExternalForce_Basic : public FKawaiiPhys
 	FRuntimeFloatCurve ForceRateByBoneLengthRate;
 
 	/** 外力を適用する間隔 / Interval for applying the force */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce", meta=(Units="s"))
 	float Interval = 0.0f;
 
 	virtual void PreApply(FAnimNode_KawaiiPhysics& Node, FComponentSpacePoseContext& PoseContext) override;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h
@@ -108,7 +108,7 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 	bool bOverrideSwayPhaseOffset = false;
 
 	/** 一斉揺れ(Sway)の開始位相 / Sway start phase offset. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Units="Degrees"), Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
 	float SwayPhaseOffset = 0.0f;
 
 	/** RippleForce を上書きする / Override RippleForce. */
@@ -132,7 +132,7 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 	bool bOverrideRipplePhaseOffset = false;
 
 	/** 波揺れ(Ripple)の位相 / Spatial wave phase. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Units="Degrees"), Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
 	float RipplePhaseOffset = 0.0f;
 
 	/** RippleTipPhaseDelay を上書きする / Override RippleTipPhaseDelay. */
@@ -140,7 +140,7 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 	bool bOverrideRippleTipPhaseDelay = false;
 
 	/** 毛先 r=1 での位相遅れ量 / Phase delay at tip r=1. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Units="Degrees"), Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
 	float RippleTipPhaseDelay = 180.0f;
 
 	/** StrengthCycleRange を上書きする / Override StrengthCycleRange. */
@@ -164,7 +164,7 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 	bool bOverrideStrengthCyclePhaseOffset = false;
 
 	/** 強弱サイクル(StrengthCycle)位相 / StrengthCycle phase. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Units="Degrees"), Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
 	float StrengthCyclePhaseOffset = 0.0f;
 
 	/** RandomForce を上書きする / Override RandomForce. */
@@ -188,7 +188,7 @@ struct KAWAIIPHYSICS_API FKawaiiProceduralWindDynamicParams
 	bool bOverrideWindDirectionNoiseAngle = false;
 
 	/** 方向揺らぎの円錐半角 / Cone half-angle for directional noise. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Units="Degrees"), Category="Kawaii Physics|ExternalForce|Procedural Wind|DynamicParams")
 	float WindDirectionNoiseAngle = 0.0f;
 
 	/** WindDirectionNoisePeriod を上書きする / Override WindDirectionNoisePeriod. */

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsCollisionLimits.h
@@ -126,7 +126,7 @@ struct FSphericalLimit : public FCollisionLimitBase
 	}
 
 	/** 球の半径 / Radius of the sphere */
-	UPROPERTY(EditAnywhere, Category = "Spherical Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Spherical Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Radius = 5.0f;
 
 	/** 球の外側と内側のどちらに拘束するか / Whether to lock bodies inside or outside of the sphere */
@@ -162,11 +162,11 @@ struct FCapsuleLimit : public FCollisionLimitBase
 	}
 
 	/** カプセルの半径 / Radius of the capsule */
-	UPROPERTY(EditAnywhere, Category = "Capsule Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Capsule Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Radius = 5.0f;
 
 	/** カプセルの長さ / Length of the capsule */
-	UPROPERTY(EditAnywhere, Category = "Capsule Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Capsule Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Length = 10.0f;
 
 	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)
@@ -210,15 +210,15 @@ struct FTaperedCapsuleLimit : public FCollisionLimitBase
 	}
 
 	/** +Z端の半径 / Radius at the +Z end */
-	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Radius0 = 5.0f;
 
 	/** -Z端の半径 / Radius at the -Z end */
-	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Radius1 = 5.0f;
 
 	/** カプセルの長さ / Length of the capsule */
-	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0"))
+	UPROPERTY(EditAnywhere, Category = "Tapered Capsule Limit", meta = (ClampMin = "0", Units = "cm"))
 	float Length = 10.0f;
 
 	// 実行時キャッシュ（毎ステップ再計算、シリアライズ対象外） / Runtime cache (recomputed every step, not serialized)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
@@ -64,7 +64,7 @@ public:
 	* Blend-in time (seconds) before a newly gathered collider starts pushing out at full strength. 0 disables the fade (immediate full strength).
 	*/
 	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",
-		meta = (DisplayName = "Fade-In Time", ClampMin = "0"))
+		meta = (DisplayName = "Fade-In Time", ClampMin = "0", Units = "s"))
 	float SimpleWorldCollisionFadeInTime = 0.2f;
 
 	/**
@@ -72,7 +72,7 @@ public:
 	* Beyond this camera distance (cm), the gather interval is throttled (doubled).
 	*/
 	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",
-		meta = (DisplayName = "Distance Throttle Start", ClampMin = "0"))
+		meta = (DisplayName = "Distance Throttle Start", ClampMin = "0", Units = "cm"))
 	float SimpleWorldCollisionDistanceThrottleStart = 3000.f;
 
 	/**
@@ -80,7 +80,7 @@ public:
 	* Beyond this camera distance (cm), gathering is stopped entirely.
 	*/
 	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",
-		meta = (DisplayName = "Distance Throttle Stop", ClampMin = "0"))
+		meta = (DisplayName = "Distance Throttle Stop", ClampMin = "0", Units = "cm"))
 	float SimpleWorldCollisionDistanceThrottleStop = 10000.f;
 
 	/**

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsTypes.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsTypes.h
@@ -217,7 +217,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSettings
 	* 各ボーンのコリジョン半径
 	* Radius of bone's collision
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0", DisplayName="Collision Radius"),
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0", DisplayName="Collision Radius", Units = "cm"),
 		Category = "Kawaii Physics")
 	float Radius = 3.0f;
 
@@ -225,7 +225,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSettings
 	* 物理挙動による回転制限。適切に設定することで荒ぶりを抑制
 	* Rotational limitations in physical behavior. Setting the value properly can suppress excessive shaking
 	*/
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0"), Category = "Kawaii Physics")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ClampMin = "0", Units = "Degrees"), Category = "Kawaii Physics")
 	float LimitAngle = 0.0f;
 };
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsMultiplierSection.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Public/MovieSceneKawaiiPhysicsSettingsMultiplierSection.h
@@ -66,7 +66,7 @@ public:
 	bool bFilterExactMatch = false;
 
 	/** セクションの評価終了時（範囲外へのスクラブ・停止・削除）に、現在の適用率から 0 へフェードする秒数 / Blend-out seconds from the current applied ratio to 0 when the section stops evaluating (scrubbed out, stopped, or removed) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Kawaii Physics", meta = (ClampMin = "0.0"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Kawaii Physics", meta = (ClampMin = "0.0", Units = "s"))
 	float BlendOutTimeOnEnd = 0.2f;
 
 	/** 指定時刻の実効重み = Clamp(Weight,0,1) x EvaluateEasing / Effective weight at the time = Clamp(Weight,0,1) x EvaluateEasing (exposed for tests) */


### PR DESCRIPTION
## 概要
秒・cm・度の単位を持つ編集可能な float プロパティに `Units` meta を追加し、Details パネルで単位付きで表示・入力できるようにしました。起点は Simple World Collision の収集間隔（`SimpleWorldCollisionGatherInterval`）で、同じ規約をプラグイン全体に揃えています。表示のみの変更で、保存値・ランタイム挙動・ローカライズ文言は変わりません。

## 変更内容
- `Units="s"`（12 件）: `SimpleWorldCollisionGatherInterval` / `SimpleWorldCollisionFadeInTime` / `FKawaiiPhysics_ExternalForce_Basic::Interval` / TriggerGust Notify の `RiseTime` `HoldTime` `DecayTime` / SettingsMultiplier Notify・NotifyState の `Duration` `BlendInTime` `BlendOutTime` / Sequencer Section の `BlendOutTimeOnEnd`
- `Units="cm"`（12 件）: `DummyBoneLength` / `TeleportDistanceThreshold` / `SimpleWorldCollisionGatherRadius` / `SimpleWorldCollisionDistanceThrottleStart` `Stop` / `FKawaiiPhysicsSettings::Radius` / Spherical・Capsule・TaperedCapsule Limit の `Radius` `Length` 系 6 件
- `Units="Degrees"`（7 件）: `TeleportRotationThreshold` / `FKawaiiPhysicsSettings::LimitAngle` / `FKawaiiProceduralWindDynamicParams` の位相・角度 5 件（本体側の同名プロパティには既に付与済み）
- 綴りは既存の `Units="s"` / `"cm"` / `"Degrees"` に統一（`ForceUnits` は不使用）。`Units=` は初期値に応じた最適単位で表示されます（例: 0.2 → 200 ms、3000 cm → 30 m）
- 対象外: FVector / FRotator（Math 構造体のカスタマイズが Units meta を参照しないため）、倍率・係数・カウント、BlueprintReadOnly / 内部プロパティ、Gravity / Force 系（対応する EUnit なし）

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 239/239（フィルタ: KawaiiPhysics）
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件（WARN 6 件は `uproperty-missing-clamp`。元から ClampMin の無い `Interval` と DynamicParams の位相 5 件が diff に含まれたためで、位相は負値を取り Interval は 0=無効の既存仕様のため今回は追加していません）
- PIE: 未（表示のみの変更。Details パネルで `Gather Interval` に ms/s 表示・「0.5s」入力が通ることの目視はマージ前に任意）
- 性能: 対象外（ホットパス変更なし）
