### PR TITLE
[improve] Skip unchanged Simple World Collision reads and publish the ground box separately

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -234,12 +234,17 @@ void FAnimNode_KawaiiPhysics::Initialize_AnyThread(const FAnimationInitializeCon
 	// シンプルワールドコリジョンのキャッシュをリセット
 	ReleaseSimpleWorldCollision();
 	SimpleWorldMergedScratch.Reset();
+	SimpleWorldGroundScratch.Reset();
 	SimpleWorldSphericalLimits.Reset();
 	SimpleWorldCapsuleLimits.Reset();
 	SimpleWorldTaperedCapsuleLimits.Reset();
 	SimpleWorldBoxLimits.Reset();
+	SimpleWorldGroundBoxLimits.Reset();
 	SimpleWorldConvexLimits.Reset();
-	bSimpleWorldRadiusWarningLogged = false;
+	LastReadSimpleWorldShapeSerial = 0;
+	LastReadSimpleWorldGroundSerial = 0;
+	bSimpleWorldRadiusChecked = false;
+	SimpleWorldRadiusCheckDeferrals = 0;
 
 	ApplyLimitsDataAsset(RequiredBones);
 	ApplyPhysicsAsset(RequiredBones);
@@ -821,11 +826,15 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 		// ランタイム無効化時は自Descを即時解除し、古い押し出しを残さない
 		ReleaseSimpleWorldCollision();
 		SimpleWorldMergedScratch.Reset();
+		SimpleWorldGroundScratch.Reset();
 		SimpleWorldSphericalLimits.Reset();
 		SimpleWorldCapsuleLimits.Reset();
 		SimpleWorldTaperedCapsuleLimits.Reset();
 		SimpleWorldBoxLimits.Reset();
+		SimpleWorldGroundBoxLimits.Reset();
 		SimpleWorldConvexLimits.Reset();
+		LastReadSimpleWorldShapeSerial = 0;
+		LastReadSimpleWorldGroundSerial = 0;
 	}
 
 	// 入力規模カウンタ & メモリの更新（毎フレーム。負荷=N×L等の相関とダミー膨張の可視化用）
@@ -841,7 +850,7 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 	SET_DWORD_STAT(STAT_KawaiiPhysics_NumSimpleWorldColliders,
 	               SimpleWorldSphericalLimits.Num() + SimpleWorldCapsuleLimits.Num() +
 	               SimpleWorldTaperedCapsuleLimits.Num() + SimpleWorldBoxLimits.Num() +
-	               SimpleWorldConvexLimits.Num());
+	               SimpleWorldGroundBoxLimits.Num() + SimpleWorldConvexLimits.Num());
 	SET_DWORD_STAT(STAT_KawaiiPhysics_NumMergedBoneConstraints, MergedBoneConstraints.Num());
 	SET_MEMORY_STAT(STAT_KawaiiPhysics_ModifyBonesMemory,
 	                ModifyBones.GetAllocatedSize() + MergedBoneConstraints.GetAllocatedSize());

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -63,7 +63,38 @@ namespace
 		}
 	}
 
-	void AppendSharedCollisionDataToSimulationSpace(
+	template <typename LimitType, typename PostConvertType>
+	bool RefreshWorldLimitsToSimulationSpaceInPlace(
+		const FAnimNode_KawaiiPhysics& Node,
+		FComponentSpacePoseContext& Output,
+		EKawaiiPhysicsSimulationSpace TargetSpace,
+		const TArray<LimitType>& InLimits,
+		TArray<LimitType>& OutLimits,
+		PostConvertType PostConvert)
+	{
+		if (InLimits.Num() != OutLimits.Num())
+		{
+			return false;
+		}
+
+		for (int32 Index = 0; Index < InLimits.Num(); ++Index)
+		{
+			const LimitType& Source = InLimits[Index];
+			LimitType& Target = OutLimits[Index];
+			const FTransform WorldTransform(Source.Rotation, Source.Location);
+			const FTransform SimTransform = Node.ConvertSimulationSpaceTransform(
+				Output, EKawaiiPhysicsSimulationSpace::WorldSpace, TargetSpace, WorldTransform);
+			Target.Location = SimTransform.GetLocation();
+			Target.Rotation = SimTransform.GetRotation();
+			Target.bEnable = true;
+			PostConvert(Target, SimTransform);
+		}
+
+		return true;
+	}
+}
+
+void KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
 		const FAnimNode_KawaiiPhysics& Node,
 		FComponentSpacePoseContext& Output,
 		EKawaiiPhysicsSimulationSpace TargetSpace,
@@ -74,38 +105,91 @@ namespace
 		TArray<FBoxLimit>& OutBoxLimits,
 		TArray<FPlanarLimit>* OutPlanarLimits,
 		TArray<FKawaiiPhysicsConvexLimit>* OutConvexLimits)
+{
+	auto NoOp = [](auto&, const FTransform&) {};
+	auto RecomputePlane = [](FPlanarLimit& Limit, const FTransform& Transform)
 	{
-		auto NoOp = [](auto&, const FTransform&) {};
-		auto RecomputePlane = [](FPlanarLimit& Limit, const FTransform& Transform)
-		{
-			Limit.Plane = FPlane(Limit.Location, Transform.GetRotation().GetUpVector());
-		};
-		auto RecomputeConvexCache = [](FKawaiiPhysicsConvexLimit& Limit, const FTransform&)
-		{
-			Limit.UpdateRuntimeCache();
-		};
+		Limit.Plane = FPlane(Limit.Location, Transform.GetRotation().GetUpVector());
+	};
+	auto RecomputeConvexCache = [](FKawaiiPhysicsConvexLimit& Limit, const FTransform&)
+	{
+		Limit.UpdateRuntimeCache();
+	};
 
-		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.SphericalLimits,
-			OutSphericalLimits, NoOp);
-		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.CapsuleLimits,
-			OutCapsuleLimits, NoOp);
-		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.TaperedCapsuleLimits,
-			OutTaperedCapsuleLimits, NoOp);
-		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.BoxLimits,
-			OutBoxLimits, NoOp);
+	AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.SphericalLimits,
+		OutSphericalLimits, NoOp);
+	AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.CapsuleLimits,
+		OutCapsuleLimits, NoOp);
+	AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.TaperedCapsuleLimits,
+		OutTaperedCapsuleLimits, NoOp);
+	AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.BoxLimits,
+		OutBoxLimits, NoOp);
 
-		if (OutPlanarLimits)
-		{
-			AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.PlanarLimits,
-				*OutPlanarLimits, RecomputePlane);
-		}
-
-		if (OutConvexLimits)
-		{
-			AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.ConvexLimits,
-				*OutConvexLimits, RecomputeConvexCache);
-		}
+	if (OutPlanarLimits)
+	{
+		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.PlanarLimits,
+			*OutPlanarLimits, RecomputePlane);
 	}
+
+	if (OutConvexLimits)
+	{
+		AppendWorldLimitsToSimulationSpace(Node, Output, TargetSpace, InData.ConvexLimits,
+			*OutConvexLimits, RecomputeConvexCache);
+	}
+}
+
+bool KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+	const FAnimNode_KawaiiPhysics& Node,
+	FComponentSpacePoseContext& Output,
+	EKawaiiPhysicsSimulationSpace TargetSpace,
+	const FKawaiiPhysicsSharedCollisionData& InData,
+	TArray<FSphericalLimit>& OutSphericalLimits,
+	TArray<FCapsuleLimit>& OutCapsuleLimits,
+	TArray<FTaperedCapsuleLimit>& OutTaperedCapsuleLimits,
+	TArray<FBoxLimit>& OutBoxLimits,
+	TArray<FKawaiiPhysicsConvexLimit>& OutConvexLimits)
+{
+	auto NoOp = [](auto&, const FTransform&) {};
+	auto RecomputeConvexCache = [](FKawaiiPhysicsConvexLimit& Limit, const FTransform&)
+	{
+		Limit.UpdateRuntimeCache();
+	};
+
+	if (InData.SphericalLimits.Num() != OutSphericalLimits.Num()
+		|| InData.CapsuleLimits.Num() != OutCapsuleLimits.Num()
+		|| InData.TaperedCapsuleLimits.Num() != OutTaperedCapsuleLimits.Num()
+		|| InData.BoxLimits.Num() != OutBoxLimits.Num()
+		|| InData.ConvexLimits.Num() != OutConvexLimits.Num())
+	{
+		return false;
+	}
+
+	RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InData.SphericalLimits,
+		OutSphericalLimits, NoOp);
+	RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InData.CapsuleLimits,
+		OutCapsuleLimits, NoOp);
+	RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InData.TaperedCapsuleLimits,
+		OutTaperedCapsuleLimits, NoOp);
+	RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InData.BoxLimits,
+		OutBoxLimits, NoOp);
+	RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InData.ConvexLimits,
+		OutConvexLimits, RecomputeConvexCache);
+	return true;
+}
+
+bool KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+	const FAnimNode_KawaiiPhysics& Node,
+	FComponentSpacePoseContext& Output,
+	EKawaiiPhysicsSimulationSpace TargetSpace,
+	const TArray<FBoxLimit>& InBoxLimits,
+	TArray<FBoxLimit>& OutBoxLimits)
+{
+	auto NoOp = [](FBoxLimit&, const FTransform&) {};
+	if (InBoxLimits.Num() != OutBoxLimits.Num())
+	{
+		return false;
+	}
+	return RefreshWorldLimitsToSimulationSpaceInPlace(Node, Output, TargetSpace, InBoxLimits, OutBoxLimits, NoOp);
 }
 
 void FAnimNode_KawaiiPhysics::ApplyLimitsDataAsset(const FBoneContainer& RequiredBones)
@@ -780,6 +864,7 @@ void FAnimNode_KawaiiPhysics::PrepareCollisionShapeCaches()
 	UpdateEnabledCaches(SimpleWorldCapsuleLimits);
 	UpdateEnabledCaches(SimpleWorldTaperedCapsuleLimits);
 	UpdateEnabledCaches(SimpleWorldBoxLimits);
+	UpdateEnabledCaches(SimpleWorldGroundBoxLimits);
 	UpdateEnabledCaches(SimpleWorldConvexLimits);
 }
 
@@ -1435,7 +1520,7 @@ void FAnimNode_KawaiiPhysics::UpdateSharedCollisionLimits(
 	}
 
 	// source ノードは Convex を publish しない。SimpleWorld 経路が Planar を捨てるのと対称の扱い。
-	AppendSharedCollisionDataToSimulationSpace(*this, Output, SimulationSpace, SharedCollisionMergedData,
+	KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(*this, Output, SimulationSpace, SharedCollisionMergedData,
 		SharedSphericalLimits, SharedCapsuleLimits, SharedTaperedCapsuleLimits, SharedBoxLimits,
 		&SharedPlanarLimits, nullptr);
 }
@@ -1481,14 +1566,15 @@ void FAnimNode_KawaiiPhysics::InitializeSimpleWorldCollision()
 void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePoseContext& Output)
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_UpdateSimpleWorldCollisionLimits);
-	SimpleWorldSphericalLimits.Reset();
-	SimpleWorldCapsuleLimits.Reset();
-	SimpleWorldTaperedCapsuleLimits.Reset();
-	SimpleWorldBoxLimits.Reset();
-	SimpleWorldConvexLimits.Reset();
 
 	if (!CachedSimpleWorldEntry.IsValid())
 	{
+		SimpleWorldSphericalLimits.Reset();
+		SimpleWorldCapsuleLimits.Reset();
+		SimpleWorldTaperedCapsuleLimits.Reset();
+		SimpleWorldBoxLimits.Reset();
+		SimpleWorldGroundBoxLimits.Reset();
+		SimpleWorldConvexLimits.Reset();
 		return;
 	}
 
@@ -1498,6 +1584,13 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 
 	if (!bSimpleWorldDescSent || !(Desc == LastSentSimpleWorldDesc))
 	{
+		// 半径警告の再チェックは収集半径の指定が変わったときだけ解禁する（GatherInterval のピン駆動で毎フレーム再送されても走査を繰り返さない）。
+		if (!bSimpleWorldDescSent
+			|| !FMath::IsNearlyEqual(Desc.GatherRadiusOverride, LastSentSimpleWorldDesc.GatherRadiusOverride))
+		{
+			bSimpleWorldRadiusChecked = false;
+			SimpleWorldRadiusCheckDeferrals = 0;
+		}
 		CachedSimpleWorldEntry->SetDesc(SourceID, Desc);
 		LastSentSimpleWorldDesc = Desc;
 		bSimpleWorldDescSent = true;
@@ -1512,44 +1605,120 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 		SimpleWorldCapsuleLimits.Reset();
 		SimpleWorldTaperedCapsuleLimits.Reset();
 		SimpleWorldBoxLimits.Reset();
+		SimpleWorldGroundBoxLimits.Reset();
 		SimpleWorldConvexLimits.Reset();
+		SimpleWorldMergedScratch.Reset();
+		SimpleWorldGroundScratch.Reset();
+		LastReadSimpleWorldShapeSerial = 0;
+		LastReadSimpleWorldGroundSerial = 0;
 		return;
 	}
 
-	SimpleWorldMergedScratch.Reset();
-	CachedSimpleWorldEntry->Slot.AppendTo(SimpleWorldMergedScratch);
-
-	if (bOverrideSimpleWorldCollisionGatherRadius && !bSimpleWorldRadiusWarningLogged)
+	const uint64 ShapeSerial = CachedSimpleWorldEntry->Slot.GetPublishSerial();
+	if (LastReadSimpleWorldShapeSerial == 0 || ShapeSerial != LastReadSimpleWorldShapeSerial)
 	{
-		const FVector ComponentOriginSim = ConvertSimulationSpaceLocation(
-			Output, EKawaiiPhysicsSimulationSpace::ComponentSpace, SimulationSpace, FVector::ZeroVector);
+		SimpleWorldMergedScratch.Reset();
+		CachedSimpleWorldEntry->Slot.AppendTo(SimpleWorldMergedScratch);
+		LastReadSimpleWorldShapeSerial = ShapeSerial;
 
-		float RequiredRadius = 0.0f;
-		for (const FKawaiiPhysicsModifyBone& Bone : ModifyBones)
-		{
-			RequiredRadius = FMath::Max(
-				RequiredRadius,
-				FVector::Dist(ComponentOriginSim, Bone.PoseLocation) + Bone.PhysicsSettings.Radius);
-		}
-
-		if (SimpleWorldCollisionGatherRadius + KINDA_SMALL_NUMBER < RequiredRadius)
-		{
-			KAWAII_LOG_NODE_WARNING(LogKawaiiPhysics,
-				TEXT("SimpleWorldCollision: GatherRadius %.2f may be smaller than the physics chain reach %.2f. "
-					"Increase SimpleWorldCollisionGatherRadius or disable the override to use SkeletalMesh bounds."),
-				SimpleWorldCollisionGatherRadius, RequiredRadius);
-			bSimpleWorldRadiusWarningLogged = true;
-		}
+		SimpleWorldSphericalLimits.Reset();
+		SimpleWorldCapsuleLimits.Reset();
+		SimpleWorldTaperedCapsuleLimits.Reset();
+		SimpleWorldBoxLimits.Reset();
+		SimpleWorldConvexLimits.Reset();
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+			SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
+			SimpleWorldBoxLimits, nullptr, &SimpleWorldConvexLimits);
 	}
-
-	if (SimpleWorldMergedScratch.IsEmpty())
-	{
-		return;
-	}
-
-	AppendSharedCollisionDataToSimulationSpace(*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+	else if (!KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+		*this, Output, SimulationSpace, SimpleWorldMergedScratch,
 		SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
-		SimpleWorldBoxLimits, nullptr, &SimpleWorldConvexLimits);
+		SimpleWorldBoxLimits, SimpleWorldConvexLimits))
+	{
+		// 配列数がずれた場合は、前回配列が外部テスト注入や将来の形状追加で変わった可能性があるため全再構築へ戻す。
+		SimpleWorldSphericalLimits.Reset();
+		SimpleWorldCapsuleLimits.Reset();
+		SimpleWorldTaperedCapsuleLimits.Reset();
+		SimpleWorldBoxLimits.Reset();
+		SimpleWorldConvexLimits.Reset();
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+			SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
+			SimpleWorldBoxLimits, nullptr, &SimpleWorldConvexLimits);
+	}
+
+	const uint64 GroundSerial = CachedSimpleWorldEntry->GroundSlot.GetPublishSerial();
+	if (LastReadSimpleWorldGroundSerial == 0 || GroundSerial != LastReadSimpleWorldGroundSerial)
+	{
+		SimpleWorldGroundScratch.Reset();
+		CachedSimpleWorldEntry->GroundSlot.AppendTo(SimpleWorldGroundScratch);
+		LastReadSimpleWorldGroundSerial = GroundSerial;
+
+		SimpleWorldGroundBoxLimits.Reset();
+		auto NoOp = [](FBoxLimit&, const FTransform&) {};
+		AppendWorldLimitsToSimulationSpace(*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits,
+			SimpleWorldGroundBoxLimits, NoOp);
+	}
+	else if (!KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+		*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits, SimpleWorldGroundBoxLimits))
+	{
+		// 配列数がずれた場合は、地面 Box の有無が外部から変わった可能性があるため全再構築へ戻す。
+		SimpleWorldGroundBoxLimits.Reset();
+		auto NoOp = [](FBoxLimit&, const FTransform&) {};
+		AppendWorldLimitsToSimulationSpace(*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits,
+			SimpleWorldGroundBoxLimits, NoOp);
+	}
+
+	CheckSimpleWorldGatherRadius(Output);
+}
+
+void FAnimNode_KawaiiPhysics::CheckSimpleWorldGatherRadius(FComponentSpacePoseContext& Output)
+{
+	if (!bOverrideSimpleWorldCollisionGatherRadius || bSimpleWorldRadiusChecked || ModifyBones.IsEmpty())
+	{
+		return;
+	}
+
+	bool bHasNonZeroPoseLocation = false;
+	for (const FKawaiiPhysicsModifyBone& Bone : ModifyBones)
+	{
+		if (!Bone.PoseLocation.IsNearlyZero())
+		{
+			bHasNonZeroPoseLocation = true;
+			break;
+		}
+	}
+	if (!bHasNonZeroPoseLocation)
+	{
+		// 全ボーンがゼロ姿勢のフレームは持ち越すが、退化チェーンで無限に走査し続けないよう上限で打ち切る。
+		if (++SimpleWorldRadiusCheckDeferrals >= MaxSimpleWorldRadiusCheckDeferrals)
+		{
+			bSimpleWorldRadiusChecked = true;
+		}
+		return;
+	}
+
+	const FVector ComponentOriginSim = ConvertSimulationSpaceLocation(
+		Output, EKawaiiPhysicsSimulationSpace::ComponentSpace, SimulationSpace, FVector::ZeroVector);
+
+	float RequiredRadius = 0.0f;
+	for (const FKawaiiPhysicsModifyBone& Bone : ModifyBones)
+	{
+		RequiredRadius = FMath::Max(
+			RequiredRadius,
+			FVector::Dist(ComponentOriginSim, Bone.PoseLocation) + Bone.PhysicsSettings.Radius);
+	}
+
+	if (SimpleWorldCollisionGatherRadius + KINDA_SMALL_NUMBER < RequiredRadius)
+	{
+		KAWAII_LOG_NODE_WARNING(LogKawaiiPhysics,
+			TEXT("SimpleWorldCollision: GatherRadius %.2f may be smaller than the physics chain reach %.2f. "
+				"Increase SimpleWorldCollisionGatherRadius or disable the override to use SkeletalMesh bounds."),
+			SimpleWorldCollisionGatherRadius, RequiredRadius);
+	}
+
+	bSimpleWorldRadiusChecked = true;
 }
 
 void FAnimNode_KawaiiPhysics::ReleaseSimpleWorldCollision()
@@ -1562,13 +1731,22 @@ void FAnimNode_KawaiiPhysics::ReleaseSimpleWorldCollision()
 	CachedSimpleWorldEntry.Reset();
 	bSimpleWorldCollisionInitialized = false;
 	bSimpleWorldDescSent = false;
+	SimpleWorldMergedScratch.Reset();
+	SimpleWorldGroundScratch.Reset();
+	LastReadSimpleWorldShapeSerial = 0;
+	LastReadSimpleWorldGroundSerial = 0;
 }
 
 void FAnimNode_KawaiiPhysics::RequestSimpleWorldCollisionReinit()
 {
 	bSimpleWorldCollisionInitialized = false;
 	bSimpleWorldDescSent = false;
-	bSimpleWorldRadiusWarningLogged = false;
+	bSimpleWorldRadiusChecked = false;
+	SimpleWorldRadiusCheckDeferrals = 0;
+	LastReadSimpleWorldShapeSerial = 0;
+	LastReadSimpleWorldGroundSerial = 0;
+	SimpleWorldMergedScratch.Reset();
+	SimpleWorldGroundScratch.Reset();
 	if (CachedSimpleWorldEntry.IsValid())
 	{
 		CachedSimpleWorldEntry->RemoveDesc(reinterpret_cast<uint64>(this));

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsDebug.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsDebug.cpp
@@ -231,6 +231,12 @@ void FAnimNode_KawaiiPhysics::AnimDrawDebug(FComponentSpacePoseContext& Output)
 						                       FColor::Cyan, LineThickness);
 					}
 
+					for (const auto& BoxLimit : SimpleWorldGroundBoxLimits)
+					{
+						this->AnimDrawDebugBox(Output, BoxLimit.Location, BoxLimit.Rotation, BoxLimit.Extent,
+						                       FColor::Cyan, LineThickness);
+					}
+
 					for (const auto& ConvexLimit : SimpleWorldConvexLimits)
 					{
 #if !UE_BUILD_SHIPPING

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsInternal.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsInternal.h
@@ -61,3 +61,39 @@ DECLARE_DWORD_COUNTER_STAT_EXTERN(TEXT("KawaiiPhysics_NumWorldCollisionChecks"),
 
 // ModifyBones / MergedBoneConstraints のアロケーション量（subdivision/bridge dummyによる膨張の可視化） / Allocated size of ModifyBones / MergedBoneConstraints (visualize growth from subdivision/bridge dummies)
 DECLARE_MEMORY_STAT_EXTERN(TEXT("KawaiiPhysics_ModifyBonesMemory"), STAT_KawaiiPhysics_ModifyBonesMemory, STATGROUP_Anim, KAWAIIPHYSICS_API);
+
+namespace KawaiiPhysicsSimpleWorldReadPath
+{
+	// 共有コリジョンデータをシミュレーション空間配列へ追加する / Appends shared collision data to simulation-space arrays
+	KAWAIIPHYSICS_API void AppendSharedCollisionDataToSimulationSpace(
+		const FAnimNode_KawaiiPhysics& Node,
+		FComponentSpacePoseContext& Output,
+		EKawaiiPhysicsSimulationSpace TargetSpace,
+		const FKawaiiPhysicsSharedCollisionData& InData,
+		TArray<FSphericalLimit>& OutSphericalLimits,
+		TArray<FCapsuleLimit>& OutCapsuleLimits,
+		TArray<FTaperedCapsuleLimit>& OutTaperedCapsuleLimits,
+		TArray<FBoxLimit>& OutBoxLimits,
+		TArray<FPlanarLimit>* OutPlanarLimits,
+		TArray<FKawaiiPhysicsConvexLimit>* OutConvexLimits);
+
+	// 既存配列の要素数が一致する場合だけ in-place でシミュレーション空間へ再変換する / Refreshes simulation-space arrays in place only when element counts match
+	KAWAIIPHYSICS_API bool RefreshSimulationSpaceLimitsInPlace(
+		const FAnimNode_KawaiiPhysics& Node,
+		FComponentSpacePoseContext& Output,
+		EKawaiiPhysicsSimulationSpace TargetSpace,
+		const FKawaiiPhysicsSharedCollisionData& InData,
+		TArray<FSphericalLimit>& OutSphericalLimits,
+		TArray<FCapsuleLimit>& OutCapsuleLimits,
+		TArray<FTaperedCapsuleLimit>& OutTaperedCapsuleLimits,
+		TArray<FBoxLimit>& OutBoxLimits,
+		TArray<FKawaiiPhysicsConvexLimit>& OutConvexLimits);
+
+	// Box 配列だけを in-place でシミュレーション空間へ再変換する / Refreshes only box limits in simulation space in place
+	KAWAIIPHYSICS_API bool RefreshSimulationSpaceLimitsInPlace(
+		const FAnimNode_KawaiiPhysics& Node,
+		FComponentSpacePoseContext& Output,
+		EKawaiiPhysicsSimulationSpace TargetSpace,
+		const TArray<FBoxLimit>& InBoxLimits,
+		TArray<FBoxLimit>& OutBoxLimits);
+}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsSimulation.cpp
@@ -971,6 +971,7 @@ void FAnimNode_KawaiiPhysics::SimulateOnce(FComponentSpacePoseContext& Output,
 			AdjustByCapsuleCollision(Bone, SimpleWorldCapsuleLimits);
 			AdjustByTaperedCapsuleCollision(Bone, SimpleWorldTaperedCapsuleLimits);
 			AdjustByBoxCollision(Bone, SimpleWorldBoxLimits);
+			AdjustByBoxCollision(Bone, SimpleWorldGroundBoxLimits);
 			AdjustByConvexCollision(Bone, SimpleWorldConvexLimits);
 		}
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -299,6 +299,10 @@ namespace
 		Entry.GroundComponentTM = FTransform::Identity;
 		Entry.GroundInstanceIndex = INDEX_NONE;
 		Entry.bGroundComponentStatic = true;
+		if (bOutChanged)
+		{
+			Entry.bGroundBoxDirty = true;
+		}
 	}
 
 	void ResolveSimpleWorldGroundSource(
@@ -399,6 +403,10 @@ namespace
 		bOutChanged = !bHadGroundBox
 			|| !IsSimpleWorldGroundBoxNearlyEqual(PreviousBox, Entry.GroundBox)
 			|| PreviousGroundComponent != NewGroundComponent;
+		if (bOutChanged)
+		{
+			Entry.bGroundBoxDirty = true;
+		}
 		return true;
 	}
 
@@ -775,6 +783,7 @@ void FKawaiiPhysicsSharedCollisionSourceSlot::Publish(FKawaiiPhysicsSharedCollis
 	FWriteScopeLock WriteLock(BufferLock);
 	// Swapで旧BufferをInOutDataへ返し、呼び出し側が確保済みメモリを再利用できるようにする（ロック区間はSwapのみで最小）
 	Swap(Buffer, InOutData);
+	PublishSerial.fetch_add(1, std::memory_order_release);
 
 	// フレーム番号を記録（鮮度チェック用）
 	LastPublishFrame.store(GFrameCounter, std::memory_order_release);
@@ -1314,6 +1323,478 @@ bool UKawaiiPhysicsSharedCollisionSubsystem::BuildSimpleWorldCollisionDebugInfo(
 #endif
 }
 
+void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	float BoxEnableThreshold)
+{
+	Entry.PublishScratch.Reset();
+	for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& Component : Entry.GatheredComponents)
+	{
+		// フェード計算本体は KawaiiPhysicsSimpleWorldCollision 名前空間へ移設済み（単体テスト可能化のため）。
+		// しきい値定数はここ（Subsystem側）で保持したまま引数として渡す。
+		if (!Component.BodyBindings.IsEmpty())
+		{
+			KawaiiPhysicsSimpleWorldCollision::AppendFadedSkeletalLocalLimits(
+				Component.LocalLimits,
+				MakeArrayView(Component.BodyBindings),
+				MakeArrayView(Component.LastBodyWorldTMs),
+				Component.FadeAlpha,
+				Entry.PublishScratch,
+				BoxEnableThreshold);
+		}
+		else
+		{
+			KawaiiPhysicsSimpleWorldCollision::AppendFadedLocalLimits(
+				Component.LocalLimits,
+				Component.FadeAlpha,
+				Component.LastComponentTM,
+				Entry.PublishScratch,
+				BoxEnableThreshold);
+		}
+	}
+
+	Entry.Slot.Publish(Entry.PublishScratch);
+	Entry.bWorldLimitsDirty = false;
+}
+
+void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldGroundBox(
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry)
+{
+	Entry.GroundPublishScratch.Reset();
+	if (Entry.bHasGroundBox)
+	{
+		Entry.GroundPublishScratch.BoxLimits.Add(Entry.GroundBox);
+	}
+
+	Entry.GroundSlot.Publish(Entry.GroundPublishScratch);
+	Entry.bGroundBoxDirty = false;
+}
+
+void UKawaiiPhysicsSharedCollisionSubsystem::GatherSimpleWorldEntry(
+	UWorld& World,
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	const USkeletalMeshComponent& SkelComp,
+	const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+	const FVector& Center,
+	float Radius,
+	float GroundTraceLength,
+	ECollisionChannel CollisionChannel,
+	int32 EffectiveMaxGatheredComponents,
+	int32 EffectiveMaxPhysicsAssetBodies,
+	int32 EffectiveMaxConvexPlanes,
+	bool bUseMovementGround,
+	bool bBuildConvexDebugGeometry)
+{
+	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Gather);
+	Entry.LastGatherRadius = Radius;
+
+	const FCollisionResponseParams ResponseParams =
+		KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldResponseParams(Desc.ObjectTypes);
+	FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(KawaiiPhysicsSimpleWorldCollision), false);
+	// Overlap応答（トリガー等）は物理クエリのPreFilterで除外し、結果配列に返さない（ループ側のbBlockingHit判定は防御として残す）。
+	QueryParams.bIgnoreTouches = true;
+	QueryParams.AddIgnoredActor(SkelComp.GetOwner());
+	// Owner が無いプレビューコンポーネントでも自分自身を収集しない。
+	QueryParams.AddIgnoredComponent(&SkelComp);
+
+	Entry.OverlapScratch.Reset();
+	World.OverlapMultiByChannel(
+		Entry.OverlapScratch,
+		Center,
+		FQuat::Identity,
+		CollisionChannel,
+		FCollisionShape::MakeSphere(Radius),
+		QueryParams,
+		ResponseParams);
+
+	const bool bUseGatherOrder = KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(Entry.OverlapScratch.Num(), EffectiveMaxGatheredComponents);
+	if (bUseGatherOrder)
+	{
+		Entry.GatherDistanceScratch.Reset(Entry.OverlapScratch.Num());
+		for (const FOverlapResult& Overlap : Entry.OverlapScratch)
+		{
+			float DistanceSquared = TNumericLimits<float>::Max();
+			if (const UPrimitiveComponent* Component = Overlap.GetComponent())
+			{
+				FVector GatherLocation = Component->Bounds.Origin;
+				if (const UInstancedStaticMeshComponent* ISMComponent =
+					Cast<const UInstancedStaticMeshComponent>(Component))
+				{
+					// FOverlapResult::GetItemIndexは5.7で追加されたため、それ以前は公開メンバのItemIndexを直接読む。
+#if UE_VERSION_OLDER_THAN(5, 7, 0)
+					const int32 OverlapItemIndex = Overlap.ItemIndex;
+#else
+					const int32 OverlapItemIndex = Overlap.GetItemIndex();
+#endif
+					if (OverlapItemIndex >= 0 && OverlapItemIndex < ISMComponent->GetInstanceCount())
+					{
+						FTransform InstanceTM;
+						if (ISMComponent->GetInstanceTransform(OverlapItemIndex, InstanceTM, true))
+						{
+							GatherLocation = InstanceTM.GetLocation();
+						}
+					}
+				}
+				DistanceSquared = FVector::DistSquared(Center, GatherLocation);
+			}
+			Entry.GatherDistanceScratch.Add(DistanceSquared);
+		}
+		KawaiiPhysicsSimpleWorldCollision::SortSimpleWorldGatherOrderByDistance(
+			MakeArrayView(Entry.GatherDistanceScratch),
+			Entry.GatherOrderScratch);
+	}
+
+	TSet<FKawaiiPhysicsSimpleWorldGatherKey> UniqueGatherKeys;
+	TArray<FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent> NewGatheredComponents;
+	NewGatheredComponents.Reserve(
+		FMath::Max(0, FMath::Min(Entry.OverlapScratch.Num(), EffectiveMaxGatheredComponents)));
+
+	const int32 NumOverlapVisits = bUseGatherOrder ? Entry.GatherOrderScratch.Num() : Entry.OverlapScratch.Num();
+	for (int32 VisitIndex = 0; VisitIndex < NumOverlapVisits; ++VisitIndex)
+	{
+		if (NewGatheredComponents.Num() >= EffectiveMaxGatheredComponents)
+		{
+			break;
+		}
+
+		const int32 OverlapIndex = bUseGatherOrder ? Entry.GatherOrderScratch[VisitIndex] : VisitIndex;
+		const FOverlapResult& Overlap = Entry.OverlapScratch[OverlapIndex];
+		if (!Overlap.bBlockingHit)
+		{
+			// レスポンスが Overlap/Ignore のコンポーネント（トリガー等）は収集対象外。
+			continue;
+		}
+
+		UPrimitiveComponent* Component = Overlap.GetComponent();
+		if (!Component)
+		{
+			continue;
+		}
+
+		const AActor* ComponentOwner = Component->GetOwner();
+		if ((ComponentOwner && ComponentOwner->ActorHasTag(GSimpleWorldIgnoreTagName))
+			|| Component->ComponentHasTag(GSimpleWorldIgnoreTagName))
+		{
+			continue;
+		}
+
+		int32 InstanceIndex = INDEX_NONE;
+		FTransform ComponentTM = GetScaleStrippedComponentTransform(*Component);
+		FVector Scale3D = Component->GetComponentScale();
+		if (const UInstancedStaticMeshComponent* ISMComponent = Cast<UInstancedStaticMeshComponent>(Component))
+		{
+			// FOverlapResult::GetItemIndexは5.7で追加されたため、それ以前は公開メンバのItemIndexを直接読む。
+#if UE_VERSION_OLDER_THAN(5, 7, 0)
+			const int32 OverlapItemIndex = Overlap.ItemIndex;
+#else
+			const int32 OverlapItemIndex = Overlap.GetItemIndex();
+#endif
+			if (OverlapItemIndex < 0 || OverlapItemIndex >= ISMComponent->GetInstanceCount())
+			{
+				continue;
+			}
+
+			FTransform InstanceTM;
+			if (!ISMComponent->GetInstanceTransform(OverlapItemIndex, InstanceTM, true))
+			{
+				continue;
+			}
+
+			InstanceIndex = OverlapItemIndex;
+			ComponentTM = GetScaleStrippedKawaiiPhysicsSimpleWorldInstanceTransform(InstanceTM);
+			Scale3D = InstanceTM.GetScale3D();
+		}
+
+		const FKawaiiPhysicsSimpleWorldGatherKey GatherKey(Component, InstanceIndex);
+		if (UniqueGatherKeys.Contains(GatherKey))
+		{
+			continue;
+		}
+		UniqueGatherKeys.Add(GatherKey);
+
+		FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent NewComponent;
+		NewComponent.Component = Component;
+		NewComponent.InstanceIndex = InstanceIndex;
+		NewComponent.bStatic = IsSimpleWorldComponentStatic(*Component);
+		NewComponent.FadeAlpha = Entry.bHasGatheredOnce ? 0.0f : 1.0f;
+		NewComponent.GatheredScale3D = Scale3D;
+
+		if (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent* ExistingComponent =
+			Entry.GatheredComponents.FindByPredicate(
+				[Component, InstanceIndex](
+					const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& Candidate)
+				{
+					return Candidate.Component.Get() == Component && Candidate.InstanceIndex == InstanceIndex;
+				}))
+		{
+			NewComponent.FadeAlpha = ExistingComponent->FadeAlpha;
+		}
+
+		NewComponent.LastComponentTM = ComponentTM;
+		if (!BuildLocalLimitsForSimpleWorldComponent(
+				*Component,
+				NewComponent.LastComponentTM,
+				Scale3D,
+				Desc,
+				EffectiveMaxPhysicsAssetBodies,
+				EffectiveMaxConvexPlanes,
+				bBuildConvexDebugGeometry,
+				NewComponent.LocalLimits,
+				NewComponent.BodyBindings))
+		{
+			continue;
+		}
+
+		if (!NewComponent.BodyBindings.IsEmpty())
+		{
+			const USkeletalMeshComponent* GatheredSkelComp = Cast<const USkeletalMeshComponent>(Component);
+			NewComponent.SkeletalComponent = GatheredSkelComp;
+			NewComponent.GatheredSkinnedAsset = GatheredSkelComp ? GatheredSkelComp->GetSkinnedAsset() : nullptr;
+			NewComponent.GatheredPhysicsAsset = GatheredSkelComp ? GatheredSkelComp->GetPhysicsAsset() : nullptr;
+			NewComponent.bStatic = false;
+		}
+
+		NewGatheredComponents.Add(MoveTemp(NewComponent));
+	}
+
+	Entry.GatheredComponents = MoveTemp(NewGatheredComponents);
+	ResolveSimpleWorldGroundSource(Entry, SkelComp, bUseMovementGround);
+
+	if (Desc.bGroundCollision)
+	{
+		SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Ground);
+		bool bGroundChanged = false;
+		if (!TryUpdateSimpleWorldGroundBoxFromSource(Entry, SkelComp, Radius, bGroundChanged))
+		{
+			FHitResult Hit;
+			const bool bHitGround = World.LineTraceSingleByChannel(
+				Hit,
+				Center,
+				Center - FVector(0.0f, 0.0f, GroundTraceLength),
+				CollisionChannel,
+				QueryParams,
+				ResponseParams);
+
+			FBoxLimit NewGroundBox;
+			if (bHitGround
+				&& KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldGroundBox(
+					Hit.ImpactPoint, Hit.ImpactNormal, Radius, NewGroundBox))
+			{
+				Entry.GroundBox = NewGroundBox;
+				Entry.bHasGroundBox = true;
+				Entry.GroundComponent = Hit.GetComponent();
+				Entry.GroundBoxSource = EKawaiiPhysicsSimpleWorldGroundSource::Trace;
+				Entry.GroundComponentTM = FTransform::Identity;
+				Entry.GroundInstanceIndex = INDEX_NONE;
+				Entry.bGroundComponentStatic = true;
+
+				if (const UPrimitiveComponent* GroundHitComponent = Hit.GetComponent())
+				{
+					InitializeSimpleWorldTraceGroundFloor(
+						*GroundHitComponent,
+						Hit.Item,
+						Entry.GroundComponentTM,
+						Entry.GroundInstanceIndex,
+						Entry.bGroundComponentStatic);
+					Entry.GroundBoxLocal =
+						KawaiiPhysicsSimpleWorldCollision::MakeSimpleWorldGroundBoxLocal(
+							Entry.GroundBox,
+							Entry.GroundComponentTM);
+				}
+			}
+			else
+			{
+				ClearSimpleWorldGroundBox(Entry, bGroundChanged);
+			}
+		}
+	}
+	else
+	{
+		bool bGroundChanged = false;
+		ClearSimpleWorldGroundBox(Entry, bGroundChanged);
+	}
+
+	Entry.bHasGatheredOnce = true;
+	Entry.bWorldLimitsDirty = true;
+	Entry.bGroundBoxDirty = true;
+	Entry.TimeSinceLastGather = 0.0f;
+}
+
+void UKawaiiPhysicsSharedCollisionSubsystem::UpdateSimpleWorldGround(
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	const USkeletalMeshComponent& SkelComp,
+	const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+	float Radius,
+	bool bGatherInputValid)
+{
+	if (!Desc.bGroundCollision)
+	{
+		return;
+	}
+
+	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Ground);
+	// Provider / CharacterMovement の再取得は収集中心・半径が有効なフレームだけ行う。
+	// Trace ソースの床追従（F14）は Center/Radius を使わないため、入力が不正な間も動き続ける。
+	if (bGatherInputValid
+		&& (Entry.GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::Provider
+			|| Entry.GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::CharacterMovement))
+	{
+		bool bGroundChanged = false;
+		const bool bGroundBoxUpdated =
+			TryUpdateSimpleWorldGroundBoxFromSource(Entry, SkelComp, Radius, bGroundChanged);
+		if (!bGroundChanged && !bGroundBoxUpdated)
+		{
+			// Provider / CharacterMovement が床を返さない間（落下中など）は、収集フレームのトレースが作った Trace 由来の Box を動く床に追従させる。
+			if (UpdateSimpleWorldTraceGroundBoxFromFloor(Entry))
+			{
+				Entry.bGroundBoxDirty = true;
+			}
+		}
+		return;
+	}
+
+	if (UpdateSimpleWorldTraceGroundBoxFromFloor(Entry))
+	{
+		Entry.bGroundBoxDirty = true;
+	}
+}
+
+bool UKawaiiPhysicsSharedCollisionSubsystem::UpdateSimpleWorldTransforms(
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	float DeltaTime,
+	bool bRegatherOnScaleChange,
+	float FadeInTime)
+{
+	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_UpdateTransforms);
+	bool bDirty = Entry.bWorldLimitsDirty;
+	for (auto ComponentIt = Entry.GatheredComponents.CreateIterator(); ComponentIt; ++ComponentIt)
+	{
+		const UPrimitiveComponent* Component = ComponentIt->Component.Get();
+		if (!Component)
+		{
+			ComponentIt.RemoveCurrent();
+			bDirty = true;
+			continue;
+		}
+
+		if (ComponentIt->FadeAlpha < 1.0f)
+		{
+			ComponentIt->FadeAlpha = FadeInTime > KINDA_SMALL_NUMBER
+				? FMath::Min(1.0f, ComponentIt->FadeAlpha + DeltaTime / FadeInTime)
+				: 1.0f;
+			bDirty = true;
+		}
+
+		if (!ComponentIt->BodyBindings.IsEmpty())
+		{
+			const USkeletalMeshComponent* SkeletalComponent = ComponentIt->SkeletalComponent.Get();
+			if (!SkeletalComponent)
+			{
+				ComponentIt.RemoveCurrent();
+				bDirty = true;
+				continue;
+			}
+
+			// SkinnedAsset / PhysicsAsset の差し替え、および（opt-in 時の）コンポーネントスケール変化は
+			// 焼き込み済み Limit と食い違うため次 Tick で再収集する
+			if (SkeletalComponent->GetSkinnedAsset() != ComponentIt->GatheredSkinnedAsset.Get()
+				|| SkeletalComponent->GetPhysicsAsset() != ComponentIt->GatheredPhysicsAsset.Get()
+				|| (bRegatherOnScaleChange
+					&& !SkeletalComponent->GetComponentScale().Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER)))
+			{
+				ComponentIt.RemoveCurrent();
+				Entry.TimeSinceLastGather = FLT_MAX;
+				bDirty = true;
+				continue;
+			}
+
+			// 相手SkelCompのPostAnimEvaluationとSubsystem Tickの順序次第で、ここで読むポーズは1フレーム前の可能性がある。
+			// Targetノード側ではPublish/Readの位相差も含めて最大2フレーム遅延し得る。
+			const TArray<FTransform>& ComponentSpaceTransforms = SkeletalComponent->GetComponentSpaceTransforms();
+			const int32 NumMissingBones = KawaiiPhysicsSimpleWorldCollision::UpdateSkeletalBodyWorldTransforms(
+				MakeArrayView(ComponentIt->BodyBindings),
+				MakeArrayView(ComponentSpaceTransforms),
+				SkeletalComponent->GetComponentTransform(),
+				ComponentIt->BodyWorldTMScratch);
+			if (NumMissingBones > 0)
+			{
+				ComponentIt.RemoveCurrent();
+				Entry.TimeSinceLastGather = FLT_MAX;
+				bDirty = true;
+				continue;
+			}
+
+			bool bBodyTransformsDirty = ComponentIt->LastBodyWorldTMs.Num() != ComponentIt->BodyWorldTMScratch.Num();
+			if (!bBodyTransformsDirty)
+			{
+				for (int32 BodyIndex = 0; BodyIndex < ComponentIt->LastBodyWorldTMs.Num(); ++BodyIndex)
+				{
+					if (!ComponentIt->LastBodyWorldTMs[BodyIndex].Equals(
+						ComponentIt->BodyWorldTMScratch[BodyIndex], KINDA_SMALL_NUMBER))
+					{
+						bBodyTransformsDirty = true;
+						break;
+					}
+				}
+			}
+
+			if (bBodyTransformsDirty)
+			{
+				Swap(ComponentIt->LastBodyWorldTMs, ComponentIt->BodyWorldTMScratch);
+				bDirty = true;
+			}
+			continue;
+		}
+
+		if (!ComponentIt->bStatic)
+		{
+			FTransform CurrentComponentTM = GetScaleStrippedComponentTransform(*Component);
+			FVector CurrentScale3D = Component->GetComponentScale();
+			if (ComponentIt->InstanceIndex != INDEX_NONE)
+			{
+				const UInstancedStaticMeshComponent* ISMComponent =
+					Cast<const UInstancedStaticMeshComponent>(Component);
+				if (!ISMComponent
+					|| ComponentIt->InstanceIndex < 0
+					|| ComponentIt->InstanceIndex >= ISMComponent->GetInstanceCount())
+				{
+					ComponentIt.RemoveCurrent();
+					Entry.TimeSinceLastGather = FLT_MAX;
+					bDirty = true;
+					continue;
+				}
+
+				FTransform InstanceTM;
+				if (!ISMComponent->GetInstanceTransform(ComponentIt->InstanceIndex, InstanceTM, true))
+				{
+					ComponentIt.RemoveCurrent();
+					Entry.TimeSinceLastGather = FLT_MAX;
+					bDirty = true;
+					continue;
+				}
+				CurrentComponentTM = GetScaleStrippedKawaiiPhysicsSimpleWorldInstanceTransform(InstanceTM);
+				CurrentScale3D = InstanceTM.GetScale3D();
+			}
+
+			// opt-in 時、スケール変化は焼き込み済み Limit と食い違うため次 Tick で再収集する
+			if (bRegatherOnScaleChange && !CurrentScale3D.Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER))
+			{
+				ComponentIt.RemoveCurrent();
+				Entry.TimeSinceLastGather = FLT_MAX;
+				bDirty = true;
+				continue;
+			}
+
+			if (!ComponentIt->LastComponentTM.Equals(CurrentComponentTM, KINDA_SMALL_NUMBER))
+			{
+				ComponentIt->LastComponentTM = CurrentComponentTM;
+				bDirty = true;
+			}
+		}
+	}
+	return bDirty;
+}
+
 void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float DeltaTime)
 {
 	UWorld* World = GetWorld();
@@ -1408,6 +1889,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 			Entry->bHasGatheredOnce = false;
 			Entry->TimeSinceLastGather = FLT_MAX;
 			Entry->bWorldLimitsDirty = true;
+			Entry->bGroundBoxDirty = true;
 		}
 
 		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
@@ -1461,395 +1943,42 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 
 		if (bShouldGather)
 		{
-			SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Gather);
-			Entry->LastGatherRadius = Radius;
-
 			const ECollisionChannel CollisionChannel = Desc.CollisionChannel != ECC_MAX
 				? Desc.CollisionChannel.GetValue()
 				: SkelComp->GetCollisionObjectType();
-			const FCollisionResponseParams ResponseParams =
-				KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldResponseParams(Desc.ObjectTypes);
-			FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(KawaiiPhysicsSimpleWorldCollision), false);
-			// Overlap応答（トリガー等）は物理クエリのPreFilterで除外し、結果配列に返さない（ループ側のbBlockingHit判定は防御として残す）。
-			QueryParams.bIgnoreTouches = true;
-			QueryParams.AddIgnoredActor(SkelComp->GetOwner());
-
-			Entry->OverlapScratch.Reset();
-			World->OverlapMultiByChannel(
-				Entry->OverlapScratch,
+			GatherSimpleWorldEntry(
+				*World,
+				*Entry,
+				*SkelComp,
+				Desc,
 				Center,
-				FQuat::Identity,
+				Radius,
+				GroundTraceLength,
 				CollisionChannel,
-				FCollisionShape::MakeSphere(Radius),
-				QueryParams,
-				ResponseParams);
-
-			TSet<FKawaiiPhysicsSimpleWorldGatherKey> UniqueGatherKeys;
-			TArray<FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent> NewGatheredComponents;
-			NewGatheredComponents.Reserve(
-				FMath::Max(0, FMath::Min(Entry->OverlapScratch.Num(), EffectiveMaxGatheredComponents)));
-
-			for (const FOverlapResult& Overlap : Entry->OverlapScratch)
-			{
-				if (NewGatheredComponents.Num() >= EffectiveMaxGatheredComponents)
-				{
-					break;
-				}
-
-				if (!Overlap.bBlockingHit)
-				{
-					// レスポンスが Overlap/Ignore のコンポーネント（トリガー等）は収集対象外。
-					continue;
-				}
-
-				UPrimitiveComponent* Component = Overlap.GetComponent();
-				if (!Component)
-				{
-					continue;
-				}
-
-				const AActor* ComponentOwner = Component->GetOwner();
-				if ((ComponentOwner && ComponentOwner->ActorHasTag(GSimpleWorldIgnoreTagName))
-					|| Component->ComponentHasTag(GSimpleWorldIgnoreTagName))
-				{
-					continue;
-				}
-
-				int32 InstanceIndex = INDEX_NONE;
-				FTransform ComponentTM = GetScaleStrippedComponentTransform(*Component);
-				FVector Scale3D = Component->GetComponentScale();
-				if (const UInstancedStaticMeshComponent* ISMComponent = Cast<UInstancedStaticMeshComponent>(Component))
-				{
-					// FOverlapResult::GetItemIndexは5.7で追加されたため、それ以前は公開メンバのItemIndexを直接読む。
-#if UE_VERSION_OLDER_THAN(5, 7, 0)
-					const int32 OverlapItemIndex = Overlap.ItemIndex;
-#else
-					const int32 OverlapItemIndex = Overlap.GetItemIndex();
-#endif
-					if (OverlapItemIndex < 0 || OverlapItemIndex >= ISMComponent->GetInstanceCount())
-					{
-						continue;
-					}
-
-					FTransform InstanceTM;
-					if (!ISMComponent->GetInstanceTransform(OverlapItemIndex, InstanceTM, true))
-					{
-						continue;
-					}
-
-					InstanceIndex = OverlapItemIndex;
-					ComponentTM = GetScaleStrippedKawaiiPhysicsSimpleWorldInstanceTransform(InstanceTM);
-					Scale3D = InstanceTM.GetScale3D();
-				}
-
-				const FKawaiiPhysicsSimpleWorldGatherKey GatherKey(Component, InstanceIndex);
-				if (UniqueGatherKeys.Contains(GatherKey))
-				{
-					continue;
-				}
-				UniqueGatherKeys.Add(GatherKey);
-
-				FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent NewComponent;
-				NewComponent.Component = Component;
-				NewComponent.InstanceIndex = InstanceIndex;
-				NewComponent.bStatic = IsSimpleWorldComponentStatic(*Component);
-				NewComponent.FadeAlpha = Entry->bHasGatheredOnce ? 0.0f : 1.0f;
-				NewComponent.GatheredScale3D = Scale3D;
-
-				if (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent* ExistingComponent =
-					Entry->GatheredComponents.FindByPredicate(
-						[Component, InstanceIndex](
-							const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& Candidate)
-						{
-							return Candidate.Component.Get() == Component && Candidate.InstanceIndex == InstanceIndex;
-						}))
-				{
-					NewComponent.FadeAlpha = ExistingComponent->FadeAlpha;
-				}
-
-				NewComponent.LastComponentTM = ComponentTM;
-				if (!BuildLocalLimitsForSimpleWorldComponent(
-						*Component,
-						NewComponent.LastComponentTM,
-						Scale3D,
-						Desc,
-						EffectiveMaxPhysicsAssetBodies,
-						EffectiveMaxConvexPlanes,
-						bBuildConvexDebugGeometry,
-						NewComponent.LocalLimits,
-						NewComponent.BodyBindings))
-				{
-					continue;
-				}
-
-				if (!NewComponent.BodyBindings.IsEmpty())
-				{
-					const USkeletalMeshComponent* GatheredSkelComp = Cast<const USkeletalMeshComponent>(Component);
-					NewComponent.SkeletalComponent = GatheredSkelComp;
-					NewComponent.GatheredSkinnedAsset = GatheredSkelComp ? GatheredSkelComp->GetSkinnedAsset() : nullptr;
-					NewComponent.GatheredPhysicsAsset = GatheredSkelComp ? GatheredSkelComp->GetPhysicsAsset() : nullptr;
-					NewComponent.bStatic = false;
-				}
-
-				NewGatheredComponents.Add(MoveTemp(NewComponent));
-			}
-
-			Entry->GatheredComponents = MoveTemp(NewGatheredComponents);
-			ResolveSimpleWorldGroundSource(*Entry, *SkelComp, bUseMovementGround);
-
-			if (Desc.bGroundCollision)
-			{
-				SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Ground);
-				bool bGroundChanged = false;
-				if (!TryUpdateSimpleWorldGroundBoxFromSource(*Entry, *SkelComp, Radius, bGroundChanged))
-				{
-					FHitResult Hit;
-					const bool bHitGround = World->LineTraceSingleByChannel(
-						Hit,
-						Center,
-						Center - FVector(0.0f, 0.0f, GroundTraceLength),
-						CollisionChannel,
-						QueryParams,
-						ResponseParams);
-
-					FBoxLimit NewGroundBox;
-					if (bHitGround
-						&& KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldGroundBox(
-							Hit.ImpactPoint, Hit.ImpactNormal, Radius, NewGroundBox))
-					{
-						Entry->GroundBox = NewGroundBox;
-						Entry->bHasGroundBox = true;
-						Entry->GroundComponent = Hit.GetComponent();
-						Entry->GroundBoxSource = EKawaiiPhysicsSimpleWorldGroundSource::Trace;
-						Entry->GroundComponentTM = FTransform::Identity;
-						Entry->GroundInstanceIndex = INDEX_NONE;
-						Entry->bGroundComponentStatic = true;
-
-						if (const UPrimitiveComponent* GroundHitComponent = Hit.GetComponent())
-						{
-							InitializeSimpleWorldTraceGroundFloor(
-								*GroundHitComponent,
-								Hit.Item,
-								Entry->GroundComponentTM,
-								Entry->GroundInstanceIndex,
-								Entry->bGroundComponentStatic);
-							Entry->GroundBoxLocal =
-								KawaiiPhysicsSimpleWorldCollision::MakeSimpleWorldGroundBoxLocal(
-									Entry->GroundBox,
-									Entry->GroundComponentTM);
-						}
-					}
-					else
-					{
-						ClearSimpleWorldGroundBox(*Entry, bGroundChanged);
-					}
-				}
-			}
-			else
-			{
-				bool bGroundChanged = false;
-				ClearSimpleWorldGroundBox(*Entry, bGroundChanged);
-			}
-
-			Entry->bHasGatheredOnce = true;
-			Entry->bWorldLimitsDirty = true;
-			Entry->TimeSinceLastGather = 0.0f;
+				EffectiveMaxGatheredComponents,
+				EffectiveMaxPhysicsAssetBodies,
+				EffectiveMaxConvexPlanes,
+				bUseMovementGround,
+				bBuildConvexDebugGeometry);
 		}
-		else if (bGatherInputValid
-			&& bAllowGather
-			&& Desc.bGroundCollision
-			&& (Entry->GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::Provider
-				|| Entry->GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::CharacterMovement))
+		else if (bAllowGather)
 		{
-			SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Ground);
-			bool bGroundChanged = false;
-			const bool bGroundBoxUpdated =
-				TryUpdateSimpleWorldGroundBoxFromSource(*Entry, *SkelComp, Radius, bGroundChanged);
-			if (bGroundChanged)
-			{
-				Entry->bWorldLimitsDirty = true;
-			}
-			else if (!bGroundBoxUpdated)
-			{
-				// Provider / CharacterMovement が床を返さない間（落下中など）は、収集フレームのトレースが作った Trace 由来の Box を動く床に追従させる。
-				if (UpdateSimpleWorldTraceGroundBoxFromFloor(*Entry))
-				{
-					Entry->bWorldLimitsDirty = true;
-				}
-			}
-		}
-		else if (bAllowGather && Desc.bGroundCollision)
-		{
-			SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Ground);
-			if (UpdateSimpleWorldTraceGroundBoxFromFloor(*Entry))
-			{
-				Entry->bWorldLimitsDirty = true;
-			}
+			UpdateSimpleWorldGround(*Entry, *SkelComp, Desc, Radius, bGatherInputValid);
 		}
 
-		SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_UpdateTransforms);
-		bool bDirty = Entry->bWorldLimitsDirty;
-		for (auto ComponentIt = Entry->GatheredComponents.CreateIterator(); ComponentIt; ++ComponentIt)
-		{
-			const UPrimitiveComponent* Component = ComponentIt->Component.Get();
-			if (!Component)
-			{
-				ComponentIt.RemoveCurrent();
-				bDirty = true;
-				continue;
-			}
-
-			if (ComponentIt->FadeAlpha < 1.0f)
-			{
-				ComponentIt->FadeAlpha = KawaiiSettings->SimpleWorldCollisionFadeInTime > KINDA_SMALL_NUMBER
-					? FMath::Min(1.0f, ComponentIt->FadeAlpha + DeltaTime / KawaiiSettings->SimpleWorldCollisionFadeInTime)
-					: 1.0f;
-				bDirty = true;
-			}
-
-			if (!ComponentIt->BodyBindings.IsEmpty())
-			{
-				const USkeletalMeshComponent* SkeletalComponent = ComponentIt->SkeletalComponent.Get();
-				if (!SkeletalComponent)
-				{
-					ComponentIt.RemoveCurrent();
-					bDirty = true;
-					continue;
-				}
-
-				// SkinnedAsset / PhysicsAsset の差し替え、および（opt-in 時の）コンポーネントスケール変化は
-				// 焼き込み済み Limit と食い違うため次 Tick で再収集する
-				if (SkeletalComponent->GetSkinnedAsset() != ComponentIt->GatheredSkinnedAsset.Get()
-					|| SkeletalComponent->GetPhysicsAsset() != ComponentIt->GatheredPhysicsAsset.Get()
-					|| (bRegatherOnScaleChange
-						&& !SkeletalComponent->GetComponentScale().Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER)))
-				{
-					ComponentIt.RemoveCurrent();
-					Entry->TimeSinceLastGather = FLT_MAX;
-					bDirty = true;
-					continue;
-				}
-
-				// 相手SkelCompのPostAnimEvaluationとSubsystem Tickの順序次第で、ここで読むポーズは1フレーム前の可能性がある。
-				// Targetノード側ではPublish/Readの位相差も含めて最大2フレーム遅延し得る。
-				const TArray<FTransform>& ComponentSpaceTransforms = SkeletalComponent->GetComponentSpaceTransforms();
-				const int32 NumMissingBones = KawaiiPhysicsSimpleWorldCollision::UpdateSkeletalBodyWorldTransforms(
-					MakeArrayView(ComponentIt->BodyBindings),
-					MakeArrayView(ComponentSpaceTransforms),
-					SkeletalComponent->GetComponentTransform(),
-					ComponentIt->BodyWorldTMScratch);
-				if (NumMissingBones > 0)
-				{
-					ComponentIt.RemoveCurrent();
-					Entry->TimeSinceLastGather = FLT_MAX;
-					bDirty = true;
-					continue;
-				}
-
-				bool bBodyTransformsDirty = ComponentIt->LastBodyWorldTMs.Num() != ComponentIt->BodyWorldTMScratch.Num();
-				if (!bBodyTransformsDirty)
-				{
-					for (int32 BodyIndex = 0; BodyIndex < ComponentIt->LastBodyWorldTMs.Num(); ++BodyIndex)
-					{
-						if (!ComponentIt->LastBodyWorldTMs[BodyIndex].Equals(
-							ComponentIt->BodyWorldTMScratch[BodyIndex], KINDA_SMALL_NUMBER))
-						{
-							bBodyTransformsDirty = true;
-							break;
-						}
-					}
-				}
-
-				if (bBodyTransformsDirty)
-				{
-					Swap(ComponentIt->LastBodyWorldTMs, ComponentIt->BodyWorldTMScratch);
-					bDirty = true;
-				}
-				continue;
-			}
-
-			if (!ComponentIt->bStatic)
-			{
-				FTransform CurrentComponentTM = GetScaleStrippedComponentTransform(*Component);
-				FVector CurrentScale3D = Component->GetComponentScale();
-				if (ComponentIt->InstanceIndex != INDEX_NONE)
-				{
-					const UInstancedStaticMeshComponent* ISMComponent =
-						Cast<const UInstancedStaticMeshComponent>(Component);
-					if (!ISMComponent
-						|| ComponentIt->InstanceIndex < 0
-						|| ComponentIt->InstanceIndex >= ISMComponent->GetInstanceCount())
-					{
-						ComponentIt.RemoveCurrent();
-						Entry->TimeSinceLastGather = FLT_MAX;
-						bDirty = true;
-						continue;
-					}
-
-					FTransform InstanceTM;
-					if (!ISMComponent->GetInstanceTransform(ComponentIt->InstanceIndex, InstanceTM, true))
-					{
-						ComponentIt.RemoveCurrent();
-						Entry->TimeSinceLastGather = FLT_MAX;
-						bDirty = true;
-						continue;
-					}
-					CurrentComponentTM = GetScaleStrippedKawaiiPhysicsSimpleWorldInstanceTransform(InstanceTM);
-					CurrentScale3D = InstanceTM.GetScale3D();
-				}
-
-				// opt-in 時、スケール変化は焼き込み済み Limit と食い違うため次 Tick で再収集する
-				if (bRegatherOnScaleChange && !CurrentScale3D.Equals(ComponentIt->GatheredScale3D, KINDA_SMALL_NUMBER))
-				{
-					ComponentIt.RemoveCurrent();
-					Entry->TimeSinceLastGather = FLT_MAX;
-					bDirty = true;
-					continue;
-				}
-
-				if (!ComponentIt->LastComponentTM.Equals(CurrentComponentTM, KINDA_SMALL_NUMBER))
-				{
-					ComponentIt->LastComponentTM = CurrentComponentTM;
-					bDirty = true;
-				}
-			}
-		}
+		const bool bDirty = UpdateSimpleWorldTransforms(
+			*Entry,
+			DeltaTime,
+			bRegatherOnScaleChange,
+			KawaiiSettings->SimpleWorldCollisionFadeInTime);
 
 		if (bDirty)
 		{
-			Entry->PublishScratch.Reset();
-			for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& Component : Entry->GatheredComponents)
-			{
-				// フェード計算本体は KawaiiPhysicsSimpleWorldCollision 名前空間へ移設済み（単体テスト可能化のため）。
-				// しきい値定数はここ（Subsystem側）で保持したまま引数として渡す。
-				if (!Component.BodyBindings.IsEmpty())
-				{
-					KawaiiPhysicsSimpleWorldCollision::AppendFadedSkeletalLocalLimits(
-						Component.LocalLimits,
-						MakeArrayView(Component.BodyBindings),
-						MakeArrayView(Component.LastBodyWorldTMs),
-						Component.FadeAlpha,
-						Entry->PublishScratch,
-						GSimpleWorldFadeBoxEnableThreshold);
-				}
-				else
-				{
-					KawaiiPhysicsSimpleWorldCollision::AppendFadedLocalLimits(
-						Component.LocalLimits,
-						Component.FadeAlpha,
-						Component.LastComponentTM,
-						Entry->PublishScratch,
-						GSimpleWorldFadeBoxEnableThreshold);
-				}
-			}
-
-			if (Entry->bHasGroundBox)
-			{
-				Entry->PublishScratch.BoxLimits.Add(Entry->GroundBox);
-			}
-
-			Entry->Slot.Publish(Entry->PublishScratch);
-			Entry->bWorldLimitsDirty = false;
+			PublishSimpleWorldShapeLimits(*Entry, GSimpleWorldFadeBoxEnableThreshold);
+		}
+		if (Entry->bGroundBoxDirty)
+		{
+			PublishSimpleWorldGroundBox(*Entry);
 		}
 
 #if ENABLE_DRAW_DEBUG

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
@@ -2,6 +2,7 @@
 
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 
+#include "Algo/StableSort.h"
 #include "Engine/EngineTypes.h"
 #include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
@@ -151,6 +152,26 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		return !Center.ContainsNaN()
 			&& FMath::IsFinite(Radius)
 			&& Radius > KINDA_SMALL_NUMBER;
+	}
+
+	bool ShouldUseSimpleWorldGatherOrder(int32 NumOverlaps, int32 MaxGatheredComponents)
+	{
+		// 上限 0（CVar で指定可）では visit ループが即座に打ち切られるため、距離計算と StableSort を払わない（master と同じ O(1)）。
+		return MaxGatheredComponents > 0 && NumOverlaps > MaxGatheredComponents;
+	}
+
+	void SortSimpleWorldGatherOrderByDistance(TArrayView<const float> DistanceSquared, TArray<int32>& OutOrder)
+	{
+		OutOrder.Reset(DistanceSquared.Num());
+		for (int32 Index = 0; Index < DistanceSquared.Num(); ++Index)
+		{
+			OutOrder.Add(Index);
+		}
+
+		Algo::StableSort(OutOrder, [&DistanceSquared](int32 Lhs, int32 Rhs)
+		{
+			return DistanceSquared[Lhs] < DistanceSquared[Rhs];
+		});
 	}
 
 	void AppendBoundsLocalLimits(

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsPerfTest.cpp
@@ -3,6 +3,7 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "Misc/AutomationTest.h"
+#include "Animation/AnimInstanceProxy.h"
 #include "HAL/PlatformTime.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "Templates/Function.h"
@@ -500,6 +501,221 @@ namespace
 
 		return bCountOk;
 	}
+
+	// ---------------------------------------------------------------
+	// SimpleWorld 読み取りベンチ
+	// ---------------------------------------------------------------
+	// SimpleWorld のワーカー側読み取り経路（Slot serial 判定、必要時 AppendTo、simulation 空間配列更新）を計測する。
+	// 形状 Slot は Convex64+Box64、GroundSlot は Box1。Publish 間隔 1 と 12 で全再構築寄り/インプレース更新寄りを分ける。
+
+	constexpr int32 GSimpleWorldReadConvexCount = 64;
+	constexpr int32 GSimpleWorldReadBoxCount = 64;
+	constexpr int32 GSimpleWorldReadGroundBoxCount = 1;
+	constexpr int32 GSimpleWorldReadLimitsPerFrame =
+		GSimpleWorldReadConvexCount + GSimpleWorldReadBoxCount + GSimpleWorldReadGroundBoxCount;
+
+	TArray<FPlane> MakeSimpleWorldReadUnitCubePlanes()
+	{
+		TArray<FPlane> Planes;
+		Planes.Reserve(6);
+		Planes.Add(FPlane(1.0f, 0.0f, 0.0f, 1.0f));
+		Planes.Add(FPlane(-1.0f, 0.0f, 0.0f, 1.0f));
+		Planes.Add(FPlane(0.0f, 1.0f, 0.0f, 1.0f));
+		Planes.Add(FPlane(0.0f, -1.0f, 0.0f, 1.0f));
+		Planes.Add(FPlane(0.0f, 0.0f, 1.0f, 1.0f));
+		Planes.Add(FPlane(0.0f, 0.0f, -1.0f, 1.0f));
+		return Planes;
+	}
+
+	FKawaiiPhysicsSharedCollisionData MakeSimpleWorldReadSourceTemplate()
+	{
+		FKawaiiPhysicsSharedCollisionData Data;
+		Data.ConvexLimits.Reserve(GSimpleWorldReadConvexCount);
+		Data.BoxLimits.Reserve(GSimpleWorldReadBoxCount);
+
+		const TArray<FPlane> UnitCubePlanes = MakeSimpleWorldReadUnitCubePlanes();
+		for (int32 Index = 0; Index < GSimpleWorldReadConvexCount; ++Index)
+		{
+			const int32 GridX = Index % 8;
+			const int32 GridY = Index / 8;
+
+			FKawaiiPhysicsConvexLimit Convex;
+			Convex.Location = FVector(GridX * 25.0f, GridY * 25.0f, 30.0f + (Index % 4) * 6.0f);
+			Convex.Rotation = FQuat(FVector::ZAxisVector, FMath::DegreesToRadians(Index * 3.0f));
+			Convex.LocalPlanes = UnitCubePlanes;
+			Convex.LocalBounds = FBox(FVector(-1.0f, -1.0f, -1.0f), FVector(1.0f, 1.0f, 1.0f));
+			Convex.bEnable = true;
+			Convex.SourceType = ECollisionSourceType::SimpleWorld;
+			Data.ConvexLimits.Add(Convex);
+		}
+
+		for (int32 Index = 0; Index < GSimpleWorldReadBoxCount; ++Index)
+		{
+			const int32 GridX = Index % 8;
+			const int32 GridY = Index / 8;
+
+			FBoxLimit Box;
+			Box.Location = FVector(220.0f + GridX * 28.0f, GridY * 28.0f, 40.0f + (Index % 5) * 5.0f);
+			Box.Rotation = FQuat(FVector::YAxisVector, FMath::DegreesToRadians(Index * 2.0f));
+			Box.Extent = FVector(10.0f, 10.0f, 10.0f);
+			Box.bEnable = true;
+			Box.SourceType = ECollisionSourceType::SimpleWorld;
+			Data.BoxLimits.Add(Box);
+		}
+
+		return Data;
+	}
+
+	FKawaiiPhysicsSharedCollisionData MakeSimpleWorldReadGroundTemplate()
+	{
+		FKawaiiPhysicsSharedCollisionData Data;
+		Data.BoxLimits.Reserve(GSimpleWorldReadGroundBoxCount);
+
+		FBoxLimit GroundBox;
+		GroundBox.Location = FVector(120.0f, 120.0f, -20.0f);
+		GroundBox.Rotation = FQuat(FVector::XAxisVector, FMath::DegreesToRadians(2.0f));
+		GroundBox.Extent = FVector(180.0f, 180.0f, 10.0f);
+		GroundBox.bEnable = true;
+		GroundBox.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.BoxLimits.Add(GroundBox);
+
+		return Data;
+	}
+
+	void EnsureSimpleWorldReadScratch(const FKawaiiPhysicsSharedCollisionData& Template,
+	                                  FKawaiiPhysicsSharedCollisionData& Scratch)
+	{
+		if (Scratch.SphericalLimits.Num() == Template.SphericalLimits.Num() &&
+			Scratch.CapsuleLimits.Num() == Template.CapsuleLimits.Num() &&
+			Scratch.TaperedCapsuleLimits.Num() == Template.TaperedCapsuleLimits.Num() &&
+			Scratch.BoxLimits.Num() == Template.BoxLimits.Num() &&
+			Scratch.PlanarLimits.Num() == Template.PlanarLimits.Num() &&
+			Scratch.ConvexLimits.Num() == Template.ConvexLimits.Num())
+		{
+			return;
+		}
+
+		Scratch.Reset();
+		CopyLimitsElementwise(Template.SphericalLimits, Scratch.SphericalLimits);
+		CopyLimitsElementwise(Template.CapsuleLimits, Scratch.CapsuleLimits);
+		CopyLimitsElementwise(Template.TaperedCapsuleLimits, Scratch.TaperedCapsuleLimits);
+		CopyLimitsElementwise(Template.BoxLimits, Scratch.BoxLimits);
+		CopyLimitsElementwise(Template.PlanarLimits, Scratch.PlanarLimits);
+		CopyLimitsElementwise(Template.ConvexLimits, Scratch.ConvexLimits);
+	}
+
+	template <typename TLimitArray>
+	void OffsetSimpleWorldReadLimitLocations(const TLimitArray& TemplateLimits, TLimitArray& ScratchLimits,
+	                                         const FVector& Offset)
+	{
+		for (int32 Index = 0; Index < ScratchLimits.Num(); ++Index)
+		{
+			ScratchLimits[Index].Location = TemplateLimits[Index].Location + Offset;
+		}
+	}
+
+	void PublishSimpleWorldReadSource(const FKawaiiPhysicsSharedCollisionData& Template,
+	                                  FKawaiiPhysicsSharedCollisionData& Scratch,
+	                                  FKawaiiPhysicsSharedCollisionSourceSlot& Slot,
+	                                  uint64 PublishIndex)
+	{
+		EnsureSimpleWorldReadScratch(Template, Scratch);
+
+		const FVector Offset(0.01f * static_cast<float>(PublishIndex), 0.0f, 0.0f);
+		OffsetSimpleWorldReadLimitLocations(Template.SphericalLimits, Scratch.SphericalLimits, Offset);
+		OffsetSimpleWorldReadLimitLocations(Template.CapsuleLimits, Scratch.CapsuleLimits, Offset);
+		OffsetSimpleWorldReadLimitLocations(Template.TaperedCapsuleLimits, Scratch.TaperedCapsuleLimits, Offset);
+		OffsetSimpleWorldReadLimitLocations(Template.BoxLimits, Scratch.BoxLimits, Offset);
+		OffsetSimpleWorldReadLimitLocations(Template.PlanarLimits, Scratch.PlanarLimits, Offset);
+		OffsetSimpleWorldReadLimitLocations(Template.ConvexLimits, Scratch.ConvexLimits, Offset);
+
+		Slot.Publish(Scratch);
+	}
+
+	bool RunSimpleWorldReadPerf(FAutomationTestBase& Test, const TCHAR* TestLabel, int32 PublishInterval)
+	{
+		constexpr int32 MeasureFrames = 100000;
+		const int32 SafePublishInterval = FMath::Max(1, PublishInterval);
+		const FKawaiiPhysicsSharedCollisionData SourceTemplate = MakeSimpleWorldReadSourceTemplate();
+		const FKawaiiPhysicsSharedCollisionData GroundTemplate = MakeSimpleWorldReadGroundTemplate();
+
+		TArray<double> MsPerFrameValues;
+		MsPerFrameValues.Reserve(GTrials);
+		bool bOk = true;
+
+		for (int32 Trial = 0; Trial < GTrials; ++Trial)
+		{
+			TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+				MakeShared<FKawaiiPhysicsSimpleWorldCollisionEntry>();
+			FKawaiiPhysicsTestAccessor Accessor;
+			Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::WorldSpace);
+			Accessor.BuildVerticalChain(4, 10.0f);
+			Accessor.SetSimpleWorldEntry(Entry);
+
+			FAnimInstanceProxy AnimInstanceProxy;
+			FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+			FKawaiiPhysicsSharedCollisionData ShapeScratch;
+			FKawaiiPhysicsSharedCollisionData GroundScratch;
+			uint64 ShapePublishCount = 0;
+			uint64 GroundPublishCount = 0;
+
+			const double CalibrationStartSeconds = FPlatformTime::Seconds();
+			RunKawaiiPhysicsPerfCalibrationLoop();
+			const double CalibMs = (FPlatformTime::Seconds() - CalibrationStartSeconds) * 1000.0;
+
+			for (int32 Frame = 0; Frame < GWarmupFrames; ++Frame)
+			{
+				if (Frame % SafePublishInterval == 0)
+				{
+					PublishSimpleWorldReadSource(SourceTemplate, ShapeScratch, Entry->Slot, ShapePublishCount);
+					++ShapePublishCount;
+				}
+				PublishSimpleWorldReadSource(GroundTemplate, GroundScratch, Entry->GroundSlot, GroundPublishCount);
+				++GroundPublishCount;
+				Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+			}
+
+			const double StartSeconds = FPlatformTime::Seconds();
+			for (int32 Frame = 0; Frame < MeasureFrames; ++Frame)
+			{
+				if (Frame % SafePublishInterval == 0)
+				{
+					PublishSimpleWorldReadSource(SourceTemplate, ShapeScratch, Entry->Slot, ShapePublishCount);
+					++ShapePublishCount;
+				}
+				PublishSimpleWorldReadSource(GroundTemplate, GroundScratch, Entry->GroundSlot, GroundPublishCount);
+				++GroundPublishCount;
+				Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+			}
+			const double ElapsedSeconds = FPlatformTime::Seconds() - StartSeconds;
+			const double MsPerFrame = ElapsedSeconds * 1000.0 / static_cast<double>(MeasureFrames);
+
+			Test.AddInfo(FString::Printf(
+				TEXT("PERF_RAW KawaiiPhysics.Perf.SimpleWorldRead.%s trial=%d ms=%.6f calib_ms=%.6f"),
+				TestLabel, Trial, MsPerFrame, CalibMs));
+			MsPerFrameValues.Add(MsPerFrame);
+
+			bOk &= Test.TestEqual(
+				*FString::Printf(TEXT("SimpleWorld collider count matches final frame template for trial %d"), Trial),
+				Accessor.GetNumSimpleWorldColliders(), GSimpleWorldReadLimitsPerFrame);
+			if (SafePublishInterval == 12)
+			{
+				bOk &= Test.TestEqual(
+					*FString::Printf(TEXT("SimpleWorld shape serial matches publish count for trial %d"), Trial),
+					Accessor.GetLastReadSimpleWorldShapeSerial(), ShapePublishCount);
+			}
+		}
+
+		MsPerFrameValues.Sort();
+		const double MinMsPerFrame = MsPerFrameValues[0];
+		const double MedianMsPerFrame = MsPerFrameValues[GTrials / 2];
+		Test.AddInfo(FString::Printf(
+			TEXT("PERF KawaiiPhysics.Perf.SimpleWorldRead.%s median_ms_per_frame=%.6f min_ms_per_frame=%.6f limits_per_frame=%d"),
+			TestLabel, MedianMsPerFrame, MinMsPerFrame, GSimpleWorldReadLimitsPerFrame));
+
+		return bOk;
+	}
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfChainTest,
@@ -628,6 +844,26 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSharedCollisionCopyTest,
 bool FKawaiiPhysicsPerfSharedCollisionCopyTest::RunTest(const FString& Parameters)
 {
 	return RunSharedCollisionCopyPerf(*this);
+}
+
+// SimpleWorld 読み取り経路の全再構築寄りベンチ。形状 Slot も GroundSlot も毎フレーム Publish する。
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSimpleWorldReadPublishEveryFrameTest,
+                                 "KawaiiPhysics.Perf.SimpleWorldRead.PublishEveryFrame",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsPerfSimpleWorldReadPublishEveryFrameTest::RunTest(const FString& Parameters)
+{
+	return RunSimpleWorldReadPerf(*this, TEXT("PublishEveryFrame"), 1);
+}
+
+// SimpleWorld 読み取り経路の serial 判定ベンチ。形状 Slot は 12 フレーム間隔、GroundSlot は毎フレーム Publish する。
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSimpleWorldReadPublishEvery12Test,
+                                 "KawaiiPhysics.Perf.SimpleWorldRead.PublishEvery12",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsPerfSimpleWorldReadPublishEvery12Test::RunTest(const FString& Parameters)
+{
+	return RunSimpleWorldReadPerf(*this, TEXT("PublishEvery12"), 12);
 }
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsPerfSizeofTest,

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedCollisionSlotTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedCollisionSlotTest.cpp
@@ -205,4 +205,39 @@ bool FKawaiiPhysicsSharedCollisionSourceSlotTest::RunTest(const FString& Paramet
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedCollisionSlotPublishSerialTest,
+                                 "KawaiiPhysics.SharedCollision.SlotPublishSerial",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSharedCollisionSlotPublishSerialTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSharedCollisionSourceSlot Slot;
+
+	TestEqual(TEXT("Initial publish serial is zero"), Slot.GetPublishSerial(), static_cast<uint64>(0));
+
+	FKawaiiPhysicsSharedCollisionData FirstData = MakeSphericalData(10.0f);
+	Slot.Publish(FirstData);
+	TestEqual(TEXT("First Publish increments serial"), Slot.GetPublishSerial(), static_cast<uint64>(1));
+
+	FKawaiiPhysicsSharedCollisionData OutData;
+	Slot.AppendTo(OutData);
+	TestEqual(TEXT("AppendTo keeps serial unchanged"), Slot.GetPublishSerial(), static_cast<uint64>(1));
+
+	Slot.IsExpired(GFrameCounter, 1);
+	TestEqual(TEXT("IsExpired keeps serial unchanged"), Slot.GetPublishSerial(), static_cast<uint64>(1));
+
+	Slot.MarkExpired();
+	TestEqual(TEXT("MarkExpired keeps serial unchanged"), Slot.GetPublishSerial(), static_cast<uint64>(1));
+
+	FKawaiiPhysicsSharedCollisionData SecondData = MakeSphericalData(20.0f);
+	Slot.Publish(SecondData);
+	TestEqual(TEXT("Second Publish increments serial"), Slot.GetPublishSerial(), static_cast<uint64>(2));
+
+	FKawaiiPhysicsSharedCollisionData ThirdData = MakeSphericalData(30.0f);
+	Slot.Publish(ThirdData);
+	TestEqual(TEXT("Third Publish increments serial"), Slot.GetPublishSerial(), static_cast<uint64>(3));
+
+	return true;
+}
+
 #endif // WITH_DEV_AUTOMATION_TESTS

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -4,8 +4,10 @@
 
 #include "Misc/AutomationTest.h"
 #include "KawaiiPhysicsTestHarness.h"
+#include "AnimNode_KawaiiPhysicsInternal.h"
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "Animation/AnimInstanceProxy.h"
 #include "Components/StaticMeshComponent.h"
 #include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
@@ -87,6 +89,72 @@ namespace
 			}
 		}
 		return nullptr;
+	}
+
+	FKawaiiPhysicsSharedCollisionData MakeReadPathWorldData(const FVector& Offset)
+	{
+		FKawaiiPhysicsSharedCollisionData Data;
+
+		FSphericalLimit SphereA;
+		SphereA.Location = Offset + FVector(10.0f, 0.0f, 20.0f);
+		SphereA.Rotation = FQuat(FVector::ZAxisVector, FMath::DegreesToRadians(15.0f));
+		SphereA.Radius = 12.0f;
+		SphereA.LimitType = ESphericalLimitType::Outer;
+		SphereA.bEnable = true;
+		SphereA.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.SphericalLimits.Add(SphereA);
+
+		FSphericalLimit SphereB;
+		SphereB.Location = Offset + FVector(-20.0f, 5.0f, 40.0f);
+		SphereB.Rotation = FQuat(FVector::YAxisVector, FMath::DegreesToRadians(-20.0f));
+		SphereB.Radius = 6.0f;
+		SphereB.LimitType = ESphericalLimitType::Inner;
+		SphereB.bEnable = true;
+		SphereB.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.SphericalLimits.Add(SphereB);
+
+		FCapsuleLimit Capsule;
+		Capsule.Location = Offset + FVector(30.0f, -10.0f, 25.0f);
+		Capsule.Rotation = FQuat(FVector::XAxisVector, FMath::DegreesToRadians(45.0f));
+		Capsule.Radius = 4.0f;
+		Capsule.Length = 18.0f;
+		Capsule.bEnable = true;
+		Capsule.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.CapsuleLimits.Add(Capsule);
+
+		FBoxLimit Box;
+		Box.Location = Offset + FVector(0.0f, 40.0f, 10.0f);
+		Box.Rotation = FQuat(FVector::ZAxisVector, FMath::DegreesToRadians(30.0f));
+		Box.Extent = FVector(5.0f, 7.0f, 9.0f);
+		Box.bEnable = true;
+		Box.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.BoxLimits.Add(Box);
+
+		FKawaiiPhysicsConvexLimit Convex;
+		Convex.Location = Offset + FVector(-15.0f, -25.0f, 12.0f);
+		Convex.Rotation = FQuat(FVector::YAxisVector, FMath::DegreesToRadians(60.0f));
+		Convex.LocalPlanes = MakeUnitCubePlanes();
+		Convex.LocalBounds = FBox(FVector(-1.0f, -1.0f, -1.0f), FVector(1.0f, 1.0f, 1.0f));
+		Convex.bEnable = true;
+		Convex.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.ConvexLimits.Add(Convex);
+
+		return Data;
+	}
+
+	FKawaiiPhysicsSharedCollisionData MakeReadPathGroundWorldData(const FVector& Offset)
+	{
+		FKawaiiPhysicsSharedCollisionData Data;
+
+		FBoxLimit GroundBox;
+		GroundBox.Location = Offset + FVector(0.0f, 0.0f, -12.0f);
+		GroundBox.Rotation = FQuat(FVector::XAxisVector, FMath::DegreesToRadians(5.0f));
+		GroundBox.Extent = FVector(80.0f, 80.0f, 10.0f);
+		GroundBox.bEnable = true;
+		GroundBox.SourceType = ECollisionSourceType::SimpleWorld;
+		Data.BoxLimits.Add(GroundBox);
+
+		return Data;
 	}
 }
 
@@ -1583,6 +1651,115 @@ bool FKawaiiPhysicsSimpleWorldEntryLifecycleTest::RunTest(const FString& Paramet
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldGroundSlotIndependentPublishTest,
+                                 "KawaiiPhysics.SimpleWorld.GroundSlotIndependentPublish",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldGroundSlotIndependentPublishTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent =
+		Entry.GatheredComponents.AddDefaulted_GetRef();
+	GatheredComponent.FadeAlpha = 1.0f;
+	GatheredComponent.LastComponentTM = FTransform::Identity;
+
+	FSphericalLimit Sphere;
+	Sphere.Location = FVector(10.0f, 20.0f, 30.0f);
+	Sphere.Radius = 40.0f;
+	Sphere.bEnable = true;
+	Sphere.SourceType = ECollisionSourceType::SimpleWorld;
+	GatheredComponent.LocalLimits.SphericalLimits.Add(Sphere);
+
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(Entry, 0.5f);
+	TestEqual(TEXT("Shape slot serial after shape publish"), Entry.Slot.GetPublishSerial(), static_cast<uint64>(1));
+
+	FKawaiiPhysicsSharedCollisionData ShapeOutData;
+	Entry.Slot.AppendTo(ShapeOutData);
+	TestEqual(TEXT("Shape slot publishes one sphere"), ShapeOutData.SphericalLimits.Num(), 1);
+	TestEqual(TEXT("Shape slot publishes no boxes"), ShapeOutData.BoxLimits.Num(), 0);
+
+	Entry.bHasGroundBox = true;
+	Entry.GroundBox.Location = FVector(0.0f, 0.0f, -10.0f);
+	Entry.GroundBox.Extent = FVector(100.0f, 100.0f, 10.0f);
+	Entry.GroundBox.Rotation = FQuat::Identity;
+	Entry.GroundBox.bEnable = true;
+	Entry.GroundBox.SourceType = ECollisionSourceType::SimpleWorld;
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldGroundBox(Entry);
+
+	TestEqual(TEXT("Ground slot serial after ground publish"),
+	          Entry.GroundSlot.GetPublishSerial(),
+	          static_cast<uint64>(1));
+	TestEqual(TEXT("Shape slot serial is unchanged after ground publish"),
+	          Entry.Slot.GetPublishSerial(),
+	          static_cast<uint64>(1));
+
+	FKawaiiPhysicsSharedCollisionData GroundOutData;
+	Entry.GroundSlot.AppendTo(GroundOutData);
+	TestEqual(TEXT("Ground slot publishes one box"), GroundOutData.BoxLimits.Num(), 1);
+
+	Entry.bHasGroundBox = false;
+	Entry.bGroundBoxDirty = true;
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldGroundBox(Entry);
+
+	FKawaiiPhysicsSharedCollisionData ClearedGroundOutData;
+	Entry.GroundSlot.AppendTo(ClearedGroundOutData);
+	TestEqual(TEXT("Ground slot publishes zero boxes after clear"), ClearedGroundOutData.BoxLimits.Num(), 0);
+	TestEqual(TEXT("Ground slot serial after clear publish"),
+	          Entry.GroundSlot.GetPublishSerial(),
+	          static_cast<uint64>(2));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldSortGatherOrderByDistanceTest,
+                                 "KawaiiPhysics.SimpleWorld.SortGatherOrderByDistance",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldSortGatherOrderByDistanceTest::RunTest(const FString& Parameters)
+{
+	TArray<float> DistanceSquared = {9.0f, 1.0f, 4.0f, 1.0f, 0.0f};
+	TArray<int32> OutOrder;
+	KawaiiPhysicsSimpleWorldCollision::SortSimpleWorldGatherOrderByDistance(
+		MakeArrayView(DistanceSquared),
+		OutOrder);
+
+	const TArray<int32> ExpectedOrder = {4, 1, 3, 2, 0};
+	TestTrue(TEXT("Distance order keeps equal-distance inputs stable"), OutOrder == ExpectedOrder);
+
+	DistanceSquared.Reset();
+	KawaiiPhysicsSimpleWorldCollision::SortSimpleWorldGatherOrderByDistance(
+		MakeArrayView(DistanceSquared),
+		OutOrder);
+	TestTrue(TEXT("Empty distance list produces empty order"), OutOrder.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldGatherOrderSkippedForZeroCapTest,
+                                 "KawaiiPhysics.SimpleWorld.GatherOrderSkippedForZeroCap",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldGatherOrderSkippedForZeroCapTest::RunTest(const FString& Parameters)
+{
+	TestFalse(TEXT("Zero cap skips gather order with several overlaps"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(5, 0));
+	TestFalse(TEXT("Zero cap skips gather order with a single overlap"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(1, 0));
+	TestFalse(TEXT("Zero cap skips gather order with no overlaps"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(0, 0));
+	TestTrue(TEXT("Gather order is used when overlaps exceed the cap"),
+	         KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(5, 3));
+	TestFalse(TEXT("Gather order is skipped when overlaps equal the cap"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(3, 3));
+	TestFalse(TEXT("Gather order is skipped when overlaps are under the cap"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(2, 3));
+	TestFalse(TEXT("Negative cap is defensively treated as skip"),
+	          KawaiiPhysicsSimpleWorldCollision::ShouldUseSimpleWorldGatherOrder(5, -1));
+
+	return true;
+}
+
 // ---------------------------------------------------------------------------
 //  DebugInfo
 // ---------------------------------------------------------------------------
@@ -1718,6 +1895,206 @@ bool FKawaiiPhysicsSimpleWorldEntrySetDescSurvivesImmediateCleanupTest::RunTest(
 
 	Entry.RemoveDesc(SourceID);
 	TestTrue(TEXT("MarkRead returns false after the slot disappears"), !Entry.MarkRead(SourceID));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldInPlaceRefreshMatchesRebuildTest,
+                                 "KawaiiPhysics.SimpleWorld.InPlaceRefreshMatchesRebuild",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldInPlaceRefreshMatchesRebuildTest::RunTest(const FString& Parameters)
+{
+	auto RunCase = [this](EKawaiiPhysicsSimulationSpace TargetSpace, const TCHAR* CaseName)
+	{
+		FKawaiiPhysicsTestAccessor Accessor;
+		Accessor.SetSimulationSpace(TargetSpace);
+
+		FAnimInstanceProxy AnimInstanceProxy;
+		FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+		const FKawaiiPhysicsSharedCollisionData WorldData = MakeReadPathWorldData(FVector::ZeroVector);
+		const FKawaiiPhysicsSharedCollisionData GroundWorldData = MakeReadPathGroundWorldData(FVector::ZeroVector);
+		const FKawaiiPhysicsSharedCollisionData InitialWorldData = MakeReadPathWorldData(FVector(100.0f, 50.0f, -25.0f));
+		const FKawaiiPhysicsSharedCollisionData InitialGroundWorldData =
+			MakeReadPathGroundWorldData(FVector(-40.0f, 20.0f, 15.0f));
+
+		TArray<FSphericalLimit> RebuiltSpheres;
+		TArray<FCapsuleLimit> RebuiltCapsules;
+		TArray<FTaperedCapsuleLimit> RebuiltTaperedCapsules;
+		TArray<FBoxLimit> RebuiltBoxes;
+		TArray<FKawaiiPhysicsConvexLimit> RebuiltConvexes;
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			Accessor.Node, PoseContext, TargetSpace, WorldData,
+			RebuiltSpheres, RebuiltCapsules, RebuiltTaperedCapsules, RebuiltBoxes, nullptr, &RebuiltConvexes);
+
+		TArray<FSphericalLimit> GroundDummySpheres;
+		TArray<FCapsuleLimit> GroundDummyCapsules;
+		TArray<FTaperedCapsuleLimit> GroundDummyTaperedCapsules;
+		TArray<FBoxLimit> RebuiltGroundBoxes;
+		TArray<FKawaiiPhysicsConvexLimit> GroundDummyConvexes;
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			Accessor.Node, PoseContext, TargetSpace, GroundWorldData,
+			GroundDummySpheres, GroundDummyCapsules, GroundDummyTaperedCapsules,
+			RebuiltGroundBoxes, nullptr, &GroundDummyConvexes);
+
+		TArray<FSphericalLimit> RefreshedSpheres;
+		TArray<FCapsuleLimit> RefreshedCapsules;
+		TArray<FTaperedCapsuleLimit> RefreshedTaperedCapsules;
+		TArray<FBoxLimit> RefreshedBoxes;
+		TArray<FKawaiiPhysicsConvexLimit> RefreshedConvexes;
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			Accessor.Node, PoseContext, TargetSpace, InitialWorldData,
+			RefreshedSpheres, RefreshedCapsules, RefreshedTaperedCapsules, RefreshedBoxes, nullptr,
+			&RefreshedConvexes);
+
+		TArray<FBoxLimit> RefreshedGroundBoxes;
+		KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+			Accessor.Node, PoseContext, TargetSpace, InitialGroundWorldData,
+			GroundDummySpheres, GroundDummyCapsules, GroundDummyTaperedCapsules,
+			RefreshedGroundBoxes, nullptr, &GroundDummyConvexes);
+
+		TestTrue(FString::Printf(TEXT("%s shape refresh succeeds"), CaseName),
+		         KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+			         Accessor.Node, PoseContext, TargetSpace, WorldData,
+			         RefreshedSpheres, RefreshedCapsules, RefreshedTaperedCapsules,
+			         RefreshedBoxes, RefreshedConvexes));
+		TestTrue(FString::Printf(TEXT("%s ground refresh succeeds"), CaseName),
+		         KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+			         Accessor.Node, PoseContext, TargetSpace, GroundWorldData.BoxLimits, RefreshedGroundBoxes));
+
+		TestEqual(FString::Printf(TEXT("%s sphere count"), CaseName), RefreshedSpheres.Num(), RebuiltSpheres.Num());
+		for (int32 Index = 0; Index < RebuiltSpheres.Num() && Index < RefreshedSpheres.Num(); ++Index)
+		{
+			TestTrue(FString::Printf(TEXT("%s sphere %d location"), CaseName, Index),
+			         RefreshedSpheres[Index].Location.Equals(RebuiltSpheres[Index].Location, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s sphere %d rotation"), CaseName, Index),
+			         RefreshedSpheres[Index].Rotation.Equals(RebuiltSpheres[Index].Rotation, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s sphere %d radius"), CaseName, Index),
+			         FMath::IsNearlyEqual(RefreshedSpheres[Index].Radius, RebuiltSpheres[Index].Radius, 0.0001f));
+		}
+
+		TestEqual(FString::Printf(TEXT("%s capsule count"), CaseName), RefreshedCapsules.Num(), RebuiltCapsules.Num());
+		for (int32 Index = 0; Index < RebuiltCapsules.Num() && Index < RefreshedCapsules.Num(); ++Index)
+		{
+			TestTrue(FString::Printf(TEXT("%s capsule %d location"), CaseName, Index),
+			         RefreshedCapsules[Index].Location.Equals(RebuiltCapsules[Index].Location, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s capsule %d rotation"), CaseName, Index),
+			         RefreshedCapsules[Index].Rotation.Equals(RebuiltCapsules[Index].Rotation, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s capsule %d radius"), CaseName, Index),
+			         FMath::IsNearlyEqual(RefreshedCapsules[Index].Radius, RebuiltCapsules[Index].Radius, 0.0001f));
+		}
+
+		TestEqual(FString::Printf(TEXT("%s tapered count"), CaseName),
+		          RefreshedTaperedCapsules.Num(), RebuiltTaperedCapsules.Num());
+
+		TestEqual(FString::Printf(TEXT("%s box count"), CaseName), RefreshedBoxes.Num(), RebuiltBoxes.Num());
+		for (int32 Index = 0; Index < RebuiltBoxes.Num() && Index < RefreshedBoxes.Num(); ++Index)
+		{
+			TestTrue(FString::Printf(TEXT("%s box %d location"), CaseName, Index),
+			         RefreshedBoxes[Index].Location.Equals(RebuiltBoxes[Index].Location, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s box %d rotation"), CaseName, Index),
+			         RefreshedBoxes[Index].Rotation.Equals(RebuiltBoxes[Index].Rotation, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s box %d extent"), CaseName, Index),
+			         RefreshedBoxes[Index].Extent.Equals(RebuiltBoxes[Index].Extent, 0.0001f));
+		}
+
+		TestEqual(FString::Printf(TEXT("%s convex count"), CaseName), RefreshedConvexes.Num(), RebuiltConvexes.Num());
+		for (int32 Index = 0; Index < RebuiltConvexes.Num() && Index < RefreshedConvexes.Num(); ++Index)
+		{
+			TestTrue(FString::Printf(TEXT("%s convex %d location"), CaseName, Index),
+			         RefreshedConvexes[Index].Location.Equals(RebuiltConvexes[Index].Location, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s convex %d rotation"), CaseName, Index),
+			         RefreshedConvexes[Index].Rotation.Equals(RebuiltConvexes[Index].Rotation, 0.0001f));
+			TestEqual(FString::Printf(TEXT("%s convex %d plane count"), CaseName, Index),
+			          RefreshedConvexes[Index].LocalPlanes.Num(), RebuiltConvexes[Index].LocalPlanes.Num());
+		}
+
+		TestEqual(FString::Printf(TEXT("%s ground box count"), CaseName),
+		          RefreshedGroundBoxes.Num(), RebuiltGroundBoxes.Num());
+		for (int32 Index = 0; Index < RebuiltGroundBoxes.Num() && Index < RefreshedGroundBoxes.Num(); ++Index)
+		{
+			TestTrue(FString::Printf(TEXT("%s ground box %d location"), CaseName, Index),
+			         RefreshedGroundBoxes[Index].Location.Equals(RebuiltGroundBoxes[Index].Location, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s ground box %d rotation"), CaseName, Index),
+			         RefreshedGroundBoxes[Index].Rotation.Equals(RebuiltGroundBoxes[Index].Rotation, 0.0001f));
+			TestTrue(FString::Printf(TEXT("%s ground box %d extent"), CaseName, Index),
+			         RefreshedGroundBoxes[Index].Extent.Equals(RebuiltGroundBoxes[Index].Extent, 0.0001f));
+		}
+	};
+
+	RunCase(EKawaiiPhysicsSimulationSpace::ComponentSpace, TEXT("ComponentSpace"));
+	RunCase(EKawaiiPhysicsSimulationSpace::WorldSpace, TEXT("WorldSpace"));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldRadiusWarningOnceTest,
+                                 "KawaiiPhysics.SimpleWorld.RadiusWarningOnce",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldRadiusWarningOnceTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.SetSimpleWorldGatherRadiusOverride(1.0f);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.BuildVerticalChain(1, 10.0f);
+	Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+	TestFalse(TEXT("Zero pose frame does not mark radius check done"), Accessor.IsSimpleWorldRadiusChecked());
+
+	Accessor.BuildVerticalChain(2, 10.0f);
+	Accessor.SetSimpleWorldGatherRadiusOverride(1.0f);
+	AddExpectedError(TEXT("SimpleWorldCollision: GatherRadius"), EAutomationExpectedErrorFlags::Contains, 1);
+
+	Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+	TestTrue(TEXT("First non-zero pose frame marks radius check done"), Accessor.IsSimpleWorldRadiusChecked());
+
+	Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+	TestTrue(TEXT("Second radius check call remains done"), Accessor.IsSimpleWorldRadiusChecked());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldRadiusCheckDeferralBoundedTest,
+                                 "KawaiiPhysics.SimpleWorld.RadiusCheckDeferralBounded",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldRadiusCheckDeferralBoundedTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.BuildVerticalChain(1, 10.0f);
+	Accessor.SetSimpleWorldGatherRadiusOverride(1.0f);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	// 全ボーンがゼロ姿勢のまま呼び続けても、上限回数で完了扱いになり走査が止まる（警告は出ない）。
+	for (uint8 Attempt = 1; Attempt < FAnimNode_KawaiiPhysics::MaxSimpleWorldRadiusCheckDeferrals; ++Attempt)
+	{
+		Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+		TestFalse(FString::Printf(TEXT("Deferral %d keeps the check pending"), Attempt), Accessor.IsSimpleWorldRadiusChecked());
+		TestEqual(FString::Printf(TEXT("Deferral counter after attempt %d"), Attempt),
+		          static_cast<int32>(Accessor.GetSimpleWorldRadiusCheckDeferrals()), static_cast<int32>(Attempt));
+	}
+
+	Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+	TestTrue(TEXT("Reaching the deferral cap marks the check done"), Accessor.IsSimpleWorldRadiusChecked());
+
+	Accessor.CheckSimpleWorldGatherRadius(PoseContext);
+	TestEqual(TEXT("Counter stops growing once the check is done"),
+	          static_cast<int32>(Accessor.GetSimpleWorldRadiusCheckDeferrals()),
+	          static_cast<int32>(FAnimNode_KawaiiPhysics::MaxSimpleWorldRadiusCheckDeferrals));
+
+	// 半径 Override を変えると持ち越しカウンタもリセットされる。
+	Accessor.SetSimpleWorldGatherRadiusOverride(2.0f);
+	TestFalse(TEXT("Radius override change re-arms the check"), Accessor.IsSimpleWorldRadiusChecked());
+	TestEqual(TEXT("Radius override change resets the deferral counter"),
+	          static_cast<int32>(Accessor.GetSimpleWorldRadiusCheckDeferrals()), 0);
 
 	return true;
 }
@@ -1900,6 +2277,48 @@ bool FKawaiiPhysicsSimpleWorldCollisionPushOutTest::RunTest(const FString& Param
 		TestTrue(FString::Printf(TEXT("Gated off: SimpleWorld convex does not push the bone: got %s expected %s"),
 		                         *A.Bone(1).Location.ToString(), *ExpectedNoConvexPushOut.ToString()),
 		         A.Bone(1).Location.Equals(ExpectedNoConvexPushOut, GSimpleWorldPushOutTol));
+	}
+
+	// 地面 Box を通常 Box の末尾に入れた旧相当経路と、専用配列に分けた経路の押し出し順序を一致させる。
+	{
+		const float GroundTopZ = -10.0f;
+		const FVector GroundStart(1.0f, 0.0f, -11.0f);
+
+		FBoxLimit GroundBox;
+		GroundBox.Location = FVector(0.0f, 0.0f, -12.0f);
+		GroundBox.Rotation = FQuat::Identity;
+		GroundBox.Extent = FVector(100.0f, 100.0f, 2.0f);
+		GroundBox.bEnable = true;
+		GroundBox.SourceType = ECollisionSourceType::SimpleWorld;
+		TArray<FBoxLimit> GroundBoxes = {GroundBox};
+
+		auto BuildGroundChain = [&](FKawaiiPhysicsTestAccessor& A)
+		{
+			BuildChain(A);
+			A.Bone(1).PhysicsSettings.Radius = 1.0f;
+			A.Bone(1).Location = GroundStart;
+			A.Bone(1).PrevLocation = GroundStart;
+		};
+
+		FKawaiiPhysicsTestAccessor LegacyBoxPath;
+		BuildGroundChain(LegacyBoxPath);
+		LegacyBoxPath.SetSimpleWorldLimits(
+			EmptySpheres, EmptyCapsules, EmptyTaperedCapsules, GroundBoxes, EmptyConvexes);
+		LegacyBoxPath.StepFrame(1.0f / 60.0f);
+
+		FKawaiiPhysicsTestAccessor GroundBoxPath;
+		BuildGroundChain(GroundBoxPath);
+		GroundBoxPath.SetSimpleWorldLimits(
+			EmptySpheres, EmptyCapsules, EmptyTaperedCapsules, EmptyBoxes, EmptyConvexes, GroundBoxes);
+		GroundBoxPath.StepFrame(1.0f / 60.0f);
+
+		TestTrue(FString::Printf(TEXT("Ground box pushes bone upward: got %s top %.2f"),
+		                         *GroundBoxPath.Bone(1).Location.ToString(), GroundTopZ),
+		         GroundBoxPath.Bone(1).Location.Z >= GroundTopZ - GSimpleWorldPushOutTol);
+		TestTrue(FString::Printf(TEXT("Dedicated ground box path matches legacy box tail path: got %s expected %s"),
+		                         *GroundBoxPath.Bone(1).Location.ToString(),
+		                         *LegacyBoxPath.Bone(1).Location.ToString()),
+		         GroundBoxPath.Bone(1).Location.Equals(LegacyBoxPath.Bone(1).Location, GSimpleWorldPushOutTol));
 	}
 
 	return true;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -164,20 +164,81 @@ struct FKawaiiPhysicsTestAccessor
 	}
 
 	/**
-	 * SimpleWorld コリジョン配列（Subsystem が本来収集する5形状）を直接注入し、bUseSimpleWorldCollision も true にする。
-	 * Injects the SimpleWorld collision arrays (the five shapes the Subsystem normally gathers) directly and enables bUseSimpleWorldCollision.
+	 * SimpleWorld コリジョン配列（Subsystem が本来収集する形状と地面 Box）を直接注入し、bUseSimpleWorldCollision も true にする。
+	 * Injects the SimpleWorld collision arrays (the shapes and ground box the Subsystem normally gathers) directly and enables bUseSimpleWorldCollision.
 	 */
 	void SetSimpleWorldLimits(const TArray<FSphericalLimit>& Spherical, const TArray<FCapsuleLimit>& Capsule,
 	                          const TArray<FTaperedCapsuleLimit>& TaperedCapsule, const TArray<FBoxLimit>& Box,
-	                          const TArray<FKawaiiPhysicsConvexLimit>& Convex)
+	                          const TArray<FKawaiiPhysicsConvexLimit>& Convex,
+	                          const TArray<FBoxLimit>& GroundBox = TArray<FBoxLimit>())
 	{
 		Node.SimpleWorldSphericalLimits = Spherical;
 		Node.SimpleWorldCapsuleLimits = Capsule;
 		Node.SimpleWorldTaperedCapsuleLimits = TaperedCapsule;
 		Node.SimpleWorldBoxLimits = Box;
+		Node.SimpleWorldGroundBoxLimits = GroundBox;
 		Node.SimpleWorldConvexLimits = Convex;
 		Node.bUseSimpleWorldCollision = true;
 	}
+
+	/**
+	 * SimpleWorld コリジョン Entry を Subsystem 経由なしで直接注入し、読み取り経路を有効化する。
+	 * Injects a SimpleWorld collision Entry directly without the Subsystem and enables the read path.
+	 */
+	void SetSimpleWorldEntry(const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>& Entry)
+	{
+		Node.CachedSimpleWorldEntry = Entry;
+		Node.bUseSimpleWorldCollision = true;
+		Node.bSimpleWorldCollisionInitialized = true;
+		Node.bSimpleWorldDescSent = false;
+	}
+
+	/**
+	 * SimpleWorld コリジョンのワーカー側読み取り更新を呼び出す。
+	 * Calls the worker-side SimpleWorld collision read update.
+	 */
+	void UpdateSimpleWorldCollisionLimits(FComponentSpacePoseContext& Output)
+	{
+		Node.UpdateSimpleWorldCollisionLimits(Output);
+	}
+
+	/**
+	 * 現在読み込んでいる SimpleWorld コリジョン形状数を返す。
+	 * Returns the number of SimpleWorld collision shapes currently read.
+	 */
+	int32 GetNumSimpleWorldColliders() const
+	{
+		return Node.GetNumSimpleWorldColliders();
+	}
+
+	/**
+	 * 最後に読み取った SimpleWorld 形状 Slot の Publish serial を返す。
+	 * Returns the last read publish serial of the SimpleWorld shape Slot.
+	 */
+	uint64 GetLastReadSimpleWorldShapeSerial() const
+	{
+		return Node.LastReadSimpleWorldShapeSerial;
+	}
+
+	void SetSimpleWorldGatherRadiusOverride(float Radius)
+	{
+		Node.bOverrideSimpleWorldCollisionGatherRadius = true;
+		Node.SimpleWorldCollisionGatherRadius = Radius;
+		Node.bSimpleWorldRadiusChecked = false;
+		Node.SimpleWorldRadiusCheckDeferrals = 0;
+	}
+
+	void CheckSimpleWorldGatherRadius(FComponentSpacePoseContext& Output)
+	{
+		Node.CheckSimpleWorldGatherRadius(Output);
+	}
+
+	bool IsSimpleWorldRadiusChecked() const
+	{
+		return Node.bSimpleWorldRadiusChecked;
+	}
+
+	uint8 GetSimpleWorldRadiusCheckDeferrals() const { return Node.SimpleWorldRadiusCheckDeferrals; }
 
 	/** 固定サブステッピング設定（DeveloperSettings の代わりに直接指定） */
 	void SetFixedSubstepping(bool bEnable, int32 TargetFps, int32 MaxSubsteps = 8)
@@ -611,6 +672,7 @@ private:
 				Node.AdjustByCapsuleCollision(Bone, Node.SimpleWorldCapsuleLimits);
 				Node.AdjustByTaperedCapsuleCollision(Bone, Node.SimpleWorldTaperedCapsuleLimits);
 				Node.AdjustByBoxCollision(Bone, Node.SimpleWorldBoxLimits);
+				Node.AdjustByBoxCollision(Bone, Node.SimpleWorldGroundBoxLimits);
 				Node.AdjustByConvexCollision(Bone, Node.SimpleWorldConvexLimits);
 			}
 		}

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -658,6 +658,8 @@ struct KAWAIIPHYSICS_API FAnimNode_KawaiiPhysics : public FAnimNode_SkeletalCont
 #endif
 	static constexpr int32 MaxTransientExternalForces = 8;
 	static constexpr int32 MaxPhysicsSettingsMultipliers = 8;
+	// 半径チェックの持ち越し上限 / Cap on radius-check deferrals
+	static constexpr uint8 MaxSimpleWorldRadiusCheckDeferrals = 3;
 	// InheritForceIndex 用センチネル: 有効な authored ProceduralWind すべてに 1 つずつ transient 突風を展開する（展開はノードの一時外力上限 MaxTransientExternalForces の範囲内）
 	// Sentinel for InheritForceIndex: spawn one transient gust per enabled authored ProceduralWind (expansion is bounded by MaxTransientExternalForces).
 	static constexpr int32 TransientGustInheritAllWinds = -2;
@@ -1030,8 +1032,18 @@ private:
 	FKawaiiPhysicsSimpleWorldCollisionDesc LastSentSimpleWorldDesc;
 	bool bSimpleWorldDescSent = false;
 	bool bSimpleWorldCollisionInitialized = false;
-	bool bSimpleWorldRadiusWarningLogged = false;
+	// SimpleWorld 半径警告チェックが完了済みか / Whether the SimpleWorld radius warning check has completed
+	bool bSimpleWorldRadiusChecked = false;
+	// 半径チェックを全ゼロ姿勢で持ち越した回数。上限に達したら退化チェーンとみなして完了扱いにする / Number of radius-check deferrals due to all-zero pose. Reaching the cap marks the check done (degenerate chain)
+	uint8 SimpleWorldRadiusCheckDeferrals = 0;
+	// 前回読み取った形状 Slot の Publish serial（0 は未読） / Last read shape Slot publish serial (0 means unread)
+	uint64 LastReadSimpleWorldShapeSerial = 0;
+	// 前回読み取った GroundSlot の Publish serial（0 は未読） / Last read GroundSlot publish serial (0 means unread)
+	uint64 LastReadSimpleWorldGroundSerial = 0;
+	// 形状 Slot 用のワールド空間スクラッチ / World-space scratch for the shape Slot
 	FKawaiiPhysicsSharedCollisionData SimpleWorldMergedScratch;
+	// GroundSlot 用のワールド空間スクラッチ / World-space scratch for the GroundSlot
+	FKawaiiPhysicsSharedCollisionData SimpleWorldGroundScratch;
 
 	// シンプルワールドコリジョンワーク配列（シミュレーション空間に変換済み）
 	// Simple world collision working arrays (converted to simulation space)
@@ -1039,6 +1051,8 @@ private:
 	TArray<FCapsuleLimit> SimpleWorldCapsuleLimits;
 	TArray<FTaperedCapsuleLimit> SimpleWorldTaperedCapsuleLimits;
 	TArray<FBoxLimit> SimpleWorldBoxLimits;
+	// 地面専用のシンプルワールド Box 配列（0 または 1 要素） / Dedicated SimpleWorld ground box array (zero or one element)
+	TArray<FBoxLimit> SimpleWorldGroundBoxLimits;
 	TArray<FKawaiiPhysicsConvexLimit> SimpleWorldConvexLimits;
 
 	// 風の乱数(gust/cone)をフレーム単位でキャッシュしサブステップ間で同一値を使う（NumStep非依存＝フレームレート非依存）
@@ -1173,6 +1187,7 @@ public:
 			+ SimpleWorldCapsuleLimits.Num()
 			+ SimpleWorldTaperedCapsuleLimits.Num()
 			+ SimpleWorldBoxLimits.Num()
+			+ SimpleWorldGroundBoxLimits.Num()
 			+ SimpleWorldConvexLimits.Num();
 	}
 
@@ -1482,6 +1497,12 @@ protected:
 	 * Read Simple World Collision and convert to simulation space (any thread)
 	 */
 	void UpdateSimpleWorldCollisionLimits(FComponentSpacePoseContext& Output);
+
+	/**
+	 * SimpleWorld の収集半径がチェーン到達距離を覆うか 1 回だけ確認する（AnyThread）
+	 * Checks once whether the SimpleWorld gather radius covers the chain reach (any thread)
+	 */
+	void CheckSimpleWorldGatherRadius(FComponentSpacePoseContext& Output);
 
 	/**
 	 * シンプルワールドコリジョンのDesc登録を解除する（AnyThread）

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -22,6 +22,7 @@ class UPhysicsAsset;
 class USkeletalMeshComponent;
 class USkinnedAsset;
 class UCharacterMovementComponent;
+class UWorld;
 
 // 地面ソースの種類（DebugDraw の色分けにも使う） / Ground source kind (also used for debug draw colors)
 UENUM(BlueprintType)
@@ -59,8 +60,17 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSharedCollisionSourceSlot
 	/** スロットを即座に期限切れ化 / Mark this slot as immediately expired */
 	void MarkExpired();
 
+	/**
+	 * Publish ごとに 1 増える単調カウンタ。読み手は AppendTo の**前**に読んで前回値と比較し、一致ならコピーを省略できる（後に読むと Publish が割り込んだとき新しい serial を古いデータに紐付けて更新を取りこぼす）
+	 * Monotonic counter incremented per Publish. Readers read it **before** AppendTo and skip the copy when unchanged (reading after could pair a newer serial with older data).
+	 */
+	uint64 GetPublishSerial() const { return PublishSerial.load(std::memory_order_acquire); }
+
 private:
 	FKawaiiPhysicsSharedCollisionData Buffer;
+
+	/** Publish ごとに増える単調カウンタ / Monotonic counter incremented per Publish */
+	std::atomic<uint64> PublishSerial{0};
 
 	/** 最終Publishフレーム番号（鮮度チェック用） / Last published frame number for expiration detection */
 	std::atomic<uint64> LastPublishFrame{0};
@@ -160,8 +170,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDesc
  * Simple-world collision gather entry (per SkelComp. Merges multiple source Descs and gathers once)
  *
  * スレッド境界 / Thread boundary:
- * - Worker: SetDesc / RemoveDesc / MarkRead / RequestRegather / Slot.AppendTo
- * - GameThread Tick: RemoveExpiredDescs / BuildMergedDesc / world query, GatheredComponents更新, Slot.Publish
+ * - Worker: SetDesc / RemoveDesc / MarkRead / RequestRegather / Slot.AppendTo / GroundSlot.AppendTo
+ * - GameThread Tick: RemoveExpiredDescs / BuildMergedDesc / world query, GatheredComponents更新, Slot.Publish / GroundSlot.Publish
  * ISM / HISM はインスタンス単位で収集し、MaxGatheredComponents はインスタンス数に対して効きます。
  * ISM / HISM are gathered per instance, and MaxGatheredComponents applies to instance count.
  */
@@ -180,6 +190,8 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	bool ConsumeRegatherRequested();
 
 	FKawaiiPhysicsSharedCollisionSourceSlot Slot;
+	// 地面 Box 専用 Slot。0 または 1 個の FBoxLimit を BoxLimits に入れて Publish する / Dedicated ground-box slot. Publishes zero or one FBoxLimit in BoxLimits.
+	FKawaiiPhysicsSharedCollisionSourceSlot GroundSlot;
 
 	// Tick スレッド専有・ロック不要 / Tick-thread only; no lock required.
 	float TimeSinceLastGather = FLT_MAX;
@@ -261,8 +273,16 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	// 床コンポーネントが Static なら true（Box を使い回す）。Movable なら毎 Tick Transform を追従する
 	// True when the floor component is Static (box is reused); Movable floors are followed every tick
 	bool bGroundComponentStatic = true;
+	// Tick スレッド専有。地面 Slot の Publish が必要か / Tick-thread only. Whether the ground slot needs publishing
+	bool bGroundBoxDirty = true;
 	FKawaiiPhysicsSharedCollisionData PublishScratch;
+	// Tick スレッド専有。地面 Slot の Publish 用スクラッチ / Tick-thread only. Scratch buffer for publishing the ground slot
+	FKawaiiPhysicsSharedCollisionData GroundPublishScratch;
 	TArray<FOverlapResult> OverlapScratch;
+	// Tick スレッド専有。収集上限超過時の距離順インデックス / Tick-thread only. Distance-sorted indices used only when gather results exceed the cap
+	TArray<int32> GatherOrderScratch;
+	// Tick スレッド専有。収集上限超過時の距離二乗スクラッチ / Tick-thread only. Squared-distance scratch used only when gather results exceed the cap
+	TArray<float> GatherDistanceScratch;
 	bool bWorldLimitsDirty = true;
 
 private:
@@ -408,6 +428,18 @@ public:
 	                                              FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo);
 
 	/**
+	 * Entry の収集済み形状を Shape Slot へ Publish する（GameThread 専用。テストから直接呼べるよう static）
+	 * Publish gathered shapes from Entry to the shape slot (GameThread only; static so tests can call it directly)
+	 */
+	static void PublishSimpleWorldShapeLimits(FKawaiiPhysicsSimpleWorldCollisionEntry& Entry, float BoxEnableThreshold);
+
+	/**
+	 * Entry の地面 Box を Ground Slot へ Publish する（GameThread 専用。テストから直接呼べるよう static）
+	 * Publish the ground box from Entry to the ground slot (GameThread only; static so tests can call it directly)
+	 */
+	static void PublishSimpleWorldGroundBox(FKawaiiPhysicsSimpleWorldCollisionEntry& Entry);
+
+	/**
 	 * SkelComp の SimpleWorld Entry を検索し診断情報を返す。Entry が無ければ false（OutInfo は既定値＋bHasEntry=false）。
 	 * GameThread 専用。Shipping では常に false。
 	 * Look up the SimpleWorld entry for SkelComp and return diagnostics. Returns false when no entry exists
@@ -438,6 +470,31 @@ private:
 	static bool TryResolveRegistryKey(AActor* Actor, const FGameplayTag& Tag, FRegistryKey& OutKey);
 
 	void TickSimpleWorldCollision(float DeltaTime);
+	void GatherSimpleWorldEntry(
+		UWorld& World,
+		FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+		const USkeletalMeshComponent& SkelComp,
+		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+		const FVector& Center,
+		float Radius,
+		float GroundTraceLength,
+		ECollisionChannel CollisionChannel,
+		int32 EffectiveMaxGatheredComponents,
+		int32 EffectiveMaxPhysicsAssetBodies,
+		int32 EffectiveMaxConvexPlanes,
+		bool bUseMovementGround,
+		bool bBuildConvexDebugGeometry);
+	void UpdateSimpleWorldGround(
+		FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+		const USkeletalMeshComponent& SkelComp,
+		const FKawaiiPhysicsSimpleWorldCollisionDesc& Desc,
+		float Radius,
+		bool bGatherInputValid);
+	bool UpdateSimpleWorldTransforms(
+		FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+		float DeltaTime,
+		bool bRegatherOnScaleChange,
+		float FadeInTime);
 
 	/**
 	 * 構築済みキーで Entry を読み取りロック検索する（死んだActorのEntryはスキップ）。

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
@@ -65,6 +65,20 @@ namespace KawaiiPhysicsSimpleWorldCollision
 	 */
 	KAWAIIPHYSICS_API bool IsSimpleWorldGatherInputValid(const FVector& Center, float Radius);
 
+	/**
+	 * 上限が正で、かつ Overlap 数が上限を超えるときだけ距離順を使うかどうかを判定します。上限 0 は形状を収集しない設定なので並べ替えも省きます。
+	 * Returns whether to use distance-order sorting: only when the cap is positive and the overlap count exceeds it. A cap of 0 means gathering no shapes, so sorting is skipped too.
+	 */
+	KAWAIIPHYSICS_API bool ShouldUseSimpleWorldGatherOrder(int32 NumOverlaps, int32 MaxGatheredComponents);
+
+	/**
+	 * 距離二乗の昇順で収集順インデックスを作ります。同距離は元の順序を保ちます。
+	 * Builds gather-order indices sorted by ascending squared distance. Equal distances keep their original order.
+	 */
+	KAWAIIPHYSICS_API void SortSimpleWorldGatherOrderByDistance(
+		TArrayView<const float> DistanceSquared,
+		TArray<int32>& OutOrder);
+
 	struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldBodyBinding
 	{
 		int32 BoneIndex = INDEX_NONE;


### PR DESCRIPTION
## 概要
Simple World Collision の「Subsystem が publish → 各 KawaiiPhysics ノードが Worker スレッドで読む」経路を、変化があったときだけコピーする形に改めました。静的なシーンではノードごとの毎フレームの 2 段コピー（Slot → world 空間 scratch → simulation 空間配列）が不要になり、歩行中は地面 Box だけを再 publish します。数値挙動（形状の適用順・Golden テスト）は変えていません。

## 変更内容
- `FKawaiiPhysicsSharedCollisionSourceSlot` に単調増加の `PublishSerial` を追加。ノードは前回読んだ serial と同じなら `AppendTo` を省き、保持済みの world 空間 scratch から simulation 空間の配列だけを in-place で再変換する（要素数が違えば全再構築にフォールバック）
- 地面 Box を専用の `GroundSlot` に分離し、`SimpleWorldGroundBoxLimits`（0/1 要素）として `SimpleWorldBoxLimits` の直後・Convex の前に適用（従来の「BoxLimits 末尾」と同じ順序）
- `TickSimpleWorldCollision` を Gather / Ground / Transforms / Publish（形状・地面）のフェーズ関数に分割。距離間引き中は Gather と Ground だけを止め、可動コンポーネントの追従と publish は継続
- Overlap 結果が `MaxGatheredComponents` を超えるときは収集中心から近い順に採用（安定ソート）。超えないとき、および CVar で上限 0 を指定したときは並べ替えを行わない（従来どおり即打ち切り）
- Overlap クエリで自分の SkeletalMeshComponent を無視対象に追加
- 収集半径の到達警告チェックを 1 回だけ実行（全ボーンの PoseLocation がゼロのフレームは最大 3 回まで持ち越し）、`GatherRadiusOverride` 変更時のみ再解禁
- Initialize / 無効化時のリセット、STAT、AnimDrawDebug に地面配列を反映
- テスト追加: `SharedCollision.SlotPublishSerial`、`SimpleWorld.GroundSlotIndependentPublish` / `SortGatherOrderByDistance` / `GatherOrderSkippedForZeroCap` / `InPlaceRefreshMatchesRebuild` / `RadiusWarningOnce` / `RadiusCheckDeferralBounded`、`SimpleWorld.CollisionPushOut` 拡張、ベンチ `Perf.SimpleWorldRead.PublishEveryFrame` / `PublishEvery12`
- テストハーネス: `SetSimpleWorldLimits` に地面 Box 引数、`SetSimpleWorldEntry`、半径チェック・serial のアクセサ

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 253/253（フィルタ: KawaiiPhysics）、`Simulation.GoldenPositions` bit 一致
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件 / WARN 0 件
- PIE: 未（docs/pie/SimpleWorldReadPath_PIE_Checklist.md、INDEX.md に登録済）
- 性能: ベンチ `Perf.SimpleWorldRead.PublishEvery12` 0.0032 ms/frame vs `PublishEveryFrame` 0.0173 ms/frame（Convex 64＋Box 64＋地面 1、静的シーン相当で読み取りコスト約 5.5 倍減）。既存ベンチ（Chain / Collision 等）の回帰: なし（master を同日・同環境で 3 run ずつ計測して比較、WARN 0 / NOISY 0。Chain −13%・Collision −7%・SharedCollisionCopy −2%・ConstraintHeavy −18%）。perf baseline はハーネス変更で比較対象外（STALE）になるため master マージ後に更新
