### PR TITLE
[improve] Create the SharedCollision subsystem in editor preview worlds

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -108,6 +108,9 @@ TAutoConsoleVariable<int32> CVarSharedCollisionInitRetryThrottleInterval(
 TAutoConsoleVariable<float> CVarSharedCollisionCleanupInterval(
 	TEXT("a.AnimNode.KawaiiPhysics.SharedCollision.CleanupInterval"), 1.0f,
 	TEXT("クリーンアップ間隔（秒） / Cleanup interval in seconds."));
+TAutoConsoleVariable<int32> CVarSharedCollisionEnableInPreviewWorld(
+	TEXT("a.AnimNode.KawaiiPhysics.SharedCollision.EnableInPreviewWorld"), 1,
+	TEXT("1でPersona等のプレビューワールド（EditorPreview）でもSharedCollision Subsystemを生成する。0で従来どおり生成しない / 1 creates the SharedCollision subsystem in preview worlds (EditorPreview, e.g. Persona) too; 0 keeps the legacy behavior (not created)."));
 
 // SimpleWorldCollision CVars
 TAutoConsoleVariable<int32> CVarSimpleWorldCollisionEnable(

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -714,6 +714,7 @@ namespace
 extern TAutoConsoleVariable<int32> CVarSharedCollisionReadMaxAge;
 extern TAutoConsoleVariable<int32> CVarSharedCollisionCleanupMaxAge;
 extern TAutoConsoleVariable<float> CVarSharedCollisionCleanupInterval;
+extern TAutoConsoleVariable<int32> CVarSharedCollisionEnableInPreviewWorld;
 
 // SimpleWorldCollision CVars（AnimNode_KawaiiPhysics.cpp で定義）
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionEnable;
@@ -1870,6 +1871,17 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 	// DWORDカウンタは毎フレームリセットされるため、CleanupゲートではなくSimpleWorldのTickごとに更新する。
 	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, TotalGatheredComponents);
 	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, TotalSkeletalBodies);
+}
+
+bool UKawaiiPhysicsSharedCollisionSubsystem::DoesSupportWorldType(const EWorldType::Type WorldType) const
+{
+	// Persona等のプレビューワールドでもSubsystemを生成し、ABP上でSharedCollision/SimpleWorldCollisionをプレビューできるようにする。
+	// GamePreview（ゲーム側FPreviewScene）とInactiveは従来どおり対象外。
+	if (WorldType == EWorldType::EditorPreview)
+	{
+		return CVarSharedCollisionEnableInPreviewWorld.GetValueOnGameThread() != 0;
+	}
+	return Super::DoesSupportWorldType(WorldType);
 }
 
 void UKawaiiPhysicsSharedCollisionSubsystem::Deinitialize()

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedPublisherTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedPublisherTest.cpp
@@ -1,0 +1,69 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "Engine/World.h"
+#include "HAL/IConsoleManager.h"
+#include "Misc/ScopeExit.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedCollisionSubsystemSupportsEditorPreviewTest,
+                                 "KawaiiPhysics.SharedCollision.SubsystemSupportsEditorPreview",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSharedCollisionSubsystemSupportsEditorPreviewTest::RunTest(const FString& Parameters)
+{
+	const UKawaiiPhysicsSharedCollisionSubsystem* CDO = GetDefault<UKawaiiPhysicsSharedCollisionSubsystem>();
+	UWorld* World = NewObject<UWorld>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	IConsoleVariable* CVar = IConsoleManager::Get().FindConsoleVariable(
+		TEXT("a.AnimNode.KawaiiPhysics.SharedCollision.EnableInPreviewWorld"));
+	if (!TestNotNull(TEXT("EnableInPreviewWorld CVar exists"), CVar))
+	{
+		return false;
+	}
+
+	const int32 Saved = CVar->GetInt();
+	ON_SCOPE_EXIT
+	{
+		CVar->Set(Saved, ECVF_SetByCode);
+	};
+
+	CVar->Set(1, ECVF_SetByCode);
+
+	World->WorldType = EWorldType::EditorPreview;
+	TestTrue(TEXT("EditorPreview world creates subsystem by default"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::Game;
+	TestTrue(TEXT("Game world creates subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::Editor;
+	TestTrue(TEXT("Editor world creates subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::PIE;
+	TestTrue(TEXT("PIE world creates subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::GamePreview;
+	TestFalse(TEXT("GamePreview world does not create subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::Inactive;
+	TestFalse(TEXT("Inactive world does not create subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::None;
+	TestFalse(TEXT("None world does not create subsystem"), CDO->ShouldCreateSubsystem(World));
+
+	CVar->Set(0, ECVF_SetByCode);
+
+	World->WorldType = EWorldType::EditorPreview;
+	TestFalse(TEXT("EditorPreview world does not create subsystem when disabled by CVar"),
+	          CDO->ShouldCreateSubsystem(World));
+
+	World->WorldType = EWorldType::Game;
+	TestTrue(TEXT("Game world still creates subsystem when preview CVar is disabled"),
+	         CDO->ShouldCreateSubsystem(World));
+
+	return true;
+}
+
+#endif

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -419,6 +419,15 @@ public:
 	// USubsystem interface
 	virtual void Deinitialize() override;
 
+	// UWorldSubsystem interface
+	/**
+	 * Game / Editor / PIE に加えて EditorPreview（Persona プレビュー）でも生成する。CVar a.AnimNode.KawaiiPhysics.SharedCollision.EnableInPreviewWorld=0 で従来挙動。
+	 * GamePreview / Inactive は対象外。
+	 * Also created for EditorPreview worlds (Persona preview) in addition to Game / Editor / PIE. CVar ...EnableInPreviewWorld=0 restores the legacy behavior.
+	 * GamePreview / Inactive stay unsupported.
+	 */
+	virtual bool DoesSupportWorldType(const EWorldType::Type WorldType) const override;
+
 	// FTickableGameObject interface (via UTickableWorldSubsystem)
 	virtual void Tick(float DeltaTime) override;
 	virtual TStatId GetStatId() const override;


### PR DESCRIPTION
## 概要
Persona（Animation Blueprint エディタ）のプレビューワールドは `EWorldType::EditorPreview` で、`UWorldSubsystem::DoesSupportWorldType` の既定（Game / Editor / PIE）から外れるため、`UKawaiiPhysicsSharedCollisionSubsystem` が生成されず、SharedCollision / SimpleWorldCollision がプレビューで一切動いていませんでした。`DoesSupportWorldType` を override して `EditorPreview` でも Subsystem を生成し、ABP 上でプレビューしながら調整できるようにします。CVar で従来挙動へ戻せます。

## 変更内容
- `UKawaiiPhysicsSharedCollisionSubsystem::DoesSupportWorldType` を override: Game / Editor / PIE に加えて `EditorPreview` を許可（`GamePreview` / `Inactive` は従来どおり対象外）
- CVar `a.AnimNode.KawaiiPhysics.SharedCollision.EnableInPreviewWorld`（int32、既定 1）を追加。0 で従来どおりプレビューワールドでは生成しない
- ヘッドレステスト `KawaiiPhysics.SharedCollision.SubsystemSupportsEditorPreview` を追加（新規 `KawaiiPhysicsSharedPublisherTest.cpp`）: 透過 `UWorld` の `WorldType` を切り替えて `ShouldCreateSubsystem` を検証（EditorPreview / Game / Editor / PIE = 生成、GamePreview / Inactive / None = 非生成、CVar 0 で EditorPreview だけ非生成、`ON_SCOPE_EXIT` で CVar 復元）

### 挙動変化
- Persona プレビューで既存の `bUseSimpleWorldCollision` ノードもプレビューワールドの床メッシュ等を収集するようになります（`IsTickableInEditor()` により Persona の `World->Tick` で Subsystem が Tick）。Registry が空なら `IsTickable()` は false のため、サムネイル用の EditorPreview ワールドのコストは無視できます。プレビューワールドでは `GetFirstPlayerController()` が null のため距離間引きは効きません。
- ランタイム（Game / PIE）の挙動は不変です。

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 245/245（フィルタ: KawaiiPhysics。master 244 本 ＋ 新規 1 本）／`KawaiiPhysics.SharedCollision` 2/2
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件（WARN 0 件）
- PIE / Persona: 未（Persona で既存 Simple World Collision ノードが床 Box を拾うこと、CVar 0 で従来どおり生成されないこと。後続の共有ノード PR の PIE チェックリストにまとめて登録予定）
- 性能: ホットパス変更なし（Subsystem の生成判定のみ）
