### PR TITLE
[fix] Keep world collision and Wind Scope building on UE 5.3-5.6

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -19,6 +19,7 @@
 #include "GameFramework/Actor.h"
 #include "GameFramework/CharacterMovementComponent.h"
 #include "GameFramework/PlayerController.h"
+#include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/BodySetup.h"
 #include "PhysicsEngine/PhysicsAsset.h"
 
@@ -1237,7 +1238,12 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 				FVector Scale3D = Component->GetComponentScale();
 				if (const UInstancedStaticMeshComponent* ISMComponent = Cast<UInstancedStaticMeshComponent>(Component))
 				{
+					// FOverlapResult::GetItemIndexは5.7で追加されたため、それ以前は公開メンバのItemIndexを直接読む。
+#if UE_VERSION_OLDER_THAN(5, 7, 0)
+					const int32 OverlapItemIndex = Overlap.ItemIndex;
+#else
 					const int32 OverlapItemIndex = Overlap.GetItemIndex();
+#endif
 					if (OverlapItemIndex < 0 || OverlapItemIndex >= ISMComponent->GetInstanceCount())
 					{
 						continue;
@@ -1264,7 +1270,12 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 				FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent NewComponent;
 				NewComponent.Component = Component;
 				NewComponent.InstanceIndex = InstanceIndex;
+				// USceneComponent::GetMobilityは5.6で追加されたため、それ以前は公開UPROPERTYのMobilityを直接読む。
+#if UE_VERSION_OLDER_THAN(5, 6, 0)
+				NewComponent.bStatic = (Component->Mobility == EComponentMobility::Static);
+#else
 				NewComponent.bStatic = (Component->GetMobility() == EComponentMobility::Static);
+#endif
 				NewComponent.FadeAlpha = Entry->bHasGatheredOnce ? 0.0f : 1.0f;
 				NewComponent.GatheredScale3D = Scale3D;
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -14,6 +14,7 @@
 #include "PhysicsEngine/SkeletalBodySetup.h"
 #endif
 #include "ReferenceSkeleton.h"
+#include "UObject/Package.h"
 
 #include <limits>
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTransientForceTest.cpp
@@ -18,6 +18,7 @@
 #include "AnimNodes/AnimNode_CurveSource.h"
 #include "Curves/CurveFloat.h"
 #include "NativeGameplayTags.h"
+#include "UObject/Package.h"
 #include "UObject/UnrealType.h"
 
 UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysicsTransientForceMatch, "KawaiiPhysics.Test.TransientForce.Match");

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsEd/Private/SKawaiiPhysicsWindScopeWindow.cpp
@@ -2922,7 +2922,8 @@ FReply SKawaiiPhysicsWindScopeWindow::OnPasteWindParametersClicked()
 	const FString ImportText = ClipboardText.RightChop(FCString::Strlen(KawaiiPhysicsWindScopeWindowPrivate::WindScopeClipboardMarker)).TrimStartAndEnd();
 
 	FKawaiiPhysics_ExternalForce_ProceduralWind PastedWind;
-	const UScriptStruct* WindStruct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
+	// UScriptStruct::ImportTextは5.3では非constメンバ関数のため、constを付けずに受け取る。
+	UScriptStruct* WindStruct = FKawaiiPhysics_ExternalForce_ProceduralWind::StaticStruct();
 	const TCHAR* ImportResult = WindStruct->ImportText(
 		*ImportText,
 		&PastedWind,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysicsSequencer/Private/Tests/KawaiiPhysicsSequencerSectionTest.cpp
@@ -11,6 +11,7 @@
 #include "MovieSceneKawaiiPhysicsSettingsMultiplierSection.h"
 #include "MovieSceneKawaiiPhysicsSettingsMultiplierTemplate.h"
 #include "MovieSceneKawaiiPhysicsSettingsMultiplierTrack.h"
+#include "UObject/Package.h"
 
 namespace
 {


### PR DESCRIPTION
## 概要
master を UE 5.3 で `RunUAT BuildPlugin` すると、最近追加したワールドコリジョン（#260〜#264）と Wind Scope のコピー＆ペースト（#247 系）が新しいエンジン API を使っていたためコンパイルに失敗していました。5.4〜5.6 でも一部が壊れていたので、対応版 5.3〜5.8 の全てで Editor / Game（Development・Shipping）ターゲットが通るよう版分岐とインクルードを整えます。

## 変更内容
- `KawaiiPhysicsSharedCollisionSubsystem.cpp`: `FOverlapResult::GetItemIndex()`（5.7 で追加）と `USceneComponent::GetMobility()`（5.6 で追加）を `UE_VERSION_OLDER_THAN` で分岐し、旧版では public メンバ `ItemIndex` / `Mobility` を直接読む。`Misc/EngineVersionComparison.h` を追加
- `SKawaiiPhysicsWindScopeWindow.cpp`: `UScriptStruct::ImportText` が 5.3 では非 const メンバのため、`StaticStruct()` の戻り値を `const` を付けずに受ける（全版共通・分岐不要）
- テスト 3 ファイル（`KawaiiPhysicsSimpleWorldCollisionTest.cpp` / `KawaiiPhysicsTransientForceTest.cpp` / `KawaiiPhysicsSequencerSectionTest.cpp`）: `GetTransientPackage()` を使うのに `UObject/Package.h` を直接インクルードしていなかったため、UnrealEd の間接インクルードが無い Game ターゲットで `UPackage` が不完全型になり `NewObject<T>(UPackage*)` が C2672 になっていた。明示的にインクルード

## 確認
- ビルド: `RunUAT BuildPlugin -TargetPlatforms=Win64 -Rocket` を UE 5.3 / 5.4 / 5.5 / 5.6 / 5.7 で実行し、UnrealEditor Win64 Development / UnrealGame Win64 Development / UnrealGame Win64 Shipping の全てで BUILD SUCCESSFUL（エラー 0、プラグイン由来の警告 0）
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) — 未（エディタ起動中のため未実施。`#else` 側は元コードそのままで 5.8 の挙動変化なし。マージ前に実施予定）
- ヘッドレステスト: 未（5.8 ビルドと合わせて実施予定。テストコードの変更はインクルード追加のみ）
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件 / WARN 0 件
- PIE: 不要（ロジック変更なし。旧版では元々コンパイルできなかったコードパスの復旧のみ）
- 性能: 影響なし（ホットパス変更なし）
