### PR TITLE
[feature] Add the shared Simple World Collision registry with provider and reader entries

### DIFF
--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysics.cpp
@@ -150,6 +150,10 @@ TAutoConsoleVariable<int32> CVarSimpleWorldCollisionUseMovementGround(
 	TEXT("a.AnimNode.KawaiiPhysics.SimpleWorldCollision.UseMovementGround"), 1,
 	TEXT("1で所有Actorの地面情報（IKawaiiPhysicsGroundProvider / CharacterMovementComponent）を地面Boxに使う。0で従来の下方向トレースのみ / "
 		"1 uses the owner's ground info (IKawaiiPhysicsGroundProvider / CharacterMovementComponent) for the ground box; 0 uses only the legacy downward trace."));
+TAutoConsoleVariable<int32> CVarSimpleWorldCollisionReaderReleaseMaxAge(
+	TEXT("a.AnimNode.KawaiiPhysics.SharedPublisher.ReaderReleaseMaxAge"), 60,
+	TEXT("共有 Entry の provider が更新を止めてから reader が Entry を解放するまでの猶予フレーム数 / "
+		"Frames a reader keeps a shared entry after its provider stopped updating before releasing it."));
 
 DEFINE_STAT(STAT_KawaiiPhysics_InitModifyBones);
 DEFINE_STAT(STAT_KawaiiPhysics_Eval);
@@ -246,6 +250,9 @@ void FAnimNode_KawaiiPhysics::Initialize_AnyThread(const FAnimationInitializeCon
 	SimpleWorldConvexLimits.Reset();
 	LastReadSimpleWorldShapeSerial = 0;
 	LastReadSimpleWorldGroundSerial = 0;
+	LastReadSimpleWorldMemberSerialSum = 0;
+	SimpleWorldReaderRetryCount = 0;
+	bSimpleWorldReaderWarningLogged = false;
 	bSimpleWorldRadiusChecked = false;
 	SimpleWorldRadiusCheckDeferrals = 0;
 
@@ -811,14 +818,14 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 	// CVarで全体無効化されている間はUpdateを行わず、else側でSimpleWorldXxxLimitsをResetして適用もスキップする
 	if (bUseSimpleWorldCollision && CVarSimpleWorldCollisionEnable.GetValueOnAnyThread())
 	{
-		if (!bSimpleWorldCollisionInitialized)
+		if (!bSimpleWorldCollisionInitialized && !bSimpleWorldReaderMode)
 		{
 			InitializeSimpleWorldCollision();
 		}
-		if (CachedSimpleWorldEntry.IsValid())
+		if (CachedSimpleWorldEntry.IsValid() || bSimpleWorldReaderMode)
 		{
 			UpdateSimpleWorldCollisionLimits(Output);
-			if (TeleportType == ETeleportType::TeleportPhysics)
+			if (TeleportType == ETeleportType::TeleportPhysics && CachedSimpleWorldEntry.IsValid())
 			{
 				CachedSimpleWorldEntry->RequestRegather();
 			}
@@ -838,6 +845,9 @@ void FAnimNode_KawaiiPhysics::EvaluateSkeletalControl_AnyThread(FComponentSpaceP
 		SimpleWorldConvexLimits.Reset();
 		LastReadSimpleWorldShapeSerial = 0;
 		LastReadSimpleWorldGroundSerial = 0;
+		LastReadSimpleWorldMemberSerialSum = 0;
+		SimpleWorldReaderRetryCount = 0;
+		bSimpleWorldReaderWarningLogged = false;
 	}
 
 	// 入力規模カウンタ & メモリの更新（毎フレーム。負荷=N×L等の相関とダミー膨張の可視化用）

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/AnimNode_KawaiiPhysicsCollision.cpp
@@ -37,6 +37,10 @@
 #include "AnimNode_KawaiiPhysicsInternal.h"
 #include "KawaiiPhysicsNodeWarning.h"
 
+extern TAutoConsoleVariable<int32> CVarSharedCollisionInitRetryThreshold;
+extern TAutoConsoleVariable<int32> CVarSharedCollisionInitRetryThrottleInterval;
+extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionReaderReleaseMaxAge;
+
 namespace
 {
 	template <typename LimitType, typename PostConvertType>
@@ -1553,6 +1557,21 @@ void FAnimNode_KawaiiPhysics::InitializeSimpleWorldCollision()
 	}
 
 	const uint64 SourceID = reinterpret_cast<uint64>(this);
+	if (bSimpleWorldReaderMode)
+	{
+		CachedSimpleWorldEntry = Subsystem->FindOrCreateSimpleWorldEntry(
+			SimpleWorldReaderKey,
+			SourceID,
+			FKawaiiPhysicsSimpleWorldCollisionDesc(),
+			CachedSimpleWorldCollisionSkelComp,
+			false);
+		if (CachedSimpleWorldEntry.IsValid())
+		{
+			bSimpleWorldCollisionInitialized = true;
+		}
+		return;
+	}
+
 	const FKawaiiPhysicsSimpleWorldCollisionDesc Desc = BuildSimpleWorldCollisionDesc();
 	CachedSimpleWorldEntry = Subsystem->FindOrCreateSimpleWorldEntry(CachedSimpleWorldCollisionSkelComp, SourceID, Desc);
 	if (CachedSimpleWorldEntry.IsValid())
@@ -1567,7 +1586,7 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_UpdateSimpleWorldCollisionLimits);
 
-	if (!CachedSimpleWorldEntry.IsValid())
+	auto ResetSimpleWorldSimulationSpaceLimits = [this]()
 	{
 		SimpleWorldSphericalLimits.Reset();
 		SimpleWorldCapsuleLimits.Reset();
@@ -1575,6 +1594,151 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 		SimpleWorldBoxLimits.Reset();
 		SimpleWorldGroundBoxLimits.Reset();
 		SimpleWorldConvexLimits.Reset();
+	};
+
+	if (!CachedSimpleWorldEntry.IsValid())
+	{
+		ResetSimpleWorldSimulationSpaceLimits();
+		if (bSimpleWorldReaderMode)
+		{
+			const int32 RetryThreshold = FMath::Max(1, CVarSharedCollisionInitRetryThreshold.GetValueOnAnyThread());
+			const int32 ThrottleInterval =
+				FMath::Max(1, CVarSharedCollisionInitRetryThrottleInterval.GetValueOnAnyThread());
+			const bool bShouldRetryInitialize =
+				!bSimpleWorldReaderWarningLogged || (SimpleWorldReaderRetryCount % ThrottleInterval) == 0;
+
+			if (bShouldRetryInitialize)
+			{
+				InitializeSimpleWorldCollision();
+			}
+
+			if (CachedSimpleWorldEntry.IsValid())
+			{
+				bSimpleWorldCollisionInitialized = true;
+			}
+			else
+			{
+				++SimpleWorldReaderRetryCount;
+				if (!bSimpleWorldReaderWarningLogged && SimpleWorldReaderRetryCount >= RetryThreshold)
+				{
+					const FString TagName = SimpleWorldReaderKey.Tag.ToString();
+					const FString KeyObjectName = SimpleWorldReaderKeyObjectName.IsNone() ? FString(TEXT("None")) : SimpleWorldReaderKeyObjectName.ToString();
+					UE_LOG(LogKawaiiPhysics, Warning,
+					       TEXT("Shared Simple World Collision entry has no provider (Tag=%s, KeyObject=%s). Waiting for a Shared Publisher."),
+					       *TagName, *KeyObjectName);
+					bSimpleWorldReaderWarningLogged = true;
+				}
+				return;
+			}
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	if (bSimpleWorldReaderMode)
+	{
+		const uint64 SourceID = reinterpret_cast<uint64>(this);
+		const uint64 ProviderMaxAge =
+			static_cast<uint64>(FMath::Max(0, CVarSimpleWorldCollisionReaderReleaseMaxAge.GetValueOnAnyThread()));
+		if (!CachedSimpleWorldEntry->MarkReaderRead(SourceID, GFrameCounter, ProviderMaxAge))
+		{
+			ReleaseSimpleWorldCollision();
+			++SimpleWorldReaderRetryCount;
+			const int32 RetryThreshold = FMath::Max(1, CVarSharedCollisionInitRetryThreshold.GetValueOnAnyThread());
+			if (!bSimpleWorldReaderWarningLogged && SimpleWorldReaderRetryCount >= RetryThreshold)
+			{
+				const FString TagName = SimpleWorldReaderKey.Tag.ToString();
+				const FString KeyObjectName = SimpleWorldReaderKeyObjectName.IsNone() ? FString(TEXT("None")) : SimpleWorldReaderKeyObjectName.ToString();
+				UE_LOG(LogKawaiiPhysics, Warning,
+				       TEXT("Shared Simple World Collision entry has no provider (Tag=%s, KeyObject=%s). Waiting for a Shared Publisher."),
+				       *TagName, *KeyObjectName);
+				bSimpleWorldReaderWarningLogged = true;
+			}
+			ResetSimpleWorldSimulationSpaceLimits();
+			SimpleWorldMergedScratch.Reset();
+			SimpleWorldGroundScratch.Reset();
+			LastReadSimpleWorldShapeSerial = 0;
+			LastReadSimpleWorldGroundSerial = 0;
+			LastReadSimpleWorldMemberSerialSum = 0;
+			return;
+		}
+		SimpleWorldReaderRetryCount = 0;
+
+		if (CachedSimpleWorldEntry->IsProviderDisabled())
+		{
+			ResetSimpleWorldSimulationSpaceLimits();
+			SimpleWorldMergedScratch.Reset();
+			SimpleWorldGroundScratch.Reset();
+			LastReadSimpleWorldShapeSerial = 0;
+			LastReadSimpleWorldGroundSerial = 0;
+			LastReadSimpleWorldMemberSerialSum = 0;
+			return;
+		}
+
+		const uint64 ShapeSerial = CachedSimpleWorldEntry->Slot.GetPublishSerial();
+		const uint64 MemberSerialSum = CachedSimpleWorldEntry->GetMemberSlotsPublishSerialSum();
+		if (LastReadSimpleWorldShapeSerial == 0
+			|| ShapeSerial != LastReadSimpleWorldShapeSerial
+			|| MemberSerialSum != LastReadSimpleWorldMemberSerialSum)
+		{
+			SimpleWorldMergedScratch.Reset();
+			CachedSimpleWorldEntry->Slot.AppendTo(SimpleWorldMergedScratch);
+			CachedSimpleWorldEntry->AppendFamilyMemberLimits(
+				CachedSimpleWorldCollisionSkelComp, SimpleWorldMergedScratch);
+			LastReadSimpleWorldShapeSerial = ShapeSerial;
+			LastReadSimpleWorldMemberSerialSum = MemberSerialSum;
+
+			SimpleWorldSphericalLimits.Reset();
+			SimpleWorldCapsuleLimits.Reset();
+			SimpleWorldTaperedCapsuleLimits.Reset();
+			SimpleWorldBoxLimits.Reset();
+			SimpleWorldConvexLimits.Reset();
+			KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+				*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+				SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
+				SimpleWorldBoxLimits, nullptr, &SimpleWorldConvexLimits);
+		}
+		else if (!KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+			*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+			SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
+			SimpleWorldBoxLimits, SimpleWorldConvexLimits))
+		{
+			// 配列数がずれた場合は、前回配列が外部テスト注入や将来の形状追加で変わった可能性があるため全再構築へ戻す。
+			SimpleWorldSphericalLimits.Reset();
+			SimpleWorldCapsuleLimits.Reset();
+			SimpleWorldTaperedCapsuleLimits.Reset();
+			SimpleWorldBoxLimits.Reset();
+			SimpleWorldConvexLimits.Reset();
+			KawaiiPhysicsSimpleWorldReadPath::AppendSharedCollisionDataToSimulationSpace(
+				*this, Output, SimulationSpace, SimpleWorldMergedScratch,
+				SimpleWorldSphericalLimits, SimpleWorldCapsuleLimits, SimpleWorldTaperedCapsuleLimits,
+				SimpleWorldBoxLimits, nullptr, &SimpleWorldConvexLimits);
+		}
+
+		const uint64 GroundSerial = CachedSimpleWorldEntry->GroundSlot.GetPublishSerial();
+		if (LastReadSimpleWorldGroundSerial == 0 || GroundSerial != LastReadSimpleWorldGroundSerial)
+		{
+			SimpleWorldGroundScratch.Reset();
+			CachedSimpleWorldEntry->GroundSlot.AppendTo(SimpleWorldGroundScratch);
+			LastReadSimpleWorldGroundSerial = GroundSerial;
+
+			SimpleWorldGroundBoxLimits.Reset();
+			auto NoOp = [](FBoxLimit&, const FTransform&) {};
+			AppendWorldLimitsToSimulationSpace(*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits,
+				SimpleWorldGroundBoxLimits, NoOp);
+		}
+		else if (!KawaiiPhysicsSimpleWorldReadPath::RefreshSimulationSpaceLimitsInPlace(
+			*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits, SimpleWorldGroundBoxLimits))
+		{
+			// 配列数がずれた場合は、地面 Box の有無が外部から変わった可能性があるため全再構築へ戻す。
+			SimpleWorldGroundBoxLimits.Reset();
+			auto NoOp = [](FBoxLimit&, const FTransform&) {};
+			AppendWorldLimitsToSimulationSpace(*this, Output, SimulationSpace, SimpleWorldGroundScratch.BoxLimits,
+				SimpleWorldGroundBoxLimits, NoOp);
+		}
+
 		return;
 	}
 
@@ -1591,7 +1755,8 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 			bSimpleWorldRadiusChecked = false;
 			SimpleWorldRadiusCheckDeferrals = 0;
 		}
-		CachedSimpleWorldEntry->SetDesc(SourceID, Desc);
+		// 期限切れで provider slot が消えた後の再送でも SkelComp を失わないよう、必ず自分の SkelComp を渡す。
+		CachedSimpleWorldEntry->SetDesc(SourceID, Desc, GFrameCounter, CachedSimpleWorldCollisionSkelComp, true);
 		LastSentSimpleWorldDesc = Desc;
 		bSimpleWorldDescSent = true;
 	}
@@ -1611,6 +1776,7 @@ void FAnimNode_KawaiiPhysics::UpdateSimpleWorldCollisionLimits(FComponentSpacePo
 		SimpleWorldGroundScratch.Reset();
 		LastReadSimpleWorldShapeSerial = 0;
 		LastReadSimpleWorldGroundSerial = 0;
+		LastReadSimpleWorldMemberSerialSum = 0;
 		return;
 	}
 
@@ -1725,7 +1891,14 @@ void FAnimNode_KawaiiPhysics::ReleaseSimpleWorldCollision()
 {
 	if (CachedSimpleWorldEntry.IsValid())
 	{
-		CachedSimpleWorldEntry->RemoveDesc(reinterpret_cast<uint64>(this));
+		if (bSimpleWorldReaderMode)
+		{
+			CachedSimpleWorldEntry->RemoveReaderMember(reinterpret_cast<uint64>(this));
+		}
+		else
+		{
+			CachedSimpleWorldEntry->RemoveDesc(reinterpret_cast<uint64>(this));
+		}
 	}
 
 	CachedSimpleWorldEntry.Reset();
@@ -1735,6 +1908,7 @@ void FAnimNode_KawaiiPhysics::ReleaseSimpleWorldCollision()
 	SimpleWorldGroundScratch.Reset();
 	LastReadSimpleWorldShapeSerial = 0;
 	LastReadSimpleWorldGroundSerial = 0;
+	LastReadSimpleWorldMemberSerialSum = 0;
 }
 
 void FAnimNode_KawaiiPhysics::RequestSimpleWorldCollisionReinit()
@@ -1745,11 +1919,21 @@ void FAnimNode_KawaiiPhysics::RequestSimpleWorldCollisionReinit()
 	SimpleWorldRadiusCheckDeferrals = 0;
 	LastReadSimpleWorldShapeSerial = 0;
 	LastReadSimpleWorldGroundSerial = 0;
+	LastReadSimpleWorldMemberSerialSum = 0;
+	SimpleWorldReaderRetryCount = 0;
+	bSimpleWorldReaderWarningLogged = false;
 	SimpleWorldMergedScratch.Reset();
 	SimpleWorldGroundScratch.Reset();
 	if (CachedSimpleWorldEntry.IsValid())
 	{
-		CachedSimpleWorldEntry->RemoveDesc(reinterpret_cast<uint64>(this));
+		if (bSimpleWorldReaderMode)
+		{
+			CachedSimpleWorldEntry->RemoveReaderMember(reinterpret_cast<uint64>(this));
+		}
+		else
+		{
+			CachedSimpleWorldEntry->RemoveDesc(reinterpret_cast<uint64>(this));
+		}
 		CachedSimpleWorldEntry.Reset();
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedCollisionSubsystem.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019-2026 pafuhana1213. All Rights Reserved.
 
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "KawaiiPhysicsSharedPublisherTypes.h"
 #include "AnimNode_KawaiiPhysics.h"
 #include "KawaiiPhysicsDeveloperSettings.h"
 #include "KawaiiPhysicsGroundProvider.h"
@@ -91,6 +92,11 @@ namespace
 			&& AggGeom.TaperedCapsuleElems.IsEmpty()
 			&& AggGeom.BoxElems.IsEmpty()
 			&& AggGeom.ConvexElems.IsEmpty();
+	}
+
+	bool IsKawaiiPhysicsFrameAgeExceeded(uint64 CurrentFrame, uint64 LastFrame, uint64 MaxAgeFrames)
+	{
+		return CurrentFrame >= LastFrame && CurrentFrame - LastFrame > MaxAgeFrames;
 	}
 
 	bool BuildLocalLimitsForSimpleWorldComponent(
@@ -735,6 +741,7 @@ extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionCleanupMaxAge;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionDebugDraw;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionForceEnableOnServer;
 extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionUseMovementGround;
+extern TAutoConsoleVariable<int32> CVarSimpleWorldCollisionReaderReleaseMaxAge;
 
 DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SharedCollision_Publish"), STAT_KawaiiPhysics_SharedCollision_Publish, STATGROUP_Anim);
 DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SharedCollision_GetOrCreateSlot"), STAT_KawaiiPhysics_SharedCollision_GetOrCreateSlot, STATGROUP_Anim);
@@ -750,6 +757,7 @@ DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_UpdateTransforms"), 
 DECLARE_CYCLE_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_Ground"), STAT_KawaiiPhysics_SimpleWorldCollision_Ground, STATGROUP_Anim);
 DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents"), STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, STATGROUP_Anim);
 DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies"), STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, STATGROUP_Anim);
+DECLARE_DWORD_COUNTER_STAT(TEXT("KawaiiPhysics_SimpleWorldCollision_NumMemberSlots"), STAT_KawaiiPhysics_SimpleWorldCollision_NumMemberSlots, STATGROUP_Anim);
 
 AActor* UKawaiiPhysicsSharedCollisionSubsystem::GetFamilyRoot(AActor* Actor)
 {
@@ -888,6 +896,33 @@ bool FKawaiiPhysicsSharedCollisionEntry::IsEmpty() const
 // FKawaiiPhysicsSimpleWorldCollisionDesc / Entry
 // -------------------------------------------------------------------
 
+FKawaiiPhysicsSimpleWorldRegistryKey FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(
+	const USkeletalMeshComponent* SkelComp)
+{
+	FKawaiiPhysicsSimpleWorldRegistryKey Key;
+	Key.KeyObject = SkelComp;
+	return Key;
+}
+
+FKawaiiPhysicsSimpleWorldRegistryKey FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(
+	const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp)
+{
+	// 弱参照をそのまま格納する（Worker から呼ばれるため UObject をデリファレンスしない）。
+	FKawaiiPhysicsSimpleWorldRegistryKey Key;
+	Key.KeyObject = SkelComp;
+	return Key;
+}
+
+FKawaiiPhysicsSimpleWorldRegistryKey FKawaiiPhysicsSimpleWorldRegistryKey::MakeSharedKey(
+	const AActor* FamilyRoot,
+	const FGameplayTag& Tag)
+{
+	FKawaiiPhysicsSimpleWorldRegistryKey Key;
+	Key.KeyObject = FamilyRoot;
+	Key.Tag = Tag;
+	return Key;
+}
+
 bool FKawaiiPhysicsSimpleWorldCollisionDesc::operator==(const FKawaiiPhysicsSimpleWorldCollisionDesc& Other) const
 {
 	return GatherIntervalSec == Other.GatherIntervalSec
@@ -897,7 +932,10 @@ bool FKawaiiPhysicsSimpleWorldCollisionDesc::operator==(const FKawaiiPhysicsSimp
 		&& ObjectTypes == Other.ObjectTypes
 		&& ConvexFallbackShape == Other.ConvexFallbackShape
 		&& SkeletalMeshCollision == Other.SkeletalMeshCollision
-		&& bGroundCollision == Other.bGroundCollision;
+		&& bGroundCollision == Other.bGroundCollision
+		&& GatherScope == Other.GatherScope
+		&& bGatherFamilyMembers == Other.bGatherFamilyMembers
+		&& bProviderDisabled == Other.bProviderDisabled;
 }
 
 bool FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(
@@ -910,7 +948,10 @@ bool FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(
 		|| Old.bGroundCollision != New.bGroundCollision
 		|| Old.GatherRadiusOverride != New.GatherRadiusOverride
 		|| Old.bGatherRadiusAllOverridden != New.bGatherRadiusAllOverridden
-		|| Old.CollisionChannel != New.CollisionChannel;
+		|| Old.CollisionChannel != New.CollisionChannel
+		|| Old.GatherScope != New.GatherScope
+		|| Old.bGatherFamilyMembers != New.bGatherFamilyMembers
+		|| Old.bProviderDisabled != New.bProviderDisabled;
 }
 
 FKawaiiPhysicsSimpleWorldCollisionDesc FKawaiiPhysicsSimpleWorldCollisionDesc::Merge(
@@ -970,6 +1011,12 @@ FKawaiiPhysicsSimpleWorldCollisionDesc FKawaiiPhysicsSimpleWorldCollisionDesc::M
 		}
 
 		Merged.bGroundCollision = Merged.bGroundCollision || Desc.bGroundCollision;
+		if (Desc.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily)
+		{
+			Merged.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+		}
+		Merged.bGatherFamilyMembers = Merged.bGatherFamilyMembers || Desc.bGatherFamilyMembers;
+		Merged.bProviderDisabled = Merged.bProviderDisabled && Desc.bProviderDisabled;
 	}
 
 	if (bHasEmptyObjectTypes)
@@ -987,7 +1034,8 @@ FKawaiiPhysicsSimpleWorldCollisionDesc FKawaiiPhysicsSimpleWorldCollisionDesc::M
 }
 
 void FKawaiiPhysicsSimpleWorldCollisionEntry::SetDesc(
-	uint64 SourceID, const FKawaiiPhysicsSimpleWorldCollisionDesc& InDesc)
+	uint64 SourceID, const FKawaiiPhysicsSimpleWorldCollisionDesc& InDesc, uint64 CurrentFrame,
+	const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp, bool bProvider)
 {
 	if (SourceID == 0)
 	{
@@ -997,13 +1045,13 @@ void FKawaiiPhysicsSimpleWorldCollisionEntry::SetDesc(
 	FWriteScopeLock WriteLock(DescLock);
 	const bool bIsNewSource = !DescSlots.Contains(SourceID);
 
-	// 新規登録時のみ、同一設定のスロットが既にあるかをFindOrAddの前に調べる。
+	// 新規 provider 登録時のみ、同一設定の provider スロットが既にあるかをFindOrAddの前に調べる。
 	bool bHasEquivalentDesc = false;
-	if (bIsNewSource)
+	if (bProvider && bIsNewSource)
 	{
 		for (const auto& Pair : DescSlots)
 		{
-			if (Pair.Value.Desc == InDesc)
+			if (Pair.Value.bProvider && Pair.Value.Desc == InDesc)
 			{
 				bHasEquivalentDesc = true;
 				break;
@@ -1012,26 +1060,68 @@ void FKawaiiPhysicsSimpleWorldCollisionEntry::SetDesc(
 	}
 
 	FDescSlot& DescSlotRef = DescSlots.FindOrAdd(SourceID);
+	const bool bProviderChanged = !bIsNewSource && (DescSlotRef.bProvider != bProvider);
 	if (bIsNewSource)
 	{
 		// 登録順は新規登録時にだけ確定する（同じノードが設定を変えても順位は維持する）。
 		DescSlotRef.RegistrationOrdinal = NextDescRegistrationOrdinal++;
 	}
-	DescSlotRef.LastReadFrame = GFrameCounter;
-	if (bIsNewSource || !(DescSlotRef.Desc == InDesc))
+	DescSlotRef.LastReadFrame = CurrentFrame;
+	// Worker から呼ばれるため、弱参照はデリファレンスせずスレッドセーフ判定だけで有効性を見る。
+	if (SkelComp.IsValid(false, true))
+	{
+		DescSlotRef.SkelComp = SkelComp;
+	}
+	DescSlotRef.bProvider = bProvider;
+
+	if (bProvider)
+	{
+		LastProviderFrame = CurrentFrame;
+	}
+
+	if (bIsNewSource || bProviderChanged || !(DescSlotRef.Desc == InDesc))
 	{
 		// 新規登録と収集内容に影響する変更だけ再収集する。
 		// GatherIntervalだけの変更（ピン駆動で毎フレーム変わり得る）では収集済み形状とフェード状態を維持する。
-		// 新規登録でも同一設定のノードが既に登録済みならMerge結果が変わらないため再収集しない。
-		const bool bRequiresRegather = (bIsNewSource && !bHasEquivalentDesc)
+		// 新規登録でも同一設定のproviderが既に登録済みならMerge結果が変わらないため再収集しない。
+		const bool bRequiresRegather = (bProvider && bIsNewSource && !bHasEquivalentDesc)
 			|| (!bIsNewSource
-				&& FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(DescSlotRef.Desc, InDesc));
+				&& (bProviderChanged
+					|| (bProvider
+						&& FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(DescSlotRef.Desc, InDesc))));
 		DescSlotRef.Desc = InDesc;
 		if (bRequiresRegather)
 		{
 			bRegatherRequested.store(true, std::memory_order_release);
 		}
 	}
+
+	if (bProvider)
+	{
+		TArray<FKawaiiPhysicsSimpleWorldCollisionDesc> ProviderDescs;
+		ProviderDescs.Reserve(DescSlots.Num());
+		for (const auto& Pair : DescSlots)
+		{
+			if (Pair.Value.bProvider)
+			{
+				ProviderDescs.Add(Pair.Value.Desc);
+			}
+		}
+
+		const bool bKeepMemberSlots = !ProviderDescs.IsEmpty()
+			&& FKawaiiPhysicsSimpleWorldCollisionDesc::Merge(ProviderDescs).bGatherFamilyMembers;
+		if (!bKeepMemberSlots)
+		{
+			TArray<TWeakObjectPtr<const USkeletalMeshComponent>> EmptyMembers;
+			RemoveMemberSlotsNotInLocked(EmptyMembers);
+		}
+	}
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::SetDesc(
+	uint64 SourceID, const FKawaiiPhysicsSimpleWorldCollisionDesc& InDesc)
+{
+	SetDesc(SourceID, InDesc, GFrameCounter, TWeakObjectPtr<const USkeletalMeshComponent>(), true);
 }
 
 void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveDesc(uint64 SourceID)
@@ -1044,6 +1134,34 @@ void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveDesc(uint64 SourceID)
 	FWriteScopeLock WriteLock(DescLock);
 	if (DescSlots.Remove(SourceID) > 0)
 	{
+		TArray<FKawaiiPhysicsSimpleWorldCollisionDesc> ProviderDescs;
+		TArray<TWeakObjectPtr<const USkeletalMeshComponent>> MembersToKeep;
+		ProviderDescs.Reserve(DescSlots.Num());
+		MembersToKeep.Reserve(DescSlots.Num());
+		for (const auto& Pair : DescSlots)
+		{
+			if (Pair.Value.bProvider)
+			{
+				ProviderDescs.Add(Pair.Value.Desc);
+			}
+			// Worker から呼ばれるため、弱参照のままスレッドセーフ判定だけで残す/捨てるを決める。
+			if (Pair.Value.SkelComp.IsValid(false, true))
+			{
+				MembersToKeep.AddUnique(Pair.Value.SkelComp);
+			}
+		}
+
+		const bool bKeepMemberSlots = !ProviderDescs.IsEmpty()
+			&& FKawaiiPhysicsSimpleWorldCollisionDesc::Merge(ProviderDescs).bGatherFamilyMembers;
+		if (bKeepMemberSlots)
+		{
+			RemoveMemberSlotsNotInLocked(MembersToKeep);
+		}
+		else
+		{
+			TArray<TWeakObjectPtr<const USkeletalMeshComponent>> EmptyMembers;
+			RemoveMemberSlotsNotInLocked(EmptyMembers);
+		}
 		bRegatherRequested.store(true, std::memory_order_release);
 	}
 }
@@ -1055,36 +1173,332 @@ bool FKawaiiPhysicsSimpleWorldCollisionEntry::MarkRead(uint64 SourceID)
 	FWriteScopeLock WriteLock(DescLock);
 	if (FDescSlot* DescSlotPtr = DescSlots.Find(SourceID))
 	{
+		if (!DescSlotPtr->bProvider)
+		{
+			return false;
+		}
 		DescSlotPtr->LastReadFrame = GFrameCounter;
+		LastProviderFrame = GFrameCounter;
 		return true;
 	}
 	return false;
 }
 
+void FKawaiiPhysicsSimpleWorldCollisionEntry::AddReaderMember(
+	uint64 SourceID,
+	const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp,
+	uint64 CurrentFrame)
+{
+	if (SourceID == 0)
+	{
+		return;
+	}
+
+	FWriteScopeLock WriteLock(DescLock);
+	FDescSlot& DescSlotRef = DescSlots.FindOrAdd(SourceID);
+	// Worker から呼ばれるため、差し替え検知は弱参照同士の比較で行う（Get() でデリファレンスしない）。
+	const bool bSkelCompChanged = DescSlotRef.SkelComp != SkelComp;
+	if (DescSlotRef.RegistrationOrdinal == 0)
+	{
+		DescSlotRef.RegistrationOrdinal = NextDescRegistrationOrdinal++;
+	}
+	DescSlotRef.LastReadFrame = CurrentFrame;
+	const bool bHasSkelComp = SkelComp.IsValid(false, true);
+	if (bHasSkelComp)
+	{
+		DescSlotRef.SkelComp = SkelComp;
+	}
+	if (DescSlotRef.bProvider)
+	{
+		DescSlotRef.bProvider = false;
+		bRegatherRequested.store(true, std::memory_order_release);
+	}
+	if (bHasSkelComp && bSkelCompChanged)
+	{
+		TArray<FKawaiiPhysicsSimpleWorldCollisionDesc> ProviderDescs;
+		TArray<TWeakObjectPtr<const USkeletalMeshComponent>> MembersToKeep;
+		ProviderDescs.Reserve(DescSlots.Num());
+		MembersToKeep.Reserve(DescSlots.Num());
+		for (const auto& Pair : DescSlots)
+		{
+			if (Pair.Value.bProvider)
+			{
+				ProviderDescs.Add(Pair.Value.Desc);
+			}
+			if (Pair.Value.SkelComp.IsValid(false, true))
+			{
+				MembersToKeep.AddUnique(Pair.Value.SkelComp);
+			}
+		}
+
+		const bool bKeepMemberSlots = !ProviderDescs.IsEmpty()
+			&& FKawaiiPhysicsSimpleWorldCollisionDesc::Merge(ProviderDescs).bGatherFamilyMembers;
+		if (bKeepMemberSlots)
+		{
+			RemoveMemberSlotsNotInLocked(MembersToKeep);
+		}
+		else
+		{
+			TArray<TWeakObjectPtr<const USkeletalMeshComponent>> EmptyMembers;
+			RemoveMemberSlotsNotInLocked(EmptyMembers);
+		}
+		bRegatherRequested.store(true, std::memory_order_release);
+	}
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveReaderMember(uint64 SourceID)
+{
+	RemoveDesc(SourceID);
+}
+
+bool FKawaiiPhysicsSimpleWorldCollisionEntry::MarkReaderRead(
+	uint64 SourceID,
+	uint64 CurrentFrame,
+	uint64 ProviderMaxAgeFrames)
+{
+	FWriteScopeLock WriteLock(DescLock);
+	FDescSlot* ReaderSlotPtr = DescSlots.Find(SourceID);
+	if (!ReaderSlotPtr || ReaderSlotPtr->bProvider)
+	{
+		return false;
+	}
+
+	ReaderSlotPtr->LastReadFrame = CurrentFrame;
+
+	bool bHasProvider = false;
+	for (const auto& Pair : DescSlots)
+	{
+		if (Pair.Value.bProvider)
+		{
+			bHasProvider = true;
+			break;
+		}
+	}
+	if (!bHasProvider)
+	{
+		return false;
+	}
+
+	return CurrentFrame <= LastProviderFrame || CurrentFrame - LastProviderFrame <= ProviderMaxAgeFrames;
+}
+
 void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveExpiredDescs(uint64 CurrentFrame, uint64 MaxAge)
 {
 	FWriteScopeLock WriteLock(DescLock);
+	bool bRemoved = false;
 	for (auto DescIt = DescSlots.CreateIterator(); DescIt; ++DescIt)
 	{
 		const uint64 LastFrame = DescIt->Value.LastReadFrame;
 		if ((LastFrame == 0) || (CurrentFrame - LastFrame > MaxAge))
 		{
 			DescIt.RemoveCurrent();
-			bRegatherRequested.store(true, std::memory_order_release);
+			bRemoved = true;
 		}
+	}
+
+	if (bRemoved)
+	{
+		TArray<FKawaiiPhysicsSimpleWorldCollisionDesc> ProviderDescs;
+		TArray<TWeakObjectPtr<const USkeletalMeshComponent>> MembersToKeep;
+		ProviderDescs.Reserve(DescSlots.Num());
+		MembersToKeep.Reserve(DescSlots.Num());
+		for (const auto& Pair : DescSlots)
+		{
+			if (Pair.Value.bProvider)
+			{
+				ProviderDescs.Add(Pair.Value.Desc);
+			}
+			if (Pair.Value.SkelComp.IsValid(false, true))
+			{
+				MembersToKeep.AddUnique(Pair.Value.SkelComp);
+			}
+		}
+
+		const bool bKeepMemberSlots = !ProviderDescs.IsEmpty()
+			&& FKawaiiPhysicsSimpleWorldCollisionDesc::Merge(ProviderDescs).bGatherFamilyMembers;
+		if (bKeepMemberSlots)
+		{
+			RemoveMemberSlotsNotInLocked(MembersToKeep);
+		}
+		else
+		{
+			TArray<TWeakObjectPtr<const USkeletalMeshComponent>> EmptyMembers;
+			RemoveMemberSlotsNotInLocked(EmptyMembers);
+		}
+		bRegatherRequested.store(true, std::memory_order_release);
 	}
 }
 
 bool FKawaiiPhysicsSimpleWorldCollisionEntry::HasAnyDesc() const
 {
 	FReadScopeLock ReadLock(DescLock);
-	return !DescSlots.IsEmpty();
+	for (const auto& Pair : DescSlots)
+	{
+		if (Pair.Value.bProvider)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool FKawaiiPhysicsSimpleWorldCollisionEntry::HasProviderDesc() const
+{
+	return HasAnyDesc();
+}
+
+bool FKawaiiPhysicsSimpleWorldCollisionEntry::HasAnyReader() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	for (const auto& Pair : DescSlots)
+	{
+		if (!Pair.Value.bProvider)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool FKawaiiPhysicsSimpleWorldCollisionEntry::IsProviderDisabled() const
+{
+	bool bHasProvider = false;
+	bool bAllProvidersDisabled = true;
+	FReadScopeLock ReadLock(DescLock);
+	for (const auto& Pair : DescSlots)
+	{
+		if (Pair.Value.bProvider)
+		{
+			bHasProvider = true;
+			bAllProvidersDisabled = bAllProvidersDisabled && Pair.Value.Desc.bProviderDisabled;
+		}
+	}
+
+	return bHasProvider && bAllProvidersDisabled;
 }
 
 int32 FKawaiiPhysicsSimpleWorldCollisionEntry::GetNumDescs() const
 {
 	FReadScopeLock ReadLock(DescLock);
-	return DescSlots.Num();
+	int32 NumProviders = 0;
+	for (const auto& Pair : DescSlots)
+	{
+		if (Pair.Value.bProvider)
+		{
+			++NumProviders;
+		}
+	}
+	return NumProviders;
+}
+
+int32 FKawaiiPhysicsSimpleWorldCollisionEntry::GetNumReaders() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	int32 NumReaders = 0;
+	for (const auto& Pair : DescSlots)
+	{
+		if (!Pair.Value.bProvider)
+		{
+			++NumReaders;
+		}
+	}
+	return NumReaders;
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::CollectMemberSkelComps(
+	TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& Out) const
+{
+	FReadScopeLock ReadLock(DescLock);
+	for (const auto& Pair : DescSlots)
+	{
+		if (const USkeletalMeshComponent* SkelComp = Pair.Value.SkelComp.Get())
+		{
+			Out.AddUnique(TWeakObjectPtr<const USkeletalMeshComponent>(SkelComp));
+		}
+	}
+}
+
+const USkeletalMeshComponent* FKawaiiPhysicsSimpleWorldCollisionEntry::GetPrimarySkelComp() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	const FDescSlot* PrimarySlot = nullptr;
+	for (const auto& Pair : DescSlots)
+	{
+		if (Pair.Value.bProvider
+			&& (!PrimarySlot || Pair.Value.RegistrationOrdinal < PrimarySlot->RegistrationOrdinal))
+		{
+			PrimarySlot = &Pair.Value;
+		}
+	}
+	return PrimarySlot ? PrimarySlot->SkelComp.Get() : nullptr;
+}
+
+uint64 FKawaiiPhysicsSimpleWorldCollisionEntry::GetLastProviderFrame() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	return LastProviderFrame;
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::AppendFamilyMemberLimits(
+	const TWeakObjectPtr<const USkeletalMeshComponent>& OwnSkelComp,
+	FKawaiiPhysicsSharedCollisionData& OutData) const
+{
+	FReadScopeLock ReadLock(DescLock);
+	for (const auto& Pair : MemberSlots)
+	{
+		// Worker から呼ばれるため、有効判定はスレッドセーフ版、自己除外は弱参照同士の比較で行う。
+		if (!Pair.Key.IsValid(false, true) || Pair.Key == OwnSkelComp || !Pair.Value.IsValid())
+		{
+			continue;
+		}
+		Pair.Value->AppendTo(OutData);
+	}
+}
+
+uint64 FKawaiiPhysicsSimpleWorldCollisionEntry::GetMemberSlotsPublishSerialSum() const
+{
+	uint64 SerialSum = 0;
+	FReadScopeLock ReadLock(DescLock);
+	for (const auto& Pair : MemberSlots)
+	{
+		if (Pair.Value.IsValid())
+		{
+			SerialSum += Pair.Value->GetPublishSerial();
+		}
+	}
+	return SerialSum;
+}
+
+int32 FKawaiiPhysicsSimpleWorldCollisionEntry::GetNumMemberSlots() const
+{
+	FReadScopeLock ReadLock(DescLock);
+	return MemberSlots.Num();
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveMemberSlotsNotIn(
+	const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MembersToKeep)
+{
+	FWriteScopeLock WriteLock(DescLock);
+	RemoveMemberSlotsNotInLocked(MembersToKeep);
+}
+
+void FKawaiiPhysicsSimpleWorldCollisionEntry::RemoveMemberSlotsNotInLocked(
+	const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MembersToKeep)
+{
+	if (MembersToKeep.IsEmpty())
+	{
+		MemberSlots.Empty();
+		return;
+	}
+
+	for (auto SlotIt = MemberSlots.CreateIterator(); SlotIt; ++SlotIt)
+	{
+		// Worker 経路（SetDesc / RemoveDesc / AddReaderMember）からも到達するためスレッドセーフ判定を使う。
+		if (!SlotIt->Key.IsValid(false, true) || !MembersToKeep.Contains(SlotIt->Key))
+		{
+			SlotIt.RemoveCurrent();
+		}
+	}
 }
 
 bool FKawaiiPhysicsSimpleWorldCollisionEntry::BuildMergedDesc(
@@ -1103,8 +1517,15 @@ bool FKawaiiPhysicsSimpleWorldCollisionEntry::BuildMergedDesc(
 		OrderedDescs.Reserve(DescSlots.Num());
 		for (const auto& Pair : DescSlots)
 		{
-			OrderedDescs.Emplace(Pair.Value.RegistrationOrdinal, Pair.Value.Desc);
+			if (Pair.Value.bProvider)
+			{
+				OrderedDescs.Emplace(Pair.Value.RegistrationOrdinal, Pair.Value.Desc);
+			}
 		}
+	}
+	if (OrderedDescs.IsEmpty())
+	{
+		return false;
 	}
 
 	// RegistrationOrdinal は一意なので安定ソートは不要。
@@ -1133,6 +1554,149 @@ void FKawaiiPhysicsSimpleWorldCollisionEntry::RequestRegather()
 bool FKawaiiPhysicsSimpleWorldCollisionEntry::ConsumeRegatherRequested()
 {
 	return bRegatherRequested.exchange(false, std::memory_order_acq_rel);
+}
+
+// -------------------------------------------------------------------
+// 共有 Publisher Entry
+// -------------------------------------------------------------------
+
+bool FKawaiiPhysicsSharedPublisherEntry::PublishState(
+	const FKawaiiPhysicsSharedPublisherState& InState,
+	uint64 InProviderID,
+	uint64 CurrentFrame,
+	uint64 ProviderMaxAgeFrames)
+{
+	FWriteScopeLock WriteLock(StateLock);
+
+	// Cleanup で Registry から外れた Entry は復活させない。呼び出し側は FindOrCreateSharedPublisherEntry で取り直す。
+	if (bExpired)
+	{
+		return false;
+	}
+
+	// ProviderID == 0 は「未所有」の番兵なので、ID 0 での publish は所有権を曖昧にする。拒否する。
+	if (InProviderID == 0)
+	{
+		return false;
+	}
+
+	const uint64 LastFrame = LastPublishFrame.load(std::memory_order_acquire);
+	const bool bCanPublish = ProviderID == 0
+		|| ProviderID == InProviderID
+		|| IsKawaiiPhysicsFrameAgeExceeded(CurrentFrame, LastFrame, ProviderMaxAgeFrames);
+	if (!bCanPublish)
+	{
+		return false;
+	}
+
+	State = InState;
+	ProviderID = InProviderID;
+	bExpired = false;
+	LastPublishFrame.store(CurrentFrame, std::memory_order_release);
+	PublishSerial.fetch_add(1, std::memory_order_acq_rel);
+	return true;
+}
+
+uint64 FKawaiiPhysicsSharedPublisherEntry::ReadState(FKawaiiPhysicsSharedPublisherState& Out) const
+{
+	FReadScopeLock ReadLock(StateLock);
+	Out = State;
+	return PublishSerial.load(std::memory_order_acquire);
+}
+
+uint64 FKawaiiPhysicsSharedPublisherEntry::ReadWindState(FKawaiiPhysicsSharedWindState& Out) const
+{
+	FReadScopeLock ReadLock(StateLock);
+	Out = State.Wind;
+	return PublishSerial.load(std::memory_order_acquire);
+}
+
+uint64 FKawaiiPhysicsSharedPublisherEntry::GetPublishSerial() const
+{
+	return PublishSerial.load(std::memory_order_acquire);
+}
+
+uint64 FKawaiiPhysicsSharedPublisherEntry::GetProviderID() const
+{
+	FReadScopeLock ReadLock(StateLock);
+	return ProviderID;
+}
+
+uint64 FKawaiiPhysicsSharedPublisherEntry::GetLastPublishFrame() const
+{
+	return LastPublishFrame.load(std::memory_order_acquire);
+}
+
+bool FKawaiiPhysicsSharedPublisherEntry::IsExpired(uint64 CurrentFrame, uint64 MaxAgeFrames) const
+{
+	FReadScopeLock ReadLock(StateLock);
+	return bExpired
+		|| IsKawaiiPhysicsFrameAgeExceeded(
+			CurrentFrame,
+			LastPublishFrame.load(std::memory_order_acquire),
+			MaxAgeFrames);
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::MarkExpired()
+{
+	FWriteScopeLock WriteLock(StateLock);
+	bExpired = true;
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::RequestGust(float Strength, float RiseTime, float DecayTime, float HoldTime)
+{
+	FScopeLock Lock(&GustMutex);
+
+	FKawaiiPhysicsSharedPublisherGustRequest Request;
+	Request.Strength = Strength;
+	Request.RiseTime = RiseTime;
+	Request.DecayTime = DecayTime;
+	Request.HoldTime = HoldTime;
+	PendingGusts.Add(Request);
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::RequestGustStop(float BlendOutTime)
+{
+	FScopeLock Lock(&GustMutex);
+
+	FKawaiiPhysicsSharedPublisherGustRequest Request;
+	Request.bStop = true;
+	Request.BlendOutTime = BlendOutTime;
+	PendingGusts.Add(Request);
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::ConsumePendingGustRequests(
+	TArray<FKawaiiPhysicsSharedPublisherGustRequest>& Out)
+{
+	FScopeLock Lock(&GustMutex);
+	Out = MoveTemp(PendingGusts);
+	PendingGusts.Reset();
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::RequestPublisherEnabled(bool bEnabled)
+{
+	FScopeLock Lock(&GustMutex);
+	PendingPublisherEnabled = bEnabled;
+}
+
+void FKawaiiPhysicsSharedPublisherEntry::RequestSimpleWorldSettings(
+	const FKawaiiPhysicsSimpleWorldCollisionSettings& Settings)
+{
+	FScopeLock Lock(&GustMutex);
+	PendingSimpleWorldSettings = Settings;
+}
+
+bool FKawaiiPhysicsSharedPublisherEntry::ConsumePendingPublisherRequests(
+	FPendingPublisherRequests& Out)
+{
+	FScopeLock Lock(&GustMutex);
+
+	const bool bHasRequests = PendingPublisherEnabled.IsSet() || PendingSimpleWorldSettings.IsSet();
+	Out.Enabled = PendingPublisherEnabled;
+	Out.SimpleWorldSettings = PendingSimpleWorldSettings;
+	PendingPublisherEnabled.Reset();
+	PendingSimpleWorldSettings.Reset();
+	return bHasRequests;
 }
 
 // -------------------------------------------------------------------
@@ -1165,6 +1729,20 @@ TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> UKawaiiPhysicsSharedCollisionSubs
 	if (const TSharedPtr<FKawaiiPhysicsSharedCollisionEntry>* Found = Registry.Find(Key))
 	{
 		// Actorが無効ならスキップ（Tick()で定期的にクリーンアップ）
+		if (Key.Key.IsValid())
+		{
+			return *Found;
+		}
+	}
+	return nullptr;
+}
+
+TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindSharedPublisherEntryByKey(
+	const FRegistryKey& Key) const
+{
+	FReadScopeLock ReadLock(SharedPublisherRegistryLock);
+	if (const TSharedPtr<FKawaiiPhysicsSharedPublisherEntry>* Found = SharedPublisherRegistry.Find(Key))
+	{
 		if (Key.Key.IsValid())
 		{
 			return *Found;
@@ -1210,17 +1788,68 @@ TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> UKawaiiPhysicsSharedCollisio
 		return nullptr;
 	}
 
+	// Worker から呼ばれるため、弱参照のままキー化して渡す（SkelComp をデリファレンスしない）。
+	return FindOrCreateSimpleWorldEntry(
+		FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(SkelComp),
+		SourceID,
+		InitialDesc,
+		SkelComp,
+		true);
+}
+
+TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindOrCreateSimpleWorldEntry(
+	const FKawaiiPhysicsSimpleWorldRegistryKey& Key,
+	uint64 SourceID,
+	const FKawaiiPhysicsSimpleWorldCollisionDesc& InitialDesc,
+	const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp,
+	bool bProvider)
+{
+	if (!Key.IsValid())
+	{
+		return nullptr;
+	}
+
 	// Entry 作成と初回 Desc 登録は同一ロック内。cleanup は同ロックで HasAnyDesc を見るため、空 Entry が観測される瞬間が無い。
 	FWriteScopeLock WriteLock(SimpleWorldRegistryLock);
-	if (TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Existing = SimpleWorldRegistry.Find(SkelComp))
+	if (TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Existing = SimpleWorldRegistry.Find(Key))
 	{
-		(*Existing)->SetDesc(SourceID, InitialDesc);
+		if (bProvider)
+		{
+			(*Existing)->SetDesc(SourceID, InitialDesc, GFrameCounter, SkelComp, true);
+		}
+		else
+		{
+			(*Existing)->AddReaderMember(SourceID, SkelComp, GFrameCounter);
+		}
 		return *Existing;
 	}
 	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> NewEntry = MakeShared<FKawaiiPhysicsSimpleWorldCollisionEntry>();
-	SimpleWorldRegistry.Add(SkelComp, NewEntry);
-	NewEntry->SetDesc(SourceID, InitialDesc);
+	SimpleWorldRegistry.Add(Key, NewEntry);
+	if (bProvider)
+	{
+		NewEntry->SetDesc(SourceID, InitialDesc, GFrameCounter, SkelComp, true);
+	}
+	else
+	{
+		NewEntry->AddReaderMember(SourceID, SkelComp, GFrameCounter);
+	}
 	return NewEntry;
+}
+
+TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindSimpleWorldEntry(
+	const FKawaiiPhysicsSimpleWorldRegistryKey& Key) const
+{
+	if (!Key.IsValid())
+	{
+		return nullptr;
+	}
+
+	FReadScopeLock ReadLock(SimpleWorldRegistryLock);
+	if (const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Found = SimpleWorldRegistry.Find(Key))
+	{
+		return *Found;
+	}
+	return nullptr;
 }
 
 TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindEntry(
@@ -1236,13 +1865,53 @@ TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> UKawaiiPhysicsSharedCollisionSubs
 	return FindEntryByKey(Key);
 }
 
+TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindOrCreateSharedPublisherEntry(
+	AActor* Actor,
+	const FGameplayTag& Tag)
+{
+	FRegistryKey Key;
+	if (!TryResolveRegistryKey(Actor, Tag, Key))
+	{
+		return nullptr;
+	}
+
+	if (TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> Existing = FindSharedPublisherEntryByKey(Key))
+	{
+		return Existing;
+	}
+
+	FWriteScopeLock WriteLock(SharedPublisherRegistryLock);
+	if (TSharedPtr<FKawaiiPhysicsSharedPublisherEntry>* Existing = SharedPublisherRegistry.Find(Key))
+	{
+		return *Existing;
+	}
+
+	TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> NewEntry = MakeShared<FKawaiiPhysicsSharedPublisherEntry>();
+	SharedPublisherRegistry.Add(Key, NewEntry);
+	return NewEntry;
+}
+
+TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> UKawaiiPhysicsSharedCollisionSubsystem::FindSharedPublisherEntry(
+	AActor* Actor,
+	const FGameplayTag& Tag) const
+{
+	FRegistryKey Key;
+	if (!TryResolveRegistryKey(Actor, Tag, Key))
+	{
+		return nullptr;
+	}
+	return FindSharedPublisherEntryByKey(Key);
+}
+
 void UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(
 	const FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
-	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo)
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo,
+	const FKawaiiPhysicsSimpleWorldRegistryKey* Key)
 {
 	OutInfo = FKawaiiPhysicsSimpleWorldCollisionDebugInfo();
 	OutInfo.bHasEntry = true;
 	OutInfo.NumDescs = Entry.GetNumDescs();
+	OutInfo.NumReaders = Entry.GetNumReaders();
 	OutInfo.NumGatheredComponents = Entry.GatheredComponents.Num();
 	OutInfo.bHasGroundBox = Entry.bHasGroundBox;
 	OutInfo.bGroundComponentStatic = Entry.bGroundComponentStatic;
@@ -1254,6 +1923,29 @@ void UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(
 	OutInfo.GatherRadius = Entry.LastGatherRadius;
 	OutInfo.TimeSinceLastGather = Entry.TimeSinceLastGather == FLT_MAX ? -1.0f : Entry.TimeSinceLastGather;
 	OutInfo.bHasGatheredOnce = Entry.bHasGatheredOnce;
+	OutInfo.bProviderDisabled = Entry.IsProviderDisabled();
+	OutInfo.NumMemberSlots = Entry.GetNumMemberSlots();
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedDesc;
+	if (Entry.BuildMergedDesc(MergedDesc))
+	{
+		OutInfo.GatherScope = MergedDesc.GatherScope;
+		OutInfo.bGatherFamilyMembers = MergedDesc.bGatherFamilyMembers;
+		OutInfo.bProviderDisabled = MergedDesc.bProviderDisabled;
+	}
+
+	if (Key)
+	{
+		OutInfo.GroupTag = Key->Tag;
+		if (const UObject* KeyObject = Key->KeyObject.Get())
+		{
+			OutInfo.KeyObjectName = KeyObject->GetName();
+		}
+	}
+	else if (const USkeletalMeshComponent* PrimarySkelComp = Entry.GetPrimarySkelComp())
+	{
+		OutInfo.KeyObjectName = PrimarySkelComp->GetName();
+	}
 
 	OutInfo.GatheredComponentNames.Reserve(Entry.GatheredComponents.Num());
 	for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent : Entry.GatheredComponents)
@@ -1302,11 +1994,12 @@ bool UKawaiiPhysicsSharedCollisionSubsystem::BuildSimpleWorldCollisionDebugInfo(
 		return false;
 	}
 
+	const FKawaiiPhysicsSimpleWorldRegistryKey Key = FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(SkelComp);
 	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry;
 	{
 		FReadScopeLock ReadLock(SimpleWorldRegistryLock);
 		if (const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Found =
-			SimpleWorldRegistry.Find(TWeakObjectPtr<const USkeletalMeshComponent>(SkelComp)))
+			SimpleWorldRegistry.Find(Key))
 		{
 			Entry = *Found;
 		}
@@ -1317,7 +2010,40 @@ bool UKawaiiPhysicsSharedCollisionSubsystem::BuildSimpleWorldCollisionDebugInfo(
 		return false;
 	}
 
-	FillSimpleWorldCollisionDebugInfo(*Entry, OutInfo);
+	FillSimpleWorldCollisionDebugInfo(*Entry, OutInfo, &Key);
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UKawaiiPhysicsSharedCollisionSubsystem::BuildSimpleWorldCollisionDebugInfo(
+	const FKawaiiPhysicsSimpleWorldRegistryKey& Key,
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo) const
+{
+	OutInfo = FKawaiiPhysicsSimpleWorldCollisionDebugInfo();
+
+#if !UE_BUILD_SHIPPING
+	if (!ensure(IsInGameThread()) || !Key.IsValid())
+	{
+		return false;
+	}
+
+	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry;
+	{
+		FReadScopeLock ReadLock(SimpleWorldRegistryLock);
+		if (const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>* Found = SimpleWorldRegistry.Find(Key))
+		{
+			Entry = *Found;
+		}
+	}
+
+	if (!Entry.IsValid())
+	{
+		return false;
+	}
+
+	FillSimpleWorldCollisionDebugInfo(*Entry, OutInfo, &Key);
 	return true;
 #else
 	return false;
@@ -1329,8 +2055,15 @@ void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(
 	float BoxEnableThreshold)
 {
 	Entry.PublishScratch.Reset();
+	Entry.MemberPublishScratch.Reset();
 	for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& Component : Entry.GatheredComponents)
 	{
+		FKawaiiPhysicsSharedCollisionData* PublishTarget = &Entry.PublishScratch;
+		if (Component.MemberSkelComp.IsValid())
+		{
+			PublishTarget = &Entry.MemberPublishScratch.FindOrAdd(Component.MemberSkelComp);
+		}
+
 		// フェード計算本体は KawaiiPhysicsSimpleWorldCollision 名前空間へ移設済み（単体テスト可能化のため）。
 		// しきい値定数はここ（Subsystem側）で保持したまま引数として渡す。
 		if (!Component.BodyBindings.IsEmpty())
@@ -1340,7 +2073,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(
 				MakeArrayView(Component.BodyBindings),
 				MakeArrayView(Component.LastBodyWorldTMs),
 				Component.FadeAlpha,
-				Entry.PublishScratch,
+				*PublishTarget,
 				BoxEnableThreshold);
 		}
 		else
@@ -1349,13 +2082,77 @@ void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(
 				Component.LocalLimits,
 				Component.FadeAlpha,
 				Component.LastComponentTM,
-				Entry.PublishScratch,
+				*PublishTarget,
 				BoxEnableThreshold);
 		}
 	}
 
 	Entry.Slot.Publish(Entry.PublishScratch);
+	{
+		FWriteScopeLock WriteLock(Entry.DescLock);
+		for (auto& Pair : Entry.MemberPublishScratch)
+		{
+			if (!Pair.Key.IsValid())
+			{
+				continue;
+			}
+			TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>& MemberSlot =
+				Entry.MemberSlots.FindOrAdd(Pair.Key);
+			if (!MemberSlot.IsValid())
+			{
+				MemberSlot = MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>();
+			}
+			MemberSlot->Publish(Pair.Value);
+		}
+
+		for (auto& Pair : Entry.MemberSlots)
+		{
+			if (!Pair.Value.IsValid() || Entry.MemberPublishScratch.Contains(Pair.Key))
+			{
+				continue;
+			}
+			Entry.EmptyMemberPublishScratch.Reset();
+			Pair.Value->Publish(Entry.EmptyMemberPublishScratch);
+		}
+	}
 	Entry.bWorldLimitsDirty = false;
+}
+
+void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldEmptyLimits(
+	FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+	float BoxEnableThreshold)
+{
+	bool bShouldPublishShapes = !Entry.GatheredComponents.IsEmpty()
+		|| (Entry.bWorldLimitsDirty
+			&& (Entry.Slot.GetPublishSerial() > 0 || Entry.GetMemberSlotsPublishSerialSum() > 0));
+
+	Entry.GatheredComponents.Reset();
+	if (bShouldPublishShapes)
+	{
+		PublishSimpleWorldShapeLimits(Entry, BoxEnableThreshold);
+	}
+	else
+	{
+		Entry.bWorldLimitsDirty = false;
+	}
+
+	const bool bShouldPublishGround = Entry.bHasGroundBox
+		|| (Entry.bGroundBoxDirty && Entry.GroundSlot.GetPublishSerial() > 0);
+	bool bGroundChanged = false;
+	ClearSimpleWorldGroundBox(Entry, bGroundChanged);
+	Entry.GroundSource = EKawaiiPhysicsSimpleWorldGroundSource::None;
+	Entry.GroundProvider.Reset();
+	Entry.GroundCharacterMovement.Reset();
+	if (bShouldPublishGround)
+	{
+		PublishSimpleWorldGroundBox(Entry);
+	}
+	else
+	{
+		Entry.bGroundBoxDirty = false;
+	}
+	Entry.bHasGatheredOnce = false;
+	Entry.TimeSinceLastGather = FLT_MAX;
 }
 
 void UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldGroundBox(
@@ -1384,19 +2181,43 @@ void UKawaiiPhysicsSharedCollisionSubsystem::GatherSimpleWorldEntry(
 	int32 EffectiveMaxPhysicsAssetBodies,
 	int32 EffectiveMaxConvexPlanes,
 	bool bUseMovementGround,
-	bool bBuildConvexDebugGeometry)
+	bool bBuildConvexDebugGeometry,
+	const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MemberSkelComps,
+	const TSet<TWeakObjectPtr<const USkeletalMeshComponent>>& MemberSkelCompSet,
+	const TSet<TWeakObjectPtr<const AActor>>& MemberOwners)
 {
 	SCOPE_CYCLE_COUNTER(STAT_KawaiiPhysics_SimpleWorldCollision_Gather);
 	Entry.LastGatherRadius = Radius;
+	const bool bFilterFamilyMembers = Desc.bGatherFamilyMembers && !MemberSkelComps.IsEmpty();
 
 	const FCollisionResponseParams ResponseParams =
 		KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldResponseParams(Desc.ObjectTypes);
 	FCollisionQueryParams QueryParams(SCENE_QUERY_STAT(KawaiiPhysicsSimpleWorldCollision), false);
 	// Overlap応答（トリガー等）は物理クエリのPreFilterで除外し、結果配列に返さない（ループ側のbBlockingHit判定は防御として残す）。
 	QueryParams.bIgnoreTouches = true;
-	QueryParams.AddIgnoredActor(SkelComp.GetOwner());
+	if (!bFilterFamilyMembers)
+	{
+		if (Desc.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily)
+		{
+			for (const TWeakObjectPtr<const AActor>& MemberOwner : MemberOwners)
+			{
+				if (const AActor* Owner = MemberOwner.Get())
+				{
+					QueryParams.AddIgnoredActor(Owner);
+				}
+			}
+		}
+		else
+		{
+			QueryParams.AddIgnoredActor(SkelComp.GetOwner());
+		}
+	}
 	// Owner が無いプレビューコンポーネントでも自分自身を収集しない。
-	QueryParams.AddIgnoredComponent(&SkelComp);
+	// ファミリーメンバー収集中は primary もメンバー Slot として publish するため無視しない（reader 側が自分の Slot だけ除外する）。
+	if (!bFilterFamilyMembers)
+	{
+		QueryParams.AddIgnoredComponent(&SkelComp);
+	}
 
 	Entry.OverlapScratch.Reset();
 	World.OverlapMultiByChannel(
@@ -1479,6 +2300,25 @@ void UKawaiiPhysicsSharedCollisionSubsystem::GatherSimpleWorldEntry(
 			continue;
 		}
 
+		const USkeletalMeshComponent* MemberSkelComp = nullptr;
+		if (bFilterFamilyMembers)
+		{
+			if (const USkeletalMeshComponent* HitSkelComp = Cast<const USkeletalMeshComponent>(Component))
+			{
+				if (MemberSkelCompSet.Contains(TWeakObjectPtr<const USkeletalMeshComponent>(HitSkelComp)))
+				{
+					MemberSkelComp = HitSkelComp;
+				}
+			}
+
+			if (!MemberSkelComp
+				&& ComponentOwner
+				&& MemberOwners.Contains(TWeakObjectPtr<const AActor>(ComponentOwner)))
+			{
+				continue;
+			}
+		}
+
 		int32 InstanceIndex = INDEX_NONE;
 		FTransform ComponentTM = GetScaleStrippedComponentTransform(*Component);
 		FVector Scale3D = Component->GetComponentScale();
@@ -1515,6 +2355,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::GatherSimpleWorldEntry(
 
 		FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent NewComponent;
 		NewComponent.Component = Component;
+		NewComponent.MemberSkelComp = MemberSkelComp;
 		NewComponent.InstanceIndex = InstanceIndex;
 		NewComponent.bStatic = IsSimpleWorldComponentStatic(*Component);
 		NewComponent.FadeAlpha = Entry.bHasGatheredOnce ? 0.0f : 1.0f;
@@ -1567,13 +2408,29 @@ void UKawaiiPhysicsSharedCollisionSubsystem::GatherSimpleWorldEntry(
 		bool bGroundChanged = false;
 		if (!TryUpdateSimpleWorldGroundBoxFromSource(Entry, SkelComp, Radius, bGroundChanged))
 		{
+			// 地面トレースはファミリー収集中でも自分と家族のメッシュに当たらないよう、Overlap とは別の無視設定を使う。
+			FCollisionQueryParams GroundQueryParams(SCENE_QUERY_STAT(KawaiiPhysicsSimpleWorldGround), false);
+			GroundQueryParams.bIgnoreTouches = true;
+			GroundQueryParams.AddIgnoredComponent(&SkelComp);
+			if (const AActor* SkelCompOwner = SkelComp.GetOwner())
+			{
+				GroundQueryParams.AddIgnoredActor(SkelCompOwner);
+			}
+			for (const TWeakObjectPtr<const AActor>& MemberOwner : MemberOwners)
+			{
+				if (const AActor* Owner = MemberOwner.Get())
+				{
+					GroundQueryParams.AddIgnoredActor(Owner);
+				}
+			}
+
 			FHitResult Hit;
 			const bool bHitGround = World.LineTraceSingleByChannel(
 				Hit,
 				Center,
 				Center - FVector(0.0f, 0.0f, GroundTraceLength),
 				CollisionChannel,
-				QueryParams,
+				GroundQueryParams,
 				ResponseParams);
 
 			FBoxLimit NewGroundBox;
@@ -1818,7 +2675,6 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 
 	struct FSimpleWorldTickEntry
 	{
-		TWeakObjectPtr<const USkeletalMeshComponent> SkelComp;
 		TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry;
 	};
 
@@ -1829,7 +2685,6 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 		for (const auto& Pair : SimpleWorldRegistry)
 		{
 			FSimpleWorldTickEntry TickEntry;
-			TickEntry.SkelComp = Pair.Key;
 			TickEntry.Entry = Pair.Value;
 			Entries.Add(MoveTemp(TickEntry));
 		}
@@ -1867,6 +2722,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 
 	int32 TotalGatheredComponents = 0;
 	int32 TotalSkeletalBodies = 0;
+	int32 TotalMemberSlots = 0;
 	for (const FSimpleWorldTickEntry& TickEntry : Entries)
 	{
 		const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>& Entry = TickEntry.Entry;
@@ -1879,7 +2735,94 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 
 		// 再収集要求は Desc スナップショットを取る前に消費する。消費後に届いた SetDesc は次 Tick で再収集され、
 		// 消費前の変更はこの Tick のスナップショットに含まれるため、変更が取りこぼされる窓が無い。
-		if (Entry->ConsumeRegatherRequested())
+		const bool bRegatherRequested = Entry->ConsumeRegatherRequested();
+
+		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+		if (!Entry->BuildMergedDesc(Desc))
+		{
+			if (bRegatherRequested)
+			{
+				Entry->GatheredComponents.Reset();
+				bool bGroundChanged = false;
+				ClearSimpleWorldGroundBox(*Entry, bGroundChanged);
+				Entry->GroundSource = EKawaiiPhysicsSimpleWorldGroundSource::None;
+				Entry->GroundProvider.Reset();
+				Entry->GroundCharacterMovement.Reset();
+				Entry->bHasGatheredOnce = false;
+				Entry->TimeSinceLastGather = FLT_MAX;
+				Entry->bWorldLimitsDirty = true;
+				Entry->bGroundBoxDirty = true;
+			}
+			continue;
+		}
+
+		const USkeletalMeshComponent* SkelComp = Entry->GetPrimarySkelComp();
+		if (!SkelComp)
+		{
+			continue;
+		}
+
+		Entry->MemberSkelCompScratch.Reset();
+		Entry->MemberSkelCompSetScratch.Reset();
+		Entry->MemberOwnerScratch.Reset();
+		Entry->MemberBoundsScratch.Reset();
+		if (Desc.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily || Desc.bGatherFamilyMembers)
+		{
+			Entry->CollectMemberSkelComps(Entry->MemberSkelCompScratch);
+			Entry->MemberSkelCompScratch.AddUnique(TWeakObjectPtr<const USkeletalMeshComponent>(SkelComp));
+			for (const TWeakObjectPtr<const USkeletalMeshComponent>& MemberSkelComp : Entry->MemberSkelCompScratch)
+			{
+				if (const USkeletalMeshComponent* Member = MemberSkelComp.Get())
+				{
+					Entry->MemberSkelCompSetScratch.Add(MemberSkelComp);
+					Entry->MemberBoundsScratch.Add(Member->Bounds);
+					if (const AActor* MemberOwner = Member->GetOwner())
+					{
+						Entry->MemberOwnerScratch.Add(TWeakObjectPtr<const AActor>(MemberOwner));
+					}
+				}
+			}
+		}
+
+		if (Desc.bGatherFamilyMembers)
+		{
+			Entry->RemoveMemberSlotsNotIn(Entry->MemberSkelCompScratch);
+		}
+		else
+		{
+			TArray<TWeakObjectPtr<const USkeletalMeshComponent>> EmptyMembers;
+			Entry->RemoveMemberSlotsNotIn(EmptyMembers);
+		}
+
+		FBoxSphereBounds GatherBounds = SkelComp->Bounds;
+		if (Desc.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily)
+		{
+			KawaiiPhysicsSimpleWorldCollision::ComputeSimpleWorldGatherBounds(
+				MakeArrayView(Entry->MemberBoundsScratch),
+				GatherBounds);
+		}
+
+		const FVector Center = GatherBounds.Origin;
+
+		// 収集半径はゲート/デバッグ描画の両方で使うため、bShouldGather判定より前に確定させる
+		const float AutoRadius = GatherBounds.SphereRadius * KawaiiSettings->SimpleWorldCollisionAutoGatherRadiusScale;
+		// 全ノードがOverride指定ならOverrideをそのまま使う（自動半径より小さくできる）。1つでも自動指定があれば自動半径を下限にする。
+		const float Radius = Desc.bGatherRadiusAllOverridden && Desc.GatherRadiusOverride > KINDA_SMALL_NUMBER
+			? Desc.GatherRadiusOverride
+			: (Desc.GatherRadiusOverride > KINDA_SMALL_NUMBER ? FMath::Max(AutoRadius, Desc.GatherRadiusOverride) : AutoRadius);
+		// 地面トレースの長さは収集半径の縮小に連動させない（Bounds原点から床までの距離は半径Overrideと無関係なため）。
+		// 地面BoxのXY半径はOverrideどおり。
+		const float GroundTraceLength = FMath::Max(Radius, AutoRadius);
+		const bool bGatherInputValid = KawaiiPhysicsSimpleWorldCollision::IsSimpleWorldGatherInputValid(Center, Radius);
+
+		if (Desc.bProviderDisabled)
+		{
+			PublishSimpleWorldEmptyLimits(*Entry, GSimpleWorldFadeBoxEnableThreshold);
+			TotalMemberSlots += Entry->GetNumMemberSlots();
+			continue;
+		}
+
+		if (bRegatherRequested)
 		{
 			Entry->GatheredComponents.Reset();
 			bool bGroundChanged = false;
@@ -1892,31 +2835,6 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 			Entry->bWorldLimitsDirty = true;
 			Entry->bGroundBoxDirty = true;
 		}
-
-		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
-		if (!Entry->BuildMergedDesc(Desc))
-		{
-			continue;
-		}
-
-		const USkeletalMeshComponent* SkelComp = TickEntry.SkelComp.Get();
-		if (!SkelComp)
-		{
-			continue;
-		}
-
-		const FVector Center = SkelComp->Bounds.Origin;
-
-		// 収集半径はゲート/デバッグ描画の両方で使うため、bShouldGather判定より前に確定させる
-		const float AutoRadius = SkelComp->Bounds.SphereRadius * KawaiiSettings->SimpleWorldCollisionAutoGatherRadiusScale;
-		// 全ノードがOverride指定ならOverrideをそのまま使う（自動半径より小さくできる）。1つでも自動指定があれば自動半径を下限にする。
-		const float Radius = Desc.bGatherRadiusAllOverridden && Desc.GatherRadiusOverride > KINDA_SMALL_NUMBER
-			? Desc.GatherRadiusOverride
-			: (Desc.GatherRadiusOverride > KINDA_SMALL_NUMBER ? FMath::Max(AutoRadius, Desc.GatherRadiusOverride) : AutoRadius);
-		// 地面トレースの長さは収集半径の縮小に連動させない（Bounds原点から床までの距離は半径Overrideと無関係なため）。
-		// 地面BoxのXY半径はOverrideどおり。
-		const float GroundTraceLength = FMath::Max(Radius, AutoRadius);
-		const bool bGatherInputValid = KawaiiPhysicsSimpleWorldCollision::IsSimpleWorldGatherInputValid(Center, Radius);
 
 		bool bAllowGather = true;
 		float EffectiveGatherInterval = Desc.GatherIntervalSec * GatherIntervalScale;
@@ -1960,7 +2878,10 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 				EffectiveMaxPhysicsAssetBodies,
 				EffectiveMaxConvexPlanes,
 				bUseMovementGround,
-				bBuildConvexDebugGeometry);
+				bBuildConvexDebugGeometry,
+				Entry->MemberSkelCompScratch,
+				Entry->MemberSkelCompSetScratch,
+				Entry->MemberOwnerScratch);
 		}
 		else if (bAllowGather)
 		{
@@ -1990,6 +2911,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 #endif
 
 		TotalGatheredComponents += Entry->GatheredComponents.Num();
+		TotalMemberSlots += Entry->GetNumMemberSlots();
 		for (const FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent :
 			Entry->GatheredComponents)
 		{
@@ -2000,6 +2922,7 @@ void UKawaiiPhysicsSharedCollisionSubsystem::TickSimpleWorldCollision(float Delt
 	// DWORDカウンタは毎フレームリセットされるため、CleanupゲートではなくSimpleWorldのTickごとに更新する。
 	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumGatheredComponents, TotalGatheredComponents);
 	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumSkeletalBodies, TotalSkeletalBodies);
+	SET_DWORD_STAT(STAT_KawaiiPhysics_SimpleWorldCollision_NumMemberSlots, TotalMemberSlots);
 }
 
 bool UKawaiiPhysicsSharedCollisionSubsystem::DoesSupportWorldType(const EWorldType::Type WorldType) const
@@ -2022,6 +2945,17 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Deinitialize()
 	{
 		FWriteScopeLock WriteLock(SimpleWorldRegistryLock);
 		SimpleWorldRegistry.Empty();
+	}
+	{
+		FWriteScopeLock WriteLock(SharedPublisherRegistryLock);
+		for (const TPair<FRegistryKey, TSharedPtr<FKawaiiPhysicsSharedPublisherEntry>>& Pair : SharedPublisherRegistry)
+		{
+			if (Pair.Value.IsValid())
+			{
+				Pair.Value->MarkExpired();
+			}
+		}
+		SharedPublisherRegistry.Empty();
 	}
 	Super::Deinitialize();
 }
@@ -2088,8 +3022,28 @@ void UKawaiiPhysicsSharedCollisionSubsystem::Tick(float DeltaTime)
 			}
 
 			It->Value->RemoveExpiredDescs(CurrentFrame, SimpleWorldCleanupMaxAge);
-			if (!It->Value->HasAnyDesc())
+			if (!It->Value->HasAnyDesc() && !It->Value->HasAnyReader())
 			{
+				It.RemoveCurrent();
+				continue;
+			}
+		}
+	}
+
+	{
+		FWriteScopeLock SharedPublisherWriteLock(SharedPublisherRegistryLock);
+		const int32 SharedPublisherCleanupMaxAge = CVarSharedCollisionCleanupMaxAge.GetValueOnGameThread();
+
+		for (auto It = SharedPublisherRegistry.CreateIterator(); It; ++It)
+		{
+			if (!It->Key.Key.IsValid()
+				|| !It->Value.IsValid()
+				|| It->Value->IsExpired(CurrentFrame, SharedPublisherCleanupMaxAge))
+			{
+				if (It->Value.IsValid())
+				{
+					It->Value->MarkExpired();
+				}
 				It.RemoveCurrent();
 				continue;
 			}
@@ -2109,7 +3063,14 @@ bool UKawaiiPhysicsSharedCollisionSubsystem::IsTickable() const
 	}
 	{
 		FReadScopeLock ReadLock(SimpleWorldRegistryLock);
-		return !SimpleWorldRegistry.IsEmpty();
+		if (!SimpleWorldRegistry.IsEmpty())
+		{
+			return true;
+		}
+	}
+	{
+		FReadScopeLock ReadLock(SharedPublisherRegistryLock);
+		return !SharedPublisherRegistry.IsEmpty();
 	}
 }
 

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedPublisherTypes.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedPublisherTypes.cpp
@@ -1,0 +1,3 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsSharedPublisherTypes.h"

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedTags.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSharedTags.cpp
@@ -1,0 +1,5 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#include "KawaiiPhysicsSharedTags.h"
+
+KAWAIIPHYSICS_API UE_DEFINE_GAMEPLAY_TAG(TAG_KawaiiPhysics_Shared_Default, "KawaiiPhysics.Shared.Default");

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/KawaiiPhysicsSimpleWorldCollision.cpp
@@ -2,6 +2,8 @@
 
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 
+#include "KawaiiPhysicsSharedPublisherTypes.h"
+
 #include "Algo/StableSort.h"
 #include "Engine/EngineTypes.h"
 #include "Misc/EngineVersionComparison.h"
@@ -878,5 +880,39 @@ namespace KawaiiPhysicsSimpleWorldCollision
 				ComponentTM, OutWorldLimits.ConvexLimits);
 		}
 		AppendTransformedPlanarLimits(LocalLimits.PlanarLimits, ComponentTM, OutWorldLimits.PlanarLimits);
+	}
+
+	bool ComputeSimpleWorldGatherBounds(
+		TArrayView<const FBoxSphereBounds> MemberBounds,
+		FBoxSphereBounds& OutBounds)
+	{
+		if (MemberBounds.IsEmpty())
+		{
+			return false;
+		}
+
+		OutBounds = MemberBounds[0];
+		for (int32 Index = 1; Index < MemberBounds.Num(); ++Index)
+		{
+			OutBounds = OutBounds + MemberBounds[Index];
+		}
+		return true;
+	}
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc BuildSimpleWorldCollisionDesc(
+		const FKawaiiPhysicsSimpleWorldCollisionSettings& Settings)
+	{
+		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+		Desc.GatherIntervalSec = Settings.GatherInterval;
+		Desc.GatherRadiusOverride = Settings.bOverrideGatherRadius ? Settings.GatherRadius : 0.0f;
+		Desc.CollisionChannel = Settings.bOverrideCollisionChannel ? Settings.CollisionChannel.GetValue() : ECC_MAX;
+		Desc.ObjectTypes = Settings.ObjectTypes;
+		Desc.ConvexFallbackShape = Settings.ConvexFallbackShape;
+		Desc.SkeletalMeshCollision = Settings.SkeletalMeshCollision;
+		Desc.bGroundCollision = Settings.bGroundCollision;
+		Desc.GatherScope = Settings.GatherScope;
+		Desc.bGatherFamilyMembers = Settings.bGatherFamilyMembers;
+		Desc.bProviderDisabled = !Settings.bEnabled;
+		return Desc;
 	}
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedPublisherTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSharedPublisherTest.cpp
@@ -4,9 +4,36 @@
 
 #include "Misc/AutomationTest.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
+#include "KawaiiPhysicsSharedPublisherTypes.h"
 #include "Engine/World.h"
 #include "HAL/IConsoleManager.h"
 #include "Misc/ScopeExit.h"
+
+namespace
+{
+	bool TestKawaiiPhysicsSharedPublisherWind(
+		FAutomationTestBase& Test,
+		const TCHAR* Context,
+		const FKawaiiPhysicsSharedWindState& Actual,
+		const FKawaiiPhysicsSharedWindState& Expected)
+	{
+		bool bResult = true;
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s bPublisherWindEnabled"), Context),
+			Actual.bPublisherWindEnabled, Expected.bPublisherWindEnabled);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s Time"), Context), Actual.Time, Expected.Time);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s PublisherTimeScale"), Context),
+			Actual.PublisherTimeScale, Expected.PublisherTimeScale);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s ConstantForce"), Context),
+			Actual.Params.ConstantForce, Expected.Params.ConstantForce);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s bOverrideConstantForce"), Context),
+			Actual.Params.bOverrideConstantForce, Expected.Params.bOverrideConstantForce);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s ActiveGust bIsActive"), Context),
+			Actual.ActiveGust.bIsActive, Expected.ActiveGust.bIsActive);
+		bResult &= Test.TestEqual(FString::Printf(TEXT("%s ActiveGust Strength"), Context),
+			Actual.ActiveGust.Strength, Expected.ActiveGust.Strength);
+		return bResult;
+	}
+}
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedCollisionSubsystemSupportsEditorPreviewTest,
                                  "KawaiiPhysics.SharedCollision.SubsystemSupportsEditorPreview",
@@ -62,6 +89,181 @@ bool FKawaiiPhysicsSharedCollisionSubsystemSupportsEditorPreviewTest::RunTest(co
 	World->WorldType = EWorldType::Game;
 	TestTrue(TEXT("Game world still creates subsystem when preview CVar is disabled"),
 	         CDO->ShouldCreateSubsystem(World));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedPublisherEntryPublishReadTest,
+                                 "KawaiiPhysics.SharedPublisher.EntryPublishRead",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSharedPublisherEntryPublishReadTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSharedPublisherEntry Entry;
+
+	// provider ID 0 は未所有の番兵と衝突するため拒否される。
+	{
+		FKawaiiPhysicsSharedPublisherState ZeroState;
+		const uint64 SerialBeforeZero = Entry.GetPublishSerial();
+		TestFalse(TEXT("Zero provider ID is rejected"), Entry.PublishState(ZeroState, 0, 1, 10));
+		TestEqual(TEXT("Zero provider ID keeps serial"), Entry.GetPublishSerial(), SerialBeforeZero);
+		TestEqual(TEXT("Zero provider ID leaves entry unowned"), Entry.GetProviderID(), static_cast<uint64>(0));
+	}
+
+	FKawaiiPhysicsSharedPublisherState State;
+	State.bSimpleWorldEnabled = true;
+	State.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+	State.SimpleWorldDesc.GatherIntervalSec = 0.05f;
+	State.SimpleWorldDesc.bGatherFamilyMembers = true;
+	State.Wind.bPublisherWindEnabled = true;
+	State.Wind.Time = 12.5f;
+	State.Wind.PublisherTimeScale = 0.5f;
+	State.Wind.Params.bOverrideConstantForce = true;
+	State.Wind.Params.ConstantForce = 3.0f;
+	State.Wind.ActiveGust.bIsActive = true;
+	State.Wind.ActiveGust.Strength = 7.0f;
+
+	TestTrue(TEXT("Initial provider publishes"), Entry.PublishState(State, 11, 100, 10));
+	TestEqual(TEXT("Publish serial after first publish"), Entry.GetPublishSerial(), static_cast<uint64>(1));
+	TestEqual(TEXT("Provider ID after first publish"), Entry.GetProviderID(), static_cast<uint64>(11));
+	TestEqual(TEXT("Last publish frame after first publish"), Entry.GetLastPublishFrame(), static_cast<uint64>(100));
+
+	FKawaiiPhysicsSharedPublisherState ReadState;
+	const uint64 ReadSerial = Entry.ReadState(ReadState);
+	TestEqual(TEXT("ReadState returns current serial"), ReadSerial, static_cast<uint64>(1));
+	TestTrue(TEXT("ReadState keeps SimpleWorld enabled"), ReadState.bSimpleWorldEnabled);
+	TestTrue(TEXT("ReadState keeps gather scope"),
+		ReadState.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily);
+	TestEqual(TEXT("ReadState keeps gather interval"), ReadState.SimpleWorldDesc.GatherIntervalSec, 0.05f);
+	TestTrue(TEXT("ReadState keeps family members flag"), ReadState.SimpleWorldDesc.bGatherFamilyMembers);
+	TestKawaiiPhysicsSharedPublisherWind(*this, TEXT("ReadState wind"), ReadState.Wind, State.Wind);
+
+	FKawaiiPhysicsSharedPublisherState BlockedState = State;
+	BlockedState.bSimpleWorldEnabled = false;
+	BlockedState.SimpleWorldDesc.GatherIntervalSec = 0.75f;
+	BlockedState.Wind.Time = 20.0f;
+	TestFalse(TEXT("Live different provider is rejected"), Entry.PublishState(BlockedState, 22, 105, 10));
+
+	FKawaiiPhysicsSharedPublisherState AfterRejected;
+	Entry.ReadState(AfterRejected);
+	TestTrue(TEXT("Rejected publish keeps SimpleWorld enabled"), AfterRejected.bSimpleWorldEnabled);
+	TestEqual(TEXT("Rejected publish keeps gather interval"), AfterRejected.SimpleWorldDesc.GatherIntervalSec, 0.05f);
+	TestEqual(TEXT("Rejected publish keeps wind time"), AfterRejected.Wind.Time, 12.5f);
+	TestEqual(TEXT("Rejected publish keeps serial"), Entry.GetPublishSerial(), static_cast<uint64>(1));
+
+	TestTrue(TEXT("Expired previous provider allows replacement"), Entry.PublishState(BlockedState, 22, 111, 10));
+	TestEqual(TEXT("Publish serial after provider replacement"), Entry.GetPublishSerial(), static_cast<uint64>(2));
+	TestEqual(TEXT("Provider ID after provider replacement"), Entry.GetProviderID(), static_cast<uint64>(22));
+	TestEqual(TEXT("Last publish frame after provider replacement"), Entry.GetLastPublishFrame(), static_cast<uint64>(111));
+
+	FKawaiiPhysicsSharedWindState ReadWind;
+	const uint64 WindSerial = Entry.ReadWindState(ReadWind);
+	TestEqual(TEXT("ReadWindState returns current serial"), WindSerial, static_cast<uint64>(2));
+	TestKawaiiPhysicsSharedPublisherWind(*this, TEXT("ReadWindState"), ReadWind, BlockedState.Wind);
+
+	TestFalse(TEXT("Entry is not expired within max age"), Entry.IsExpired(120, 10));
+	TestTrue(TEXT("Entry is expired beyond max age"), Entry.IsExpired(122, 10));
+	Entry.MarkExpired();
+	TestTrue(TEXT("MarkExpired makes entry expired"), Entry.IsExpired(111, 10));
+
+	// 期限切れ Entry は同じ provider が publish しても復活しない。
+	const uint64 ExpiredSerial = Entry.GetPublishSerial();
+	FKawaiiPhysicsSharedPublisherState RevivedState = BlockedState;
+	RevivedState.Wind.Time = 33.0f;
+	TestFalse(TEXT("Expired entry rejects publish"), Entry.PublishState(RevivedState, 22, 200, 10));
+	TestEqual(TEXT("Expired entry keeps serial"), Entry.GetPublishSerial(), ExpiredSerial);
+	TestTrue(TEXT("Expired entry stays expired"), Entry.IsExpired(200, 10));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedPublisherGustQueueTest,
+                                 "KawaiiPhysics.SharedPublisher.GustQueue",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSharedPublisherGustQueueTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSharedPublisherEntry Entry;
+	Entry.RequestGust(1.0f, 0.1f, 0.2f, 0.3f);
+	Entry.RequestGust(2.0f, 0.4f, 0.5f, 0.6f);
+	Entry.RequestGustStop(0.7f);
+
+	TArray<FKawaiiPhysicsSharedPublisherGustRequest> Requests;
+	Entry.ConsumePendingGustRequests(Requests);
+	TestEqual(TEXT("Consumes all gust requests"), Requests.Num(), 3);
+
+	if (Requests.Num() == 3)
+	{
+		TestFalse(TEXT("First request starts gust"), Requests[0].bStop);
+		TestEqual(TEXT("First request strength"), Requests[0].Strength, 1.0f);
+		TestEqual(TEXT("First request rise"), Requests[0].RiseTime, 0.1f);
+		TestEqual(TEXT("First request decay"), Requests[0].DecayTime, 0.2f);
+		TestEqual(TEXT("First request hold"), Requests[0].HoldTime, 0.3f);
+
+		TestFalse(TEXT("Second request starts gust"), Requests[1].bStop);
+		TestEqual(TEXT("Second request strength"), Requests[1].Strength, 2.0f);
+		TestEqual(TEXT("Second request rise"), Requests[1].RiseTime, 0.4f);
+		TestEqual(TEXT("Second request decay"), Requests[1].DecayTime, 0.5f);
+		TestEqual(TEXT("Second request hold"), Requests[1].HoldTime, 0.6f);
+
+		TestTrue(TEXT("Third request stops gust"), Requests[2].bStop);
+		TestEqual(TEXT("Third request blend out"), Requests[2].BlendOutTime, 0.7f);
+	}
+
+	Requests.Reset();
+	Entry.ConsumePendingGustRequests(Requests);
+	TestEqual(TEXT("Second consume is empty"), Requests.Num(), 0);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSharedPublisherPublisherRequestQueueTest,
+                                 "KawaiiPhysics.SharedPublisher.PublisherRequestQueue",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSharedPublisherPublisherRequestQueueTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSharedPublisherEntry Entry;
+
+	FKawaiiPhysicsSimpleWorldCollisionSettings Settings;
+	Settings.GatherInterval = 0.4f;
+	Settings.bGatherFamilyMembers = true;
+	Entry.RequestPublisherEnabled(false);
+	Entry.RequestSimpleWorldSettings(Settings);
+
+	FKawaiiPhysicsSharedPublisherEntry::FPendingPublisherRequests Requests;
+	TestTrue(TEXT("Consumes pending publisher requests"), Entry.ConsumePendingPublisherRequests(Requests));
+	TestTrue(TEXT("Enabled request is set"), Requests.Enabled.IsSet());
+	if (Requests.Enabled.IsSet())
+	{
+		TestFalse(TEXT("Enabled request value is false"), Requests.Enabled.GetValue());
+	}
+	TestTrue(TEXT("SimpleWorld settings request is set"), Requests.SimpleWorldSettings.IsSet());
+	if (Requests.SimpleWorldSettings.IsSet())
+	{
+		TestEqual(TEXT("SimpleWorld settings gather interval"),
+			Requests.SimpleWorldSettings.GetValue().GatherInterval, 0.4f);
+		TestTrue(TEXT("SimpleWorld settings family members flag"),
+			Requests.SimpleWorldSettings.GetValue().bGatherFamilyMembers);
+	}
+
+	FKawaiiPhysicsSharedPublisherEntry::FPendingPublisherRequests EmptyRequests;
+	TestFalse(TEXT("Second publisher request consume is empty"),
+		Entry.ConsumePendingPublisherRequests(EmptyRequests));
+
+	FKawaiiPhysicsSimpleWorldCollisionSettings DefaultSettings;
+	const FKawaiiPhysicsSimpleWorldCollisionDesc DefaultDesc =
+		KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldCollisionDesc(DefaultSettings);
+	TestTrue(TEXT("Default settings use ActorFamily gather scope"),
+		DefaultDesc.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily);
+	TestFalse(TEXT("Default settings keep provider enabled"), DefaultDesc.bProviderDisabled);
+	TestTrue(TEXT("Default settings keep collision channel unspecified"), DefaultDesc.CollisionChannel == ECC_MAX);
+	TestFalse(TEXT("Default settings do not gather family members"), DefaultDesc.bGatherFamilyMembers);
+
+	DefaultSettings.bEnabled = false;
+	const FKawaiiPhysicsSimpleWorldCollisionDesc DisabledDesc =
+		KawaiiPhysicsSimpleWorldCollision::BuildSimpleWorldCollisionDesc(DefaultSettings);
+	TestTrue(TEXT("Disabled settings disable provider"), DisabledDesc.bProviderDisabled);
 
 	return true;
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsSimpleWorldCollisionTest.cpp
@@ -8,7 +8,9 @@
 #include "KawaiiPhysicsSimpleWorldCollision.h"
 #include "KawaiiPhysicsSharedCollisionSubsystem.h"
 #include "Animation/AnimInstanceProxy.h"
+#include "Components/SkeletalMeshComponent.h"
 #include "Components/StaticMeshComponent.h"
+#include "NativeGameplayTags.h"
 #include "Misc/EngineVersionComparison.h"
 #include "PhysicsEngine/PhysicsAsset.h"
 
@@ -19,6 +21,9 @@
 #include "UObject/Package.h"
 
 #include <limits>
+
+UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysicsSimpleWorldRegistryX, "KawaiiPhysics.Test.SimpleWorld.Registry.X");
+UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_KawaiiPhysicsSimpleWorldRegistryY, "KawaiiPhysics.Test.SimpleWorld.Registry.Y");
 
 // シンプルワールドコリジョン（KawaiiPhysicsSimpleWorldCollision namespace / SharedCollisionSubsystem の関連構造体）の単体テスト。
 // AggGeom→Limit変換、ローカル→ワールド変換、フェード、Desc Merge、Entryのライフサイクル、ハーネス経由のpush-out統合を検証する。
@@ -155,6 +160,99 @@ namespace
 		Data.BoxLimits.Add(GroundBox);
 
 		return Data;
+	}
+
+	FSphericalLimit MakeSimpleWorldReaderSphere(const FVector& Location)
+	{
+		FSphericalLimit Sphere;
+		Sphere.Location = Location;
+		Sphere.Radius = 8.0f;
+		Sphere.LimitType = ESphericalLimitType::Outer;
+		Sphere.bEnable = true;
+		Sphere.SourceType = ECollisionSourceType::SimpleWorld;
+		return Sphere;
+	}
+
+	FCapsuleLimit MakeSimpleWorldReaderCapsule(const FVector& Location)
+	{
+		FCapsuleLimit Capsule;
+		Capsule.Location = Location;
+		Capsule.Rotation = FQuat::Identity;
+		Capsule.Radius = 5.0f;
+		Capsule.Length = 24.0f;
+		Capsule.bEnable = true;
+		Capsule.SourceType = ECollisionSourceType::SimpleWorld;
+		return Capsule;
+	}
+
+	FBoxLimit MakeSimpleWorldReaderBox(const FVector& Location)
+	{
+		FBoxLimit Box;
+		Box.Location = Location;
+		Box.Rotation = FQuat::Identity;
+		Box.Extent = FVector(10.0f, 12.0f, 14.0f);
+		Box.bEnable = true;
+		Box.SourceType = ECollisionSourceType::SimpleWorld;
+		return Box;
+	}
+
+	FKawaiiPhysicsSharedPublisherState MakeSimpleWorldReaderState(bool bProviderDisabled)
+	{
+		FKawaiiPhysicsSharedPublisherState State;
+		State.bSimpleWorldEnabled = true;
+		State.SimpleWorldDesc.bGatherFamilyMembers = true;
+		State.SimpleWorldDesc.bProviderDisabled = bProviderDisabled;
+		return State;
+	}
+
+	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> MakeSimpleWorldReaderEntry(
+		USkeletalMeshComponent* SkelCompA,
+		USkeletalMeshComponent* SkelCompB)
+	{
+		TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+			MakeShared<FKawaiiPhysicsSimpleWorldCollisionEntry>();
+
+		// メンバー Slot は登録済みメンバーにしか残らないため、A / B を reader として先に登録しておく。
+		Entry->AddReaderMember(0xFFFF0002ull, SkelCompA, GFrameCounter);
+		Entry->AddReaderMember(0xFFFF0003ull, SkelCompB, GFrameCounter);
+
+		FKawaiiPhysicsSharedCollisionData MainData;
+		MainData.BoxLimits.Add(MakeSimpleWorldReaderBox(FVector(10.0f, 0.0f, 0.0f)));
+		Entry->Slot.Publish(MainData);
+
+		FKawaiiPhysicsSharedCollisionData GroundData;
+		GroundData.BoxLimits.Add(MakeSimpleWorldReaderBox(FVector(0.0f, 0.0f, -20.0f)));
+		Entry->GroundSlot.Publish(GroundData);
+
+		FKawaiiPhysicsSharedCollisionData MemberAData;
+		MemberAData.SphericalLimits.Add(MakeSimpleWorldReaderSphere(FVector(20.0f, 0.0f, 0.0f)));
+		TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>& MemberASlot =
+			Entry->MemberSlots.FindOrAdd(TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompA));
+		MemberASlot = MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>();
+		MemberASlot->Publish(MemberAData);
+
+		FKawaiiPhysicsSharedCollisionData MemberBData;
+		MemberBData.CapsuleLimits.Add(MakeSimpleWorldReaderCapsule(FVector(30.0f, 0.0f, 0.0f)));
+		TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>& MemberBSlot =
+			Entry->MemberSlots.FindOrAdd(TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompB));
+		MemberBSlot = MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>();
+		MemberBSlot->Publish(MemberBData);
+
+		return Entry;
+	}
+
+	void PublishSimpleWorldReaderMemberBExtraSphere(
+		FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
+		USkeletalMeshComponent* SkelCompB)
+	{
+		FKawaiiPhysicsSharedCollisionData MemberBData;
+		MemberBData.CapsuleLimits.Add(MakeSimpleWorldReaderCapsule(FVector(30.0f, 0.0f, 0.0f)));
+		MemberBData.SphericalLimits.Add(MakeSimpleWorldReaderSphere(FVector(40.0f, 0.0f, 0.0f)));
+		if (TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>* MemberBSlot =
+			Entry.MemberSlots.Find(TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompB)))
+		{
+			(*MemberBSlot)->Publish(MemberBData);
+		}
 	}
 }
 
@@ -1212,6 +1310,337 @@ bool FKawaiiPhysicsSimpleWorldGatherInputValidTest::RunTest(const FString& Param
 }
 
 // ---------------------------------------------------------------------------
+//  SimpleWorld Registry / provider-reader backend
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldRegistryKeyTest,
+                                 "KawaiiPhysics.SimpleWorld.RegistryKey",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldRegistryKeyTest::RunTest(const FString& Parameters)
+{
+	USkeletalMeshComponent* SkelCompA = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompB = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	const FKawaiiPhysicsSimpleWorldRegistryKey LocalA0 =
+		FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(SkelCompA);
+	const FKawaiiPhysicsSimpleWorldRegistryKey LocalA1 =
+		FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(SkelCompA);
+	const FKawaiiPhysicsSimpleWorldRegistryKey LocalB =
+		FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(SkelCompB);
+
+	TestTrue(TEXT("MakeLocalKey returns equal keys for the same component"), LocalA0 == LocalA1);
+	TestFalse(TEXT("MakeLocalKey separates different components"), LocalA0 == LocalB);
+	TestEqual(TEXT("Equivalent local keys have the same hash"), GetTypeHash(LocalA0), GetTypeHash(LocalA1));
+
+	FKawaiiPhysicsSimpleWorldRegistryKey SharedX;
+	SharedX.KeyObject = GetTransientPackage();
+	SharedX.Tag = TAG_KawaiiPhysicsSimpleWorldRegistryX;
+	FKawaiiPhysicsSimpleWorldRegistryKey SharedY;
+	SharedY.KeyObject = GetTransientPackage();
+	SharedY.Tag = TAG_KawaiiPhysicsSimpleWorldRegistryY;
+	TestFalse(TEXT("Shared keys with different tags are different"), SharedX == SharedY);
+	TestFalse(TEXT("MakeSharedKey separates different tags"),
+	          FKawaiiPhysicsSimpleWorldRegistryKey::MakeSharedKey(nullptr, TAG_KawaiiPhysicsSimpleWorldRegistryX) ==
+	          FKawaiiPhysicsSimpleWorldRegistryKey::MakeSharedKey(nullptr, TAG_KawaiiPhysicsSimpleWorldRegistryY));
+
+	TMap<FKawaiiPhysicsSimpleWorldRegistryKey, int32> Registry;
+	Registry.Add(LocalA0, 42);
+	const int32* FoundValue = Registry.Find(LocalA1);
+	TestTrue(TEXT("Registry key works as a TMap key"), FoundValue && *FoundValue == 42);
+
+	// Worker から呼ぶ弱参照版 MakeLocalKey は raw ポインタ版と同じキーになり、IsValid() も一致する。
+	const FKawaiiPhysicsSimpleWorldRegistryKey WeakLocalA =
+		FKawaiiPhysicsSimpleWorldRegistryKey::MakeLocalKey(TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompA));
+	TestTrue(TEXT("Weak MakeLocalKey equals the raw pointer key"), WeakLocalA == LocalA0);
+	TestEqual(TEXT("Weak MakeLocalKey has the same hash as the raw pointer key"),
+	          GetTypeHash(WeakLocalA), GetTypeHash(LocalA0));
+	TestTrue(TEXT("Weak MakeLocalKey is valid"), WeakLocalA.IsValid());
+
+	const FKawaiiPhysicsSimpleWorldRegistryKey DefaultKey;
+	TestFalse(TEXT("Default-constructed key is invalid"), DefaultKey.IsValid());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldProviderDescWinsTest,
+                                 "KawaiiPhysics.SimpleWorld.ProviderDescWins",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldProviderDescWinsTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderSourceID = 1;
+	constexpr uint64 ReaderSourceID0 = 2;
+	constexpr uint64 ReaderSourceID1 = 3;
+	constexpr uint64 Frame = 100;
+
+	USkeletalMeshComponent* ProviderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp0 =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp1 =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc ProviderDesc;
+	ProviderDesc.GatherIntervalSec = 0.05f;
+	ProviderDesc.GatherRadiusOverride = 120.0f;
+	ProviderDesc.bGatherRadiusAllOverridden = true;
+	ProviderDesc.CollisionChannel = ECC_Visibility;
+	ProviderDesc.ObjectTypes = {UEngineTypes::ConvertToObjectType(ECC_WorldStatic)};
+	ProviderDesc.bGroundCollision = false;
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc ReaderDesc;
+	ReaderDesc.GatherIntervalSec = 0.5f;
+	ReaderDesc.GatherRadiusOverride = 600.0f;
+	ReaderDesc.CollisionChannel = ECC_Pawn;
+	ReaderDesc.ObjectTypes = {UEngineTypes::ConvertToObjectType(ECC_Pawn)};
+	ReaderDesc.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	Entry.SetDesc(ProviderSourceID, ProviderDesc, Frame, ProviderSkelComp, true);
+	Entry.SetDesc(ReaderSourceID0, ReaderDesc, Frame, ReaderSkelComp0, false);
+	Entry.SetDesc(ReaderSourceID1, ReaderDesc, Frame, ReaderSkelComp1, false);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedDesc;
+	TestTrue(TEXT("BuildMergedDesc succeeds with one provider and readers"), Entry.BuildMergedDesc(MergedDesc));
+	TestTrue(TEXT("Merged desc comes from the provider"), MergedDesc == ProviderDesc);
+	TestEqual(TEXT("Reader count"), Entry.GetNumReaders(), 2);
+	TestTrue(TEXT("Provider desc exists"), Entry.HasProviderDesc());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldReaderMembersLifecycleTest,
+                                 "KawaiiPhysics.SimpleWorld.ReaderMembersLifecycle",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldReaderMembersLifecycleTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ReaderSourceID = 10;
+	constexpr uint64 ProviderSourceID = 11;
+	constexpr uint64 StartFrame = 100;
+	constexpr uint64 MaxAge = 5;
+
+	USkeletalMeshComponent* ReaderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	FKawaiiPhysicsSimpleWorldCollisionEntry ReaderEntry;
+	ReaderEntry.AddReaderMember(ReaderSourceID, ReaderSkelComp, StartFrame);
+	TestTrue(TEXT("AddReaderMember creates reader membership"), ReaderEntry.HasAnyReader());
+	TestFalse(TEXT("MarkReaderRead returns false without a provider"),
+	          ReaderEntry.MarkReaderRead(ReaderSourceID, StartFrame + 10, MaxAge));
+	ReaderEntry.RemoveExpiredDescs(StartFrame + 10 + MaxAge, MaxAge);
+	TestTrue(TEXT("Reader survives at exactly MaxAge after MarkReaderRead"), ReaderEntry.HasAnyReader());
+	ReaderEntry.RemoveExpiredDescs(StartFrame + 10 + MaxAge + 1, MaxAge);
+	TestFalse(TEXT("Reader expires after MaxAge"), ReaderEntry.HasAnyReader());
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry ProviderEntry;
+	FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+	ProviderEntry.SetDesc(ProviderSourceID, Desc, StartFrame, ReaderSkelComp, true);
+	ProviderEntry.RemoveExpiredDescs(StartFrame + MaxAge + 1, MaxAge);
+	TestFalse(TEXT("Provider expires with the same age rule"), ProviderEntry.HasAnyDesc());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldReaderReleasedWhenProviderExpiresTest,
+                                 "KawaiiPhysics.SimpleWorld.ReaderReleasedWhenProviderExpires",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldReaderReleasedWhenProviderExpiresTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderSourceID = 20;
+	constexpr uint64 ReaderSourceID = 21;
+	constexpr uint64 ProviderFrame = 100;
+	constexpr uint64 ProviderMaxAge = 60;
+
+	USkeletalMeshComponent* ProviderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+	Entry.SetDesc(ProviderSourceID, Desc, ProviderFrame, ProviderSkelComp, true);
+	Entry.AddReaderMember(ReaderSourceID, ReaderSkelComp, ProviderFrame);
+
+	TestTrue(TEXT("Reader keeps membership while provider is within max age"),
+	         Entry.MarkReaderRead(ReaderSourceID, ProviderFrame + ProviderMaxAge, ProviderMaxAge));
+	TestFalse(TEXT("Reader releases after provider exceeds max age"),
+	          Entry.MarkReaderRead(ReaderSourceID, ProviderFrame + ProviderMaxAge + 1, ProviderMaxAge));
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry ReaderOnlyEntry;
+	ReaderOnlyEntry.AddReaderMember(ReaderSourceID, ReaderSkelComp, ProviderFrame);
+	TestFalse(TEXT("Reader releases when no provider exists"),
+	          ReaderOnlyEntry.MarkReaderRead(ReaderSourceID, ProviderFrame + 1, ProviderMaxAge));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldReaderKeepsMembershipWhenProviderDisabledTest,
+                                 "KawaiiPhysics.SimpleWorld.ReaderKeepsMembershipWhenProviderDisabled",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldReaderKeepsMembershipWhenProviderDisabledTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderSourceID = 30;
+	constexpr uint64 ReaderSourceID = 31;
+	constexpr uint64 Frame = 100;
+
+	USkeletalMeshComponent* ProviderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc DisabledDesc;
+	DisabledDesc.bProviderDisabled = true;
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	Entry.SetDesc(ProviderSourceID, DisabledDesc, Frame, ProviderSkelComp, true);
+	Entry.AddReaderMember(ReaderSourceID, ReaderSkelComp, Frame);
+
+	TestTrue(TEXT("Disabled provider is still live for readers"),
+	         Entry.MarkReaderRead(ReaderSourceID, Frame + 1, 60));
+	TestTrue(TEXT("Merged provider disabled state is true"), Entry.IsProviderDisabled());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldPrimaryIsProviderSkelCompTest,
+                                 "KawaiiPhysics.SimpleWorld.PrimaryIsProviderSkelComp",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldPrimaryIsProviderSkelCompTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderSourceID = 40;
+	constexpr uint64 ReaderSourceID = 41;
+	constexpr uint64 Frame = 100;
+
+	USkeletalMeshComponent* ProviderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+	Entry.SetDesc(ProviderSourceID, Desc, Frame, ProviderSkelComp, true);
+	Entry.AddReaderMember(ReaderSourceID, ReaderSkelComp, Frame);
+
+	TestTrue(TEXT("Primary component is the provider component"), Entry.GetPrimarySkelComp() == ProviderSkelComp);
+
+	TArray<TWeakObjectPtr<const USkeletalMeshComponent>> Members;
+	Entry.CollectMemberSkelComps(Members);
+	TestEqual(TEXT("CollectMemberSkelComps returns provider and reader once"), Members.Num(), 2);
+	TestTrue(TEXT("Collected members contain provider"),
+	         Members.Contains(TWeakObjectPtr<const USkeletalMeshComponent>(ProviderSkelComp)));
+	TestTrue(TEXT("Collected members contain reader"),
+	         Members.Contains(TWeakObjectPtr<const USkeletalMeshComponent>(ReaderSkelComp)));
+
+	Entry.RemoveDesc(ProviderSourceID);
+	TestTrue(TEXT("Primary component is null after removing the provider"), Entry.GetPrimarySkelComp() == nullptr);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldDescMergeGatherScopeTest,
+                                 "KawaiiPhysics.SimpleWorld.DescMergeGatherScope",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldDescMergeGatherScopeTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSimpleWorldCollisionDesc SkeletalScopeDesc;
+	SkeletalScopeDesc.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::SkeletalMeshComponent;
+	FKawaiiPhysicsSimpleWorldCollisionDesc ActorFamilyDesc;
+	ActorFamilyDesc.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedScope =
+		FKawaiiPhysicsSimpleWorldCollisionDesc::Merge({SkeletalScopeDesc, ActorFamilyDesc});
+	TestTrue(TEXT("ActorFamily gather scope wins merge"),
+	         MergedScope.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc NoFamilyMembers;
+	NoFamilyMembers.bGatherFamilyMembers = false;
+	FKawaiiPhysicsSimpleWorldCollisionDesc WithFamilyMembers;
+	WithFamilyMembers.bGatherFamilyMembers = true;
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedFamilyMembers =
+		FKawaiiPhysicsSimpleWorldCollisionDesc::Merge({NoFamilyMembers, WithFamilyMembers});
+	TestTrue(TEXT("bGatherFamilyMembers merges with OR"), MergedFamilyMembers.bGatherFamilyMembers);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc DisabledProvider;
+	DisabledProvider.bProviderDisabled = true;
+	FKawaiiPhysicsSimpleWorldCollisionDesc EnabledProvider;
+	EnabledProvider.bProviderDisabled = false;
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedMixedDisabled =
+		FKawaiiPhysicsSimpleWorldCollisionDesc::Merge({DisabledProvider, EnabledProvider});
+	TestFalse(TEXT("bProviderDisabled true+false merges to false"), MergedMixedDisabled.bProviderDisabled);
+	FKawaiiPhysicsSimpleWorldCollisionDesc MergedAllDisabled =
+		FKawaiiPhysicsSimpleWorldCollisionDesc::Merge({DisabledProvider, DisabledProvider});
+	TestTrue(TEXT("bProviderDisabled true+true merges to true"), MergedAllDisabled.bProviderDisabled);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc Base;
+	FKawaiiPhysicsSimpleWorldCollisionDesc GatherScopeChanged = Base;
+	GatherScopeChanged.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+	TestTrue(TEXT("DoesChangeRequireRegather detects GatherScope"),
+	         FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(Base, GatherScopeChanged));
+	FKawaiiPhysicsSimpleWorldCollisionDesc FamilyMembersChanged = Base;
+	FamilyMembersChanged.bGatherFamilyMembers = true;
+	TestTrue(TEXT("DoesChangeRequireRegather detects bGatherFamilyMembers"),
+	         FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(Base, FamilyMembersChanged));
+	FKawaiiPhysicsSimpleWorldCollisionDesc ProviderDisabledChanged = Base;
+	ProviderDisabledChanged.bProviderDisabled = true;
+	TestTrue(TEXT("DoesChangeRequireRegather detects bProviderDisabled"),
+	         FKawaiiPhysicsSimpleWorldCollisionDesc::DoesChangeRequireRegather(Base, ProviderDisabledChanged));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldGatherBoundsUnionTest,
+                                 "KawaiiPhysics.SimpleWorld.GatherBoundsUnion",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldGatherBoundsUnionTest::RunTest(const FString& Parameters)
+{
+	TArray<FBoxSphereBounds> EmptyBounds;
+	FBoxSphereBounds OutBounds;
+	TestFalse(TEXT("Empty bounds input returns false"),
+	          KawaiiPhysicsSimpleWorldCollision::ComputeSimpleWorldGatherBounds(MakeArrayView(EmptyBounds), OutBounds));
+
+	TArray<FBoxSphereBounds> SingleBounds;
+	SingleBounds.Add(FBoxSphereBounds(FVector(10.0f, 20.0f, 30.0f), FVector(4.0f, 5.0f, 6.0f), 7.0f));
+	TestTrue(TEXT("Single bounds input returns true"),
+	         KawaiiPhysicsSimpleWorldCollision::ComputeSimpleWorldGatherBounds(MakeArrayView(SingleBounds), OutBounds));
+	TestTrue(TEXT("Single bounds origin unchanged"), OutBounds.Origin.Equals(SingleBounds[0].Origin, GSimpleWorldTol));
+	TestTrue(TEXT("Single bounds extent unchanged"), OutBounds.BoxExtent.Equals(SingleBounds[0].BoxExtent, GSimpleWorldTol));
+	TestTrue(TEXT("Single bounds radius unchanged"),
+	         FMath::IsNearlyEqual(OutBounds.SphereRadius, SingleBounds[0].SphereRadius, GSimpleWorldTol));
+
+	TArray<FBoxSphereBounds> PairBounds;
+	PairBounds.Add(FBoxSphereBounds(FVector(0.0f, 0.0f, 0.0f), FVector(10.0f, 10.0f, 10.0f), 10.0f));
+	PairBounds.Add(FBoxSphereBounds(FVector(100.0f, 0.0f, 0.0f), FVector(5.0f, 5.0f, 5.0f), 5.0f));
+	TestTrue(TEXT("Pair bounds input returns true"),
+	         KawaiiPhysicsSimpleWorldCollision::ComputeSimpleWorldGatherBounds(MakeArrayView(PairBounds), OutBounds));
+
+	const FBox UnionBox = OutBounds.GetBox();
+	const FBox FirstBox = PairBounds[0].GetBox();
+	const FBox SecondBox = PairBounds[1].GetBox();
+	TestTrue(TEXT("Union min contains both boxes"),
+	         UnionBox.Min.X <= FirstBox.Min.X + GSimpleWorldTol &&
+	         UnionBox.Min.Y <= FirstBox.Min.Y + GSimpleWorldTol &&
+	         UnionBox.Min.Z <= FirstBox.Min.Z + GSimpleWorldTol &&
+	         UnionBox.Min.X <= SecondBox.Min.X + GSimpleWorldTol &&
+	         UnionBox.Min.Y <= SecondBox.Min.Y + GSimpleWorldTol &&
+	         UnionBox.Min.Z <= SecondBox.Min.Z + GSimpleWorldTol);
+	TestTrue(TEXT("Union max contains both boxes"),
+	         UnionBox.Max.X + GSimpleWorldTol >= FirstBox.Max.X &&
+	         UnionBox.Max.Y + GSimpleWorldTol >= FirstBox.Max.Y &&
+	         UnionBox.Max.Z + GSimpleWorldTol >= FirstBox.Max.Z &&
+	         UnionBox.Max.X + GSimpleWorldTol >= SecondBox.Max.X &&
+	         UnionBox.Max.Y + GSimpleWorldTol >= SecondBox.Max.Y &&
+	         UnionBox.Max.Z + GSimpleWorldTol >= SecondBox.Max.Z);
+	TestTrue(TEXT("Union extent spans separated bounds"), OutBounds.BoxExtent.X > PairBounds[0].BoxExtent.X);
+	TestTrue(TEXT("Union sphere radius spans separated bounds"), OutBounds.SphereRadius > PairBounds[0].SphereRadius);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
 //  FKawaiiPhysicsSimpleWorldCollisionDesc::Merge
 // ---------------------------------------------------------------------------
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldDescMergeTest,
@@ -1760,6 +2189,222 @@ bool FKawaiiPhysicsSimpleWorldGatherOrderSkippedForZeroCapTest::RunTest(const FS
 	return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldFamilyMemberSlotsExcludeSelfTest,
+                                 "KawaiiPhysics.SimpleWorld.FamilyMemberSlotsExcludeSelf",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldFamilyMemberSlotsExcludeSelfTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	USkeletalMeshComponent* SkelCompX = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompY = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& NormalComponent =
+		Entry.GatheredComponents.AddDefaulted_GetRef();
+	NormalComponent.FadeAlpha = 1.0f;
+	NormalComponent.LastComponentTM = FTransform::Identity;
+	FSphericalLimit NormalSphere;
+	NormalSphere.Location = FVector(1.0f, 0.0f, 0.0f);
+	NormalSphere.Radius = 10.0f;
+	NormalSphere.bEnable = true;
+	NormalSphere.SourceType = ECollisionSourceType::SimpleWorld;
+	NormalComponent.LocalLimits.SphericalLimits.Add(NormalSphere);
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& MemberXComponent =
+		Entry.GatheredComponents.AddDefaulted_GetRef();
+	MemberXComponent.MemberSkelComp = SkelCompX;
+	MemberXComponent.FadeAlpha = 1.0f;
+	MemberXComponent.LastComponentTM = FTransform::Identity;
+	FSphericalLimit SphereX = NormalSphere;
+	SphereX.Location = FVector(20.0f, 0.0f, 0.0f);
+	MemberXComponent.LocalLimits.SphericalLimits.Add(SphereX);
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& MemberYComponent =
+		Entry.GatheredComponents.AddDefaulted_GetRef();
+	MemberYComponent.MemberSkelComp = SkelCompY;
+	MemberYComponent.FadeAlpha = 1.0f;
+	MemberYComponent.LastComponentTM = FTransform::Identity;
+	FSphericalLimit SphereY = NormalSphere;
+	SphereY.Location = FVector(30.0f, 0.0f, 0.0f);
+	MemberYComponent.LocalLimits.SphericalLimits.Add(SphereY);
+
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(Entry, 0.5f);
+
+	FKawaiiPhysicsSharedCollisionData MainOutData;
+	Entry.Slot.AppendTo(MainOutData);
+	TestEqual(TEXT("Main slot contains only the regular shape"), MainOutData.SphericalLimits.Num(), 1);
+	if (MainOutData.SphericalLimits.Num() == 1)
+	{
+		TestTrue(TEXT("Main slot regular shape location"),
+		         MainOutData.SphericalLimits[0].Location.Equals(FVector(1.0f, 0.0f, 0.0f), GSimpleWorldTol));
+	}
+
+	const TWeakObjectPtr<const USkeletalMeshComponent> KeyX(SkelCompX);
+	const TWeakObjectPtr<const USkeletalMeshComponent> KeyY(SkelCompY);
+	TestTrue(TEXT("Member slot X exists"), Entry.MemberSlots.Contains(KeyX));
+	TestTrue(TEXT("Member slot Y exists"), Entry.MemberSlots.Contains(KeyY));
+
+	FKawaiiPhysicsSharedCollisionData MemberXOutData;
+	if (const TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>* SlotX = Entry.MemberSlots.Find(KeyX))
+	{
+		(*SlotX)->AppendTo(MemberXOutData);
+	}
+	TestEqual(TEXT("Member slot X contains one shape"), MemberXOutData.SphericalLimits.Num(), 1);
+	if (MemberXOutData.SphericalLimits.Num() == 1)
+	{
+		TestTrue(TEXT("Member slot X shape location"),
+		         MemberXOutData.SphericalLimits[0].Location.Equals(FVector(20.0f, 0.0f, 0.0f), GSimpleWorldTol));
+	}
+
+	FKawaiiPhysicsSharedCollisionData MemberYOutData;
+	if (const TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>* SlotY = Entry.MemberSlots.Find(KeyY))
+	{
+		(*SlotY)->AppendTo(MemberYOutData);
+	}
+	TestEqual(TEXT("Member slot Y contains one shape"), MemberYOutData.SphericalLimits.Num(), 1);
+	if (MemberYOutData.SphericalLimits.Num() == 1)
+	{
+		TestTrue(TEXT("Member slot Y shape location"),
+		         MemberYOutData.SphericalLimits[0].Location.Equals(FVector(30.0f, 0.0f, 0.0f), GSimpleWorldTol));
+	}
+
+	FKawaiiPhysicsSharedCollisionData OutForX;
+	Entry.AppendFamilyMemberLimits(SkelCompX, OutForX);
+	TestEqual(TEXT("Append for X excludes self and includes Y"), OutForX.SphericalLimits.Num(), 1);
+	if (OutForX.SphericalLimits.Num() == 1)
+	{
+		TestTrue(TEXT("Append for X contains Y shape"),
+		         OutForX.SphericalLimits[0].Location.Equals(FVector(30.0f, 0.0f, 0.0f), GSimpleWorldTol));
+	}
+
+	FKawaiiPhysicsSharedCollisionData OutForY;
+	Entry.AppendFamilyMemberLimits(SkelCompY, OutForY);
+	TestEqual(TEXT("Append for Y excludes self and includes X"), OutForY.SphericalLimits.Num(), 1);
+	if (OutForY.SphericalLimits.Num() == 1)
+	{
+		TestTrue(TEXT("Append for Y contains X shape"),
+		         OutForY.SphericalLimits[0].Location.Equals(FVector(20.0f, 0.0f, 0.0f), GSimpleWorldTol));
+	}
+
+	FKawaiiPhysicsSharedCollisionData OutForNull;
+	Entry.AppendFamilyMemberLimits(TWeakObjectPtr<const USkeletalMeshComponent>(), OutForNull);
+	TestEqual(TEXT("Append for null includes both member shapes"), OutForNull.SphericalLimits.Num(), 2);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldMemberSlotRemovedWithMemberTest,
+                                 "KawaiiPhysics.SimpleWorld.MemberSlotRemovedWithMember",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldMemberSlotRemovedWithMemberTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderID = 501;
+	constexpr uint64 ReaderID = 502;
+	USkeletalMeshComponent* SkelCompX = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompY = NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+	Desc.bGatherFamilyMembers = true;
+
+	{
+		FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+		Entry.SetDesc(ProviderID, Desc, GFrameCounter, SkelCompX, true);
+		Entry.AddReaderMember(ReaderID, SkelCompY, GFrameCounter);
+
+		Entry.MemberSlots.Add(
+			TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompX),
+			MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>());
+		Entry.MemberSlots.Add(
+			TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompY),
+			MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>());
+		TestEqual(TEXT("Two member slots exist before reader removal"), Entry.GetNumMemberSlots(), 2);
+
+		Entry.RemoveReaderMember(ReaderID);
+		TestEqual(TEXT("Only provider member slot remains after removing reader Y"), Entry.GetNumMemberSlots(), 1);
+		TestTrue(TEXT("Reader Y member slot is removed"),
+		         !Entry.MemberSlots.Contains(TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompY)));
+	}
+
+	{
+		FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+		Entry.SetDesc(ProviderID, Desc, GFrameCounter, SkelCompX, true);
+		Entry.AddReaderMember(ReaderID, SkelCompY, GFrameCounter);
+		Entry.MemberSlots.Add(
+			TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompX),
+			MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>());
+		Entry.MemberSlots.Add(
+			TWeakObjectPtr<const USkeletalMeshComponent>(SkelCompY),
+			MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>());
+
+		FKawaiiPhysicsSimpleWorldCollisionDesc DisabledMemberGatherDesc = Desc;
+		DisabledMemberGatherDesc.bGatherFamilyMembers = false;
+		Entry.SetDesc(ProviderID, DisabledMemberGatherDesc, GFrameCounter, SkelCompX, true);
+		TestEqual(TEXT("All member slots are removed when merged desc stops gathering members"),
+		          Entry.GetNumMemberSlots(),
+		          0);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldProviderDisabledPublishesEmptyTest,
+                                 "KawaiiPhysics.SimpleWorld.ProviderDisabledPublishesEmpty",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldProviderDisabledPublishesEmptyTest::RunTest(const FString& Parameters)
+{
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry::FGatheredComponent& GatheredComponent =
+		Entry.GatheredComponents.AddDefaulted_GetRef();
+	GatheredComponent.FadeAlpha = 1.0f;
+	GatheredComponent.LastComponentTM = FTransform::Identity;
+	FSphericalLimit Sphere;
+	Sphere.Location = FVector(5.0f, 0.0f, 0.0f);
+	Sphere.Radius = 8.0f;
+	Sphere.bEnable = true;
+	Sphere.SourceType = ECollisionSourceType::SimpleWorld;
+	GatheredComponent.LocalLimits.SphericalLimits.Add(Sphere);
+
+	Entry.bHasGroundBox = true;
+	Entry.GroundBox.Location = FVector(0.0f, 0.0f, -20.0f);
+	Entry.GroundBox.Extent = FVector(100.0f, 100.0f, 5.0f);
+	Entry.GroundBox.Rotation = FQuat::Identity;
+	Entry.GroundBox.bEnable = true;
+	Entry.GroundBox.SourceType = ECollisionSourceType::SimpleWorld;
+
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldShapeLimits(Entry, 0.5f);
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldGroundBox(Entry);
+	const uint64 ShapeSerialBeforeClear = Entry.Slot.GetPublishSerial();
+	const uint64 GroundSerialBeforeClear = Entry.GroundSlot.GetPublishSerial();
+
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldEmptyLimits(Entry, 0.5f);
+	TestEqual(TEXT("Shape slot serial advances once when disabled clears data"),
+	          Entry.Slot.GetPublishSerial(),
+	          ShapeSerialBeforeClear + 1);
+	TestEqual(TEXT("Ground slot serial advances once when disabled clears data"),
+	          Entry.GroundSlot.GetPublishSerial(),
+	          GroundSerialBeforeClear + 1);
+
+	FKawaiiPhysicsSharedCollisionData ShapeOutData;
+	Entry.Slot.AppendTo(ShapeOutData);
+	TestTrue(TEXT("Shape slot is empty after disabled clear"), ShapeOutData.IsEmpty());
+	FKawaiiPhysicsSharedCollisionData GroundOutData;
+	Entry.GroundSlot.AppendTo(GroundOutData);
+	TestTrue(TEXT("Ground slot is empty after disabled clear"), GroundOutData.IsEmpty());
+
+	UKawaiiPhysicsSharedCollisionSubsystem::PublishSimpleWorldEmptyLimits(Entry, 0.5f);
+	TestEqual(TEXT("Shape slot serial does not advance when already empty"),
+	          Entry.Slot.GetPublishSerial(),
+	          ShapeSerialBeforeClear + 1);
+	TestEqual(TEXT("Ground slot serial does not advance when already empty"),
+	          Entry.GroundSlot.GetPublishSerial(),
+	          GroundSerialBeforeClear + 1);
+
+	return true;
+}
+
 // ---------------------------------------------------------------------------
 //  DebugInfo
 // ---------------------------------------------------------------------------
@@ -1862,6 +2507,68 @@ bool FKawaiiPhysicsSimpleWorldDebugInfoTest::RunTest(const FString& Parameters)
 		         Info.GroundSource == EKawaiiPhysicsSimpleWorldGroundSource::Provider);
 		TestTrue(TEXT("Filled entry GroundBoxSource"),
 		         Info.GroundBoxSource == EKawaiiPhysicsSimpleWorldGroundSource::CharacterMovement);
+	}
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldDebugInfoSharedFieldsTest,
+                                 "KawaiiPhysics.SimpleWorld.DebugInfoSharedFields",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldDebugInfoSharedFieldsTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderID = 601;
+	constexpr uint64 ReaderID1 = 602;
+	constexpr uint64 ReaderID2 = 603;
+
+	UObject* KeyObject = NewObject<USkeletalMeshComponent>(
+		GetTransientPackage(),
+		FName(TEXT("SimpleWorldDebugInfoSharedKey")),
+		RF_Transient);
+	USkeletalMeshComponent* ProviderSkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp1 =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* ReaderSkelComp2 =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+
+	const FGameplayTag GroupTag = FGameplayTag::RequestGameplayTag(FName(TEXT("KawaiiPhysics.Test")), false);
+	FKawaiiPhysicsSimpleWorldRegistryKey Key;
+	Key.KeyObject = KeyObject;
+	Key.Tag = GroupTag;
+
+	FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+	Desc.GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+	Desc.bProviderDisabled = true;
+	Desc.bGatherFamilyMembers = true;
+
+	FKawaiiPhysicsSimpleWorldCollisionEntry Entry;
+	Entry.SetDesc(ProviderID, Desc, GFrameCounter, ProviderSkelComp, true);
+	Entry.AddReaderMember(ReaderID1, ReaderSkelComp1, GFrameCounter);
+	Entry.AddReaderMember(ReaderID2, ReaderSkelComp2, GFrameCounter);
+	Entry.MemberSlots.Add(
+		TWeakObjectPtr<const USkeletalMeshComponent>(ProviderSkelComp),
+		MakeShared<FKawaiiPhysicsSharedCollisionSourceSlot>());
+
+	FKawaiiPhysicsSimpleWorldCollisionDebugInfo Info;
+	UKawaiiPhysicsSharedCollisionSubsystem::FillSimpleWorldCollisionDebugInfo(Entry, Info, &Key);
+
+	TestTrue(TEXT("Shared debug info has entry"), Info.bHasEntry);
+	TestEqual(TEXT("Shared debug info reader count"), Info.NumReaders, 2);
+	TestTrue(TEXT("Shared debug info gather scope"),
+	         Info.GatherScope == EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily);
+	TestTrue(TEXT("Shared debug info provider disabled"), Info.bProviderDisabled);
+	TestTrue(TEXT("Shared debug info gather family members"), Info.bGatherFamilyMembers);
+	TestEqual(TEXT("Shared debug info key object name"), Info.KeyObjectName, KeyObject->GetName());
+	TestEqual(TEXT("Shared debug info member slot count"), Info.NumMemberSlots, 1);
+	if (GroupTag.IsValid())
+	{
+		TestTrue(TEXT("Shared debug info group tag"), Info.GroupTag == GroupTag);
+	}
+	else
+	{
+		TestFalse(TEXT("Shared debug info group tag remains invalid"), Info.GroupTag.IsValid());
 	}
 
 	return true;
@@ -2025,6 +2732,244 @@ bool FKawaiiPhysicsSimpleWorldInPlaceRefreshMatchesRebuildTest::RunTest(const FS
 
 	RunCase(EKawaiiPhysicsSimulationSpace::ComponentSpace, TEXT("ComponentSpace"));
 	RunCase(EKawaiiPhysicsSimulationSpace::WorldSpace, TEXT("WorldSpace"));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldSharedReaderConsumesInjectedStateTest,
+                                 "KawaiiPhysics.SimpleWorld.SharedReaderConsumesInjectedState",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldSharedReaderConsumesInjectedStateTest::RunTest(const FString& Parameters)
+{
+	USkeletalMeshComponent* SkelCompA =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompB =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+		MakeSimpleWorldReaderEntry(SkelCompA, SkelCompB);
+
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.SetSimpleWorldOwnSkelComp(SkelCompA);
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(false), Entry);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestTrue(TEXT("Injected shared reader mode is enabled"), Accessor.IsSimpleWorldReaderMode());
+	TestEqual(TEXT("Reader includes one main box"), Accessor.GetSimpleWorldBoxLimits().Num(), 1);
+	TestEqual(TEXT("Reader excludes own member sphere"), Accessor.GetSimpleWorldSphericalLimits().Num(), 0);
+	TestEqual(TEXT("Reader includes the other member capsule"), Accessor.GetSimpleWorldCapsuleLimits().Num(), 1);
+	TestEqual(TEXT("Reader includes one ground box"), Accessor.GetSimpleWorldGroundBoxLimits().Num(), 1);
+	TestEqual(TEXT("Reader collider count includes shape and ground"), Accessor.GetNumSimpleWorldColliders(), 3);
+
+	const uint64 FirstShapeSerial = Accessor.GetLastReadSimpleWorldShapeSerial();
+	const uint64 FirstMemberSerialSum = Accessor.GetLastReadSimpleWorldMemberSerialSum();
+	FVector FirstBoxLocation = FVector::ZeroVector;
+	FVector FirstCapsuleLocation = FVector::ZeroVector;
+	FVector FirstGroundLocation = FVector::ZeroVector;
+	const bool bHasInitialReaderShapes =
+		Accessor.GetSimpleWorldBoxLimits().IsValidIndex(0)
+		&& Accessor.GetSimpleWorldCapsuleLimits().IsValidIndex(0)
+		&& Accessor.GetSimpleWorldGroundBoxLimits().IsValidIndex(0);
+	if (bHasInitialReaderShapes)
+	{
+		FirstBoxLocation = Accessor.GetSimpleWorldBoxLimits()[0].Location;
+		FirstCapsuleLocation = Accessor.GetSimpleWorldCapsuleLimits()[0].Location;
+		FirstGroundLocation = Accessor.GetSimpleWorldGroundBoxLimits()[0].Location;
+	}
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Unchanged shape serial stays cached"),
+	          Accessor.GetLastReadSimpleWorldShapeSerial(), FirstShapeSerial);
+	TestEqual(TEXT("Unchanged member serial sum stays cached"),
+	          Accessor.GetLastReadSimpleWorldMemberSerialSum(), FirstMemberSerialSum);
+	if (bHasInitialReaderShapes
+		&& Accessor.GetSimpleWorldBoxLimits().IsValidIndex(0)
+		&& Accessor.GetSimpleWorldCapsuleLimits().IsValidIndex(0)
+		&& Accessor.GetSimpleWorldGroundBoxLimits().IsValidIndex(0))
+	{
+		TestTrue(TEXT("In-place refresh keeps box location"),
+		         Accessor.GetSimpleWorldBoxLimits()[0].Location.Equals(FirstBoxLocation, GSimpleWorldTol));
+		TestTrue(TEXT("In-place refresh keeps capsule location"),
+		         Accessor.GetSimpleWorldCapsuleLimits()[0].Location.Equals(FirstCapsuleLocation, GSimpleWorldTol));
+		TestTrue(TEXT("In-place refresh keeps ground location"),
+		         Accessor.GetSimpleWorldGroundBoxLimits()[0].Location.Equals(FirstGroundLocation, GSimpleWorldTol));
+	}
+
+	PublishSimpleWorldReaderMemberBExtraSphere(*Entry, SkelCompB);
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Member serial change rebuilds and includes the new sphere"),
+	          Accessor.GetSimpleWorldSphericalLimits().Num(), 1);
+	TestEqual(TEXT("Capsule remains after member rebuild"), Accessor.GetSimpleWorldCapsuleLimits().Num(), 1);
+	TestEqual(TEXT("Reader collider count includes rebuilt member sphere"),
+	          Accessor.GetNumSimpleWorldColliders(), 4);
+	TestTrue(TEXT("Member serial sum changed"),
+	         Accessor.GetLastReadSimpleWorldMemberSerialSum() != FirstMemberSerialSum);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldLocalProviderKeepsSkelCompAfterExpiryTest,
+                                 "KawaiiPhysics.SimpleWorld.LocalProviderKeepsSkelCompAfterExpiry",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldLocalProviderKeepsSkelCompAfterExpiryTest::RunTest(const FString& Parameters)
+{
+	USkeletalMeshComponent* SkelComp =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+		MakeShared<FKawaiiPhysicsSimpleWorldCollisionEntry>();
+
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.SetSimpleWorldOwnSkelComp(SkelComp);
+	Accessor.SetSimpleWorldEntry(Entry);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestFalse(TEXT("Local provider stays out of reader mode"), Accessor.IsSimpleWorldReaderMode());
+	TestTrue(TEXT("Local provider registers a provider desc"), Entry->HasProviderDesc());
+	TestTrue(TEXT("Local provider slot carries the own skeletal mesh component"),
+	         Entry->GetPrimarySkelComp() == SkelComp);
+
+	// 収集 Tick が長く止まった状況を模し、provider slot を期限切れで落とす。
+	Entry->RemoveExpiredDescs(GFrameCounter + 1000, 10);
+	TestFalse(TEXT("Expired provider desc is removed"), Entry->HasProviderDesc());
+	TestTrue(TEXT("Expired provider slot drops the skeletal mesh component"),
+	         Entry->GetPrimarySkelComp() == nullptr);
+
+	// Desc が同値だと再送されず MarkRead 失敗で Entry が解放されるため、Desc を変えて再送経路を通す。
+	Accessor.SetSimpleWorldGroundCollision(!Accessor.GetSimpleWorldGroundCollision());
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestTrue(TEXT("Changed desc recreates the provider slot"), Entry->HasProviderDesc());
+	TestTrue(TEXT("Recreated provider slot keeps SkelComp"), Entry->GetPrimarySkelComp() == SkelComp);
+	TestTrue(TEXT("Local provider keeps the cached entry"), Accessor.HasSimpleWorldEntry());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldSharedReaderClearsWhenProviderDisabledTest,
+                                 "KawaiiPhysics.SimpleWorld.SharedReaderClearsWhenProviderDisabled",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldSharedReaderClearsWhenProviderDisabledTest::RunTest(const FString& Parameters)
+{
+	USkeletalMeshComponent* SkelCompA =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompB =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+		MakeSimpleWorldReaderEntry(SkelCompA, SkelCompB);
+
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.SetSimpleWorldOwnSkelComp(SkelCompA);
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(false), Entry);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Reader starts with injected colliders"), Accessor.GetNumSimpleWorldColliders(), 3);
+
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(true), Entry);
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Disabled provider clears colliders"), Accessor.GetNumSimpleWorldColliders(), 0);
+	TestEqual(TEXT("Disabled provider clears spheres"), Accessor.GetSimpleWorldSphericalLimits().Num(), 0);
+	TestEqual(TEXT("Disabled provider clears capsules"), Accessor.GetSimpleWorldCapsuleLimits().Num(), 0);
+	TestEqual(TEXT("Disabled provider clears boxes"), Accessor.GetSimpleWorldBoxLimits().Num(), 0);
+	TestEqual(TEXT("Disabled provider clears ground"), Accessor.GetSimpleWorldGroundBoxLimits().Num(), 0);
+	TestFalse(TEXT("Disabled provider does not log reader warning"), Accessor.IsSimpleWorldReaderWarningLogged());
+	TestEqual(TEXT("Disabled provider does not increment reader retry"),
+	          Accessor.GetSimpleWorldReaderRetryCount(), 0);
+
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(false), Entry);
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Reader colliders return when provider is enabled again"),
+	          Accessor.GetNumSimpleWorldColliders(), 3);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldSharedReaderReleasesWhenProviderGoneTest,
+                                 "KawaiiPhysics.SimpleWorld.SharedReaderReleasesWhenProviderGone",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldSharedReaderReleasesWhenProviderGoneTest::RunTest(const FString& Parameters)
+{
+	constexpr uint64 ProviderID = 0xFFFF0001;
+	USkeletalMeshComponent* SkelCompA =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompB =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+		MakeSimpleWorldReaderEntry(SkelCompA, SkelCompB);
+
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.SetSimpleWorldOwnSkelComp(SkelCompA);
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(false), Entry, ProviderID);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestEqual(TEXT("Reader starts with injected colliders"), Accessor.GetNumSimpleWorldColliders(), 3);
+
+	Entry->RemoveDesc(ProviderID);
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestFalse(TEXT("Reader releases the cached entry when provider disappears"), Accessor.HasSimpleWorldEntry());
+	TestEqual(TEXT("Reader clears colliders after provider disappears"),
+	          Accessor.GetNumSimpleWorldColliders(), 0);
+	TestEqual(TEXT("Reader increments retry after release"), Accessor.GetSimpleWorldReaderRetryCount(), 1);
+
+	AddExpectedError(TEXT("Shared Simple World Collision entry has no provider"),
+	                 EAutomationExpectedErrorFlags::Contains, 1);
+	for (int32 Attempt = 0; Attempt < 60; ++Attempt)
+	{
+		Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	}
+	TestTrue(TEXT("Reader logs the no-provider warning once after repeated retries"),
+	         Accessor.IsSimpleWorldReaderWarningLogged());
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestTrue(TEXT("Reader warning flag remains set"),
+	         Accessor.IsSimpleWorldReaderWarningLogged());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FKawaiiPhysicsSimpleWorldSharedReaderSkipsRadiusCheckTest,
+                                 "KawaiiPhysics.SimpleWorld.SharedReaderSkipsRadiusCheck",
+                                 EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKawaiiPhysicsSimpleWorldSharedReaderSkipsRadiusCheckTest::RunTest(const FString& Parameters)
+{
+	USkeletalMeshComponent* SkelCompA =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	USkeletalMeshComponent* SkelCompB =
+		NewObject<USkeletalMeshComponent>(GetTransientPackage(), NAME_None, RF_Transient);
+	const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> Entry =
+		MakeSimpleWorldReaderEntry(SkelCompA, SkelCompB);
+
+	FKawaiiPhysicsTestAccessor Accessor;
+	Accessor.SetSimulationSpace(EKawaiiPhysicsSimulationSpace::ComponentSpace);
+	Accessor.BuildVerticalChain(2, 10.0f);
+	Accessor.SetSimpleWorldGatherRadiusOverride(1.0f);
+	Accessor.SetSimpleWorldOwnSkelComp(SkelCompA);
+	Accessor.InjectSharedPublisherState(MakeSimpleWorldReaderState(false), Entry);
+
+	FAnimInstanceProxy AnimInstanceProxy;
+	FComponentSpacePoseContext PoseContext(&AnimInstanceProxy);
+
+	Accessor.UpdateSimpleWorldCollisionLimits(PoseContext);
+	TestFalse(TEXT("Shared reader path does not run SimpleWorld radius check"),
+	          Accessor.IsSimpleWorldRadiusChecked());
 
 	return true;
 }

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Private/Tests/KawaiiPhysicsTestHarness.h
@@ -8,6 +8,8 @@
 #include "AnimNode_KawaiiPhysics.h"
 #include "KawaiiPhysicsTypes.h"
 #include "KawaiiPhysicsCollisionLimits.h"
+#include "KawaiiPhysicsSharedPublisherTypes.h"
+#include "UObject/Package.h"
 
 /**
  * 自動テスト用アクセサ
@@ -193,6 +195,94 @@ struct FKawaiiPhysicsTestAccessor
 		Node.bSimpleWorldDescSent = false;
 	}
 
+	void InjectSharedPublisherState(const FKawaiiPhysicsSharedPublisherState& State,
+	                                const TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>& Entry,
+	                                uint64 ProviderID = 0xFFFF0001)
+	{
+		if (Entry.IsValid())
+		{
+			Entry->SetDesc(ProviderID, State.SimpleWorldDesc, GFrameCounter,
+			               TWeakObjectPtr<const USkeletalMeshComponent>(), true);
+		}
+
+		FKawaiiPhysicsSimpleWorldRegistryKey Key;
+		Key.KeyObject = GetTransientPackage();
+		Node.CachedSimpleWorldEntry.Reset();
+		Node.SetSimpleWorldReaderKey(Key);
+		Node.CachedSimpleWorldEntry = Entry;
+		Node.bUseSimpleWorldCollision = true;
+		Node.bSimpleWorldCollisionInitialized = Entry.IsValid();
+		Node.bSimpleWorldDescSent = false;
+
+		if (Entry.IsValid())
+		{
+			Entry->AddReaderMember(
+				reinterpret_cast<uint64>(&Node),
+				Node.CachedSimpleWorldCollisionSkelComp,
+				GFrameCounter);
+		}
+	}
+
+	void SetSimpleWorldOwnSkelComp(const USkeletalMeshComponent* SkelComp)
+	{
+		Node.CachedSimpleWorldCollisionSkelComp = SkelComp;
+	}
+
+	bool IsSimpleWorldReaderMode() const
+	{
+		return Node.bSimpleWorldReaderMode;
+	}
+
+	int32 GetSimpleWorldReaderRetryCount() const
+	{
+		return Node.SimpleWorldReaderRetryCount;
+	}
+
+	bool IsSimpleWorldReaderWarningLogged() const
+	{
+		return Node.bSimpleWorldReaderWarningLogged;
+	}
+
+	uint64 GetLastReadSimpleWorldMemberSerialSum() const
+	{
+		return Node.LastReadSimpleWorldMemberSerialSum;
+	}
+
+	const TArray<FSphericalLimit>& GetSimpleWorldSphericalLimits() const
+	{
+		return Node.SimpleWorldSphericalLimits;
+	}
+
+	const TArray<FCapsuleLimit>& GetSimpleWorldCapsuleLimits() const
+	{
+		return Node.SimpleWorldCapsuleLimits;
+	}
+
+	const TArray<FTaperedCapsuleLimit>& GetSimpleWorldTaperedCapsuleLimits() const
+	{
+		return Node.SimpleWorldTaperedCapsuleLimits;
+	}
+
+	const TArray<FBoxLimit>& GetSimpleWorldBoxLimits() const
+	{
+		return Node.SimpleWorldBoxLimits;
+	}
+
+	const TArray<FBoxLimit>& GetSimpleWorldGroundBoxLimits() const
+	{
+		return Node.SimpleWorldGroundBoxLimits;
+	}
+
+	const TArray<FKawaiiPhysicsConvexLimit>& GetSimpleWorldConvexLimits() const
+	{
+		return Node.SimpleWorldConvexLimits;
+	}
+
+	bool HasSimpleWorldEntry() const
+	{
+		return Node.CachedSimpleWorldEntry.IsValid();
+	}
+
 	/**
 	 * SimpleWorld コリジョンのワーカー側読み取り更新を呼び出す。
 	 * Calls the worker-side SimpleWorld collision read update.
@@ -218,6 +308,17 @@ struct FKawaiiPhysicsTestAccessor
 	uint64 GetLastReadSimpleWorldShapeSerial() const
 	{
 		return Node.LastReadSimpleWorldShapeSerial;
+	}
+
+	/** SimpleWorld Desc の地面コリジョン有無を切り替える（Desc 変化を起こすため） */
+	void SetSimpleWorldGroundCollision(bool bEnable)
+	{
+		Node.bSimpleWorldCollisionGroundCollision = bEnable;
+	}
+
+	bool GetSimpleWorldGroundCollision() const
+	{
+		return Node.bSimpleWorldCollisionGroundCollision;
 	}
 
 	void SetSimpleWorldGatherRadiusOverride(float Radius)

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/AnimNode_KawaiiPhysics.h
@@ -1030,8 +1030,13 @@ private:
 	TWeakObjectPtr<const USkeletalMeshComponent> CachedSimpleWorldCollisionSkelComp;
 	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> CachedSimpleWorldEntry;
 	FKawaiiPhysicsSimpleWorldCollisionDesc LastSentSimpleWorldDesc;
+	FKawaiiPhysicsSimpleWorldRegistryKey SimpleWorldReaderKey;
+	// reader 警告用にキー設定時へキャッシュした KeyObject 名（Worker で UObject を触らない）
+	// KeyObject name cached when the reader key is set, so worker-side warnings never dereference the UObject
+	FName SimpleWorldReaderKeyObjectName;
 	bool bSimpleWorldDescSent = false;
 	bool bSimpleWorldCollisionInitialized = false;
+	bool bSimpleWorldReaderMode = false;
 	// SimpleWorld 半径警告チェックが完了済みか / Whether the SimpleWorld radius warning check has completed
 	bool bSimpleWorldRadiusChecked = false;
 	// 半径チェックを全ゼロ姿勢で持ち越した回数。上限に達したら退化チェーンとみなして完了扱いにする / Number of radius-check deferrals due to all-zero pose. Reaching the cap marks the check done (degenerate chain)
@@ -1040,6 +1045,10 @@ private:
 	uint64 LastReadSimpleWorldShapeSerial = 0;
 	// 前回読み取った GroundSlot の Publish serial（0 は未読） / Last read GroundSlot publish serial (0 means unread)
 	uint64 LastReadSimpleWorldGroundSerial = 0;
+	// 前回読み取ったファミリーメンバー Slot の Publish serial 合計（0 は未読） / Last read family-member Slot publish serial sum (0 means unread)
+	uint64 LastReadSimpleWorldMemberSerialSum = 0;
+	int32 SimpleWorldReaderRetryCount = 0;
+	bool bSimpleWorldReaderWarningLogged = false;
 	// 形状 Slot 用のワールド空間スクラッチ / World-space scratch for the shape Slot
 	FKawaiiPhysicsSharedCollisionData SimpleWorldMergedScratch;
 	// GroundSlot 用のワールド空間スクラッチ / World-space scratch for the GroundSlot
@@ -1189,6 +1198,24 @@ public:
 			+ SimpleWorldBoxLimits.Num()
 			+ SimpleWorldGroundBoxLimits.Num()
 			+ SimpleWorldConvexLimits.Num();
+	}
+
+	/**
+	 * GameThreadでキャッシュした Shared Collision Subsystem を返す。Workerから新規解決しないための診断/API用。
+	 * Returns the Shared Collision Subsystem cached on the GameThread. Intended for diagnostics/API without resolving it on workers.
+	 */
+	UKawaiiPhysicsSharedCollisionSubsystem* GetSharedCollisionSubsystem() const
+	{
+		return CachedSharedCollisionSubsystem.Get();
+	}
+
+	/**
+	 * GameThreadでキャッシュした Shared Collision owner Actor を返す。WorkerからGetOwnerを呼ばないための診断/API用。
+	 * Returns the Shared Collision owner Actor cached on the GameThread. Intended for diagnostics/API without calling GetOwner on workers.
+	 */
+	AActor* GetSharedCollisionOwnerActor() const
+	{
+		return CachedSharedCollisionOwnerActor.Get();
 	}
 
 	/**
@@ -1731,6 +1758,15 @@ protected:
 
 
 private:
+	void SetSimpleWorldReaderKey(const FKawaiiPhysicsSimpleWorldRegistryKey& Key)
+	{
+		SimpleWorldReaderKey = Key;
+		// GameThread（ハーネス／将来の OnInitializeAnimInstance）からのみ呼ばれる前提なので、ここでの KeyObject デリファレンスは安全
+		SimpleWorldReaderKeyObjectName = Key.KeyObject.IsValid() ? Key.KeyObject->GetFName() : NAME_None;
+		bSimpleWorldReaderMode = Key.IsValid();
+		RequestSimpleWorldCollisionReinit();
+	}
+
 	bool bModifyBonesNeedsReinit = false;
 	int32 LastInitializedBoneSubdivisionCount = 0;
 	int32 LastInitializedBoneConstraintSubdivisionCount = 0;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsDeveloperSettings.h
@@ -84,9 +84,9 @@ public:
 	float SimpleWorldCollisionDistanceThrottleStop = 10000.f;
 
 	/**
-	* シンプルワールドコリジョンが SkeletalMeshComponent 1つあたりに保持する最大収集コンポーネント数。
+	* シンプルワールドコリジョンが収集グループ（Entry）あたりに保持する最大収集コンポーネント数。Shared Publisher で共有する場合はファミリー全体で 1 グループとして数える。
 	* a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxComponents CVar が 0 以上の場合はそちらが優先される。
-	* Maximum number of gathered components Simple World Collision keeps per SkeletalMeshComponent.
+	* Maximum number of gathered components Simple World Collision keeps per gather group (Entry). When shared by a Shared Publisher, the whole family counts as one group.
 	* Overridden by the a.AnimNode.KawaiiPhysics.SimpleWorldCollision.MaxComponents CVar when it is >= 0.
 	*/
 	UPROPERTY(EditAnywhere, config, Category = "Simple World Collision",

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedCollisionSubsystem.h
@@ -23,6 +23,7 @@ class USkeletalMeshComponent;
 class USkinnedAsset;
 class UCharacterMovementComponent;
 class UWorld;
+struct FKawaiiPhysicsSharedPublisherEntry;
 
 // 地面ソースの種類（DebugDraw の色分けにも使う） / Ground source kind (also used for debug draw colors)
 UENUM(BlueprintType)
@@ -118,73 +119,103 @@ private:
 };
 
 /**
- * シンプルワールドコリジョン収集設定
- * Simple-world collision gather settings
+ * SimpleWorld Registry のキー。Local は SkelComp + 無効 Tag、Shared はファミリー root Actor + Tag を使う。
+ * Key for the SimpleWorld registry. Local uses SkelComp + invalid Tag; Shared uses family-root Actor + Tag.
  */
-struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDesc
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldRegistryKey
 {
-	float GatherIntervalSec = 0.2f;
-	float GatherRadiusOverride = 0.0f;
-	// Merge の出力: 全 Desc が GatherRadiusOverride を指定していれば true。ノード側は false のまま / Merge output: true when every Desc specifies GatherRadiusOverride. Node-built Descs leave it false
-	bool bGatherRadiusAllOverridden = false;
-	// ECC_MAX は所有 SkeletalMeshComponent の ObjectType を使う指定 / ECC_MAX means using the owning SkeletalMeshComponent's ObjectType.
-	TEnumAsByte<ECollisionChannel> CollisionChannel = ECC_MAX;
-	TArray<TEnumAsByte<EObjectTypeQuery>> ObjectTypes;
-	EKawaiiPhysicsSimpleWorldConvexFallbackShape ConvexFallbackShape = EKawaiiPhysicsSimpleWorldConvexFallbackShape::ConvexHull;
-	EKawaiiPhysicsSimpleWorldSkeletalMeshCollision SkeletalMeshCollision = EKawaiiPhysicsSimpleWorldSkeletalMeshCollision::None;
-	bool bGroundCollision = true;
+	TWeakObjectPtr<const UObject> KeyObject;
+	FGameplayTag Tag;
 
 	/**
-	 * 複数ノードの収集設定を SkelComp 単位の1設定へマージする。
-	 * Merge multiple node gather settings into one SkelComp-level setting.
-	 *
-	 * 規則 / Rules:
-	 * - GatherIntervalSec は最小値。0以下は毎フレーム収集で最優先。
-	 * - GatherIntervalSec uses the minimum value. <= 0 means gather every frame and has highest priority.
-	 * - GatherRadiusOverride は Override 指定の最大値（指定なしは 0）。bGatherRadiusAllOverridden は全 Desc が Override 指定の時だけ true。
-	 * - GatherRadiusOverride is the max of the specified overrides (0 when none). bGatherRadiusAllOverridden is true only when every Desc specifies an override.
-	 * - CollisionChannel は ECC_MAX 以外（World Collision の Override 指定）を持つ Desc のうち、最も早く登録されたノードの値を採用。全て ECC_MAX なら ECC_MAX。
-	 * - CollisionChannel uses the value of the earliest-registered Desc whose value is not ECC_MAX (World Collision override). If all values are ECC_MAX, it stays ECC_MAX.
-	 * - ObjectTypes は union。空配列は WorldStatic + WorldDynamic の意味なので、空 Desc がある場合はそれらを明示的に union へ含める。
-	 * - ObjectTypes are unioned. Empty means WorldStatic + WorldDynamic, so those are explicitly included when any Desc is empty.
-	 * - ConvexFallbackShape は宣言順（高精度が先）の優先。
-	 * - ConvexFallbackShape priority follows declaration order (more accurate first).
-	 * - SkeletalMeshCollision は PhysicsAsset > BoundingBox > None の優先。
-	 * - SkeletalMeshCollision priority is PhysicsAsset > BoundingBox > None.
-	 * - bGroundCollision は OR。
-	 * - bGroundCollision is OR.
+	 * Worker から呼ばれる FindOrCreateSimpleWorldEntry / FindSimpleWorldEntry の前段判定に使うため、
+	 * UObject をデリファレンスしないスレッドセーフ判定（bThreadsafeTest=true）で有効性を見る。
+	 * Uses the thread-safe test (bThreadsafeTest=true) so worker-thread callers of
+	 * FindOrCreateSimpleWorldEntry / FindSimpleWorldEntry never dereference the UObject.
 	 */
-	static FKawaiiPhysicsSimpleWorldCollisionDesc Merge(const TArray<FKawaiiPhysicsSimpleWorldCollisionDesc>& Descs);
+	bool IsValid() const { return KeyObject.IsValid(false, true); }
+
+	bool operator==(const FKawaiiPhysicsSimpleWorldRegistryKey& Other) const
+	{
+		return KeyObject == Other.KeyObject && Tag == Other.Tag;
+	}
+
+	friend uint32 GetTypeHash(const FKawaiiPhysicsSimpleWorldRegistryKey& Key)
+	{
+		return HashCombine(GetTypeHash(Key.KeyObject), GetTypeHash(Key.Tag));
+	}
 
 	/**
-	 * Desc の変更が収集結果（Overlap 対象・形状変換・地面・半径）に影響するか。GatherIntervalSec だけの変化は false。
-	 * Whether a Desc change affects the gather result (overlap set, shape conversion, ground, radius). Interval-only changes return false.
+	 * GameThread 用（DebugInfo / テスト）。生ポインタをそのままキーへ格納する。
+	 * For GameThread use (debug info / tests). Stores the raw pointer into the key.
 	 */
-	static bool DoesChangeRequireRegather(const FKawaiiPhysicsSimpleWorldCollisionDesc& Old, const FKawaiiPhysicsSimpleWorldCollisionDesc& New);
-
-	bool operator==(const FKawaiiPhysicsSimpleWorldCollisionDesc& Other) const;
+	static FKawaiiPhysicsSimpleWorldRegistryKey MakeLocalKey(const USkeletalMeshComponent* SkelComp);
+	/**
+	 * Worker から呼べる弱参照版。弱参照をデリファレンスせずそのままキーへ格納する。
+	 * Weak-pointer variant callable from worker threads. Stores the weak pointer without dereferencing it.
+	 */
+	static FKawaiiPhysicsSimpleWorldRegistryKey MakeLocalKey(const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp);
+	static FKawaiiPhysicsSimpleWorldRegistryKey MakeSharedKey(const AActor* FamilyRoot, const FGameplayTag& Tag);
 };
 
 /**
- * シンプルワールドコリジョン収集Entry（SkelComp単位。複数SourceのDescをマージして1回収集）
- * Simple-world collision gather entry (per SkelComp. Merges multiple source Descs and gathers once)
+ * シンプルワールドコリジョン収集Entry。provider Desc をマージして1回収集し、reader は同じ Entry を読む。
+ * Simple-world collision gather entry. Merges provider Descs and gathers once; readers consume the same Entry.
  *
  * スレッド境界 / Thread boundary:
- * - Worker: SetDesc / RemoveDesc / MarkRead / RequestRegather / Slot.AppendTo / GroundSlot.AppendTo
+ * - Worker: SetDesc / RemoveDesc / MarkRead / AddReaderMember / RemoveReaderMember / MarkReaderRead / RequestRegather / AppendFamilyMemberLimits / Slot.AppendTo / GroundSlot.AppendTo
  * - GameThread Tick: RemoveExpiredDescs / BuildMergedDesc / world query, GatheredComponents更新, Slot.Publish / GroundSlot.Publish
+ * Worker から呼ぶ API は SkelComp 弱参照をデリファレンスしない（IsValid(false, true) と弱参照同士の比較だけを使う）。
+ * GetPrimarySkelComp / CollectMemberSkelComps は生ポインタを取り出すため GameThread（Tick）専用。
+ * Worker-callable APIs never dereference the SkelComp weak pointers (they only use IsValid(false, true) and weak-pointer comparison).
+ * GetPrimarySkelComp / CollectMemberSkelComps resolve raw pointers and are therefore GameThread (Tick) only.
  * ISM / HISM はインスタンス単位で収集し、MaxGatheredComponents はインスタンス数に対して効きます。
  * ISM / HISM are gathered per instance, and MaxGatheredComponents applies to instance count.
  */
 struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 {
+	friend class UKawaiiPhysicsSharedCollisionSubsystem;
+
+	void SetDesc(uint64 SourceID, const FKawaiiPhysicsSimpleWorldCollisionDesc& InDesc, uint64 CurrentFrame,
+	             const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp, bool bProvider = true);
 	void SetDesc(uint64 SourceID, const FKawaiiPhysicsSimpleWorldCollisionDesc& InDesc);
 	void RemoveDesc(uint64 SourceID);
 
 	bool MarkRead(uint64 SourceID);
+	void AddReaderMember(uint64 SourceID, const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp,
+	                     uint64 CurrentFrame);
+	void RemoveReaderMember(uint64 SourceID);
+	bool MarkReaderRead(uint64 SourceID, uint64 CurrentFrame, uint64 ProviderMaxAgeFrames);
 	void RemoveExpiredDescs(uint64 CurrentFrame, uint64 MaxAge);
 	bool HasAnyDesc() const;
+	bool HasProviderDesc() const;
+	bool HasAnyReader() const;
+	bool IsProviderDisabled() const;
 	bool BuildMergedDesc(FKawaiiPhysicsSimpleWorldCollisionDesc& OutMerged) const;
 	int32 GetNumDescs() const;
+	int32 GetNumReaders() const;
+	/** GameThread（Tick）専用。弱参照から生ポインタを解決する / GameThread (Tick) only. Resolves raw pointers from weak pointers. */
+	void CollectMemberSkelComps(TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& Out) const;
+	/** GameThread（Tick）専用。弱参照から生ポインタを解決する / GameThread (Tick) only. Resolves a raw pointer from a weak pointer. */
+	const USkeletalMeshComponent* GetPrimarySkelComp() const;
+	uint64 GetLastProviderFrame() const;
+	/**
+	 * OwnSkelComp 以外のファミリーメンバー Slot を OutData へ追記する。GameThread API は呼ばない。
+	 * 自己除外は弱参照同士の比較で行い、OwnSkelComp をデリファレンスしない。
+	 * Appends family-member slots other than OwnSkelComp into OutData. Does not call GameThread-only APIs.
+	 * Self-exclusion compares weak pointers, so OwnSkelComp is never dereferenced.
+	 */
+	void AppendFamilyMemberLimits(const TWeakObjectPtr<const USkeletalMeshComponent>& OwnSkelComp,
+	                              FKawaiiPhysicsSharedCollisionData& OutData) const;
+	/** 全ファミリーメンバー Slot の PublishSerial 合計を返す / Returns the sum of PublishSerial for all family-member slots */
+	uint64 GetMemberSlotsPublishSerialSum() const;
+	/** ファミリーメンバー Slot 数を返す / Returns the number of family-member slots */
+	int32 GetNumMemberSlots() const;
+	/**
+	 * 指定されたメンバー以外のファミリーメンバー Slot を削除する。空配列なら全削除。
+	 * Removes family-member slots except the specified members. An empty array removes all slots.
+	 */
+	void RemoveMemberSlotsNotIn(const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MembersToKeep);
 
 	void RequestRegather();
 	bool ConsumeRegatherRequested();
@@ -192,6 +223,7 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	FKawaiiPhysicsSharedCollisionSourceSlot Slot;
 	// 地面 Box 専用 Slot。0 または 1 個の FBoxLimit を BoxLimits に入れて Publish する / Dedicated ground-box slot. Publishes zero or one FBoxLimit in BoxLimits.
 	FKawaiiPhysicsSharedCollisionSourceSlot GroundSlot;
+	TMap<TWeakObjectPtr<const USkeletalMeshComponent>, TSharedPtr<FKawaiiPhysicsSharedCollisionSourceSlot>> MemberSlots;
 
 	// Tick スレッド専有・ロック不要 / Tick-thread only; no lock required.
 	float TimeSinceLastGather = FLT_MAX;
@@ -206,6 +238,11 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 		 * Cached SkeletalMeshComponent for exact PhysicsAsset mode. Unset for regular/bounds gathering.
 		 */
 		TWeakObjectPtr<const USkeletalMeshComponent> SkeletalComponent;
+		/**
+		 * ファミリーメンバー SkelComp の形状なら設定する。通常コンポーネントは未設定。
+		 * Set for shapes that belong to a family-member SkelComp. Unset for regular components.
+		 */
+		TWeakObjectPtr<const USkeletalMeshComponent> MemberSkelComp;
 		/**
 		 * 収集時の SkinnedAsset。差し替え検知に使う。
 		 * SkinnedAsset at gather time, used for replacement detection.
@@ -278,18 +315,28 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionEntry
 	FKawaiiPhysicsSharedCollisionData PublishScratch;
 	// Tick スレッド専有。地面 Slot の Publish 用スクラッチ / Tick-thread only. Scratch buffer for publishing the ground slot
 	FKawaiiPhysicsSharedCollisionData GroundPublishScratch;
+	// Tick スレッド専有。ファミリーメンバー Slot の Publish 用スクラッチ / Tick-thread only. Scratch buffers for publishing family-member slots
+	TMap<TWeakObjectPtr<const USkeletalMeshComponent>, FKawaiiPhysicsSharedCollisionData> MemberPublishScratch;
+	FKawaiiPhysicsSharedCollisionData EmptyMemberPublishScratch;
 	TArray<FOverlapResult> OverlapScratch;
 	// Tick スレッド専有。収集上限超過時の距離順インデックス / Tick-thread only. Distance-sorted indices used only when gather results exceed the cap
 	TArray<int32> GatherOrderScratch;
 	// Tick スレッド専有。収集上限超過時の距離二乗スクラッチ / Tick-thread only. Squared-distance scratch used only when gather results exceed the cap
 	TArray<float> GatherDistanceScratch;
+	// Tick スレッド専有。ActorFamily 収集用メンバー scratch / Tick-thread only. Member scratch for ActorFamily gathering
+	TArray<TWeakObjectPtr<const USkeletalMeshComponent>> MemberSkelCompScratch;
+	TSet<TWeakObjectPtr<const USkeletalMeshComponent>> MemberSkelCompSetScratch;
+	TSet<TWeakObjectPtr<const AActor>> MemberOwnerScratch;
+	TArray<FBoxSphereBounds> MemberBoundsScratch;
 	bool bWorldLimitsDirty = true;
 
 private:
 	struct FDescSlot
 	{
 		FKawaiiPhysicsSimpleWorldCollisionDesc Desc;
+		TWeakObjectPtr<const USkeletalMeshComponent> SkelComp;
 		uint64 LastReadFrame = 0;
+		bool bProvider = true;
 		// 登録順（Merge の順序依存規則を決定的にする） / Registration order that makes order-dependent merge rules deterministic
 		uint64 RegistrationOrdinal = 0;
 	};
@@ -298,7 +345,10 @@ private:
 	mutable FRWLock DescLock;
 	// 次に登録する Desc へ割り当てる登録順。DescLock 内でのみ触る / Registration order for the next Desc. Touched only under DescLock
 	uint64 NextDescRegistrationOrdinal = 1;
+	uint64 LastProviderFrame = 0;
 	std::atomic<bool> bRegatherRequested{false};
+
+	void RemoveMemberSlotsNotInLocked(const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MembersToKeep);
 };
 
 USTRUCT(BlueprintType)
@@ -377,6 +427,34 @@ struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDebugInfo
 	// Entry.bHasGatheredOnce / Entry.bHasGatheredOnce
 	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
 	bool bHasGatheredOnce = false;
+
+	// 収集スコープ / Gather scope
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	EKawaiiPhysicsSimpleWorldGatherScope GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::SkeletalMeshComponent;
+
+	// Registry キーの Tag。Local は空 / Registry key Tag. Empty for local entries
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	FGameplayTag GroupTag;
+
+	// Registry キーの KeyObject 名。Local は SkelComp 名 / Registry key KeyObject name. Local entries use the SkelComp name
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	FString KeyObjectName;
+
+	// Entry に登録されている reader 数 / Number of readers registered to the entry
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumReaders = 0;
+
+	// マージ済み provider disabled 状態 / Merged provider disabled state
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	bool bProviderDisabled = false;
+
+	// ファミリーメンバー形状を収集するか / Whether family-member shapes are gathered
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	bool bGatherFamilyMembers = false;
+
+	// ファミリーメンバー Slot 数 / Number of family-member slots
+	UPROPERTY(BlueprintReadOnly, Category = "Kawaii Physics|Simple World Collision")
+	int32 NumMemberSlots = 0;
 };
 
 /**
@@ -415,23 +493,65 @@ public:
 		const FKawaiiPhysicsSimpleWorldCollisionDesc& InitialDesc);
 
 	/**
+	 * SimpleWorld用: 構築済みキーの Entry を検索、なければ作成する。provider は Desc を登録し、reader は member として登録する。
+	 * 任意スレッドから呼べる（Key / SkelComp をdereferenceしない）。
+	 * For SimpleWorld: Find or create an entry by an already-built key. Providers register a Desc; readers register membership.
+	 * Callable from any thread (does not dereference Key / SkelComp).
+	 */
+	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> FindOrCreateSimpleWorldEntry(
+		const FKawaiiPhysicsSimpleWorldRegistryKey& Key, uint64 SourceID,
+		const FKawaiiPhysicsSimpleWorldCollisionDesc& InitialDesc,
+		const TWeakObjectPtr<const USkeletalMeshComponent>& SkelComp,
+		bool bProvider);
+
+	/**
+	 * SimpleWorld用: 構築済みキーの Entry を検索する。Entry が無ければ null。
+	 * For SimpleWorld: Find an entry by an already-built key. Returns null when no entry exists.
+	 */
+	TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry> FindSimpleWorldEntry(
+		const FKawaiiPhysicsSimpleWorldRegistryKey& Key) const;
+
+	/**
 	 * Target用: Actorのファミリーrootのエントリを検索（RegistryLockでスレッドセーフ。任意スレッドから呼べる）
 	 * For targets: Find an entry for the actor family root. Thread-safe via RegistryLock; callable from any thread.
 	 */
 	TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> FindEntry(AActor* Actor, const FGameplayTag& Tag) const;
 
 	/**
+	 * Shared Publisher用: Actorのファミリーrootの Entry を検索、なければ作成する。
+	 * For Shared Publisher: Find or create an entry for the actor family root.
+	 */
+	TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> FindOrCreateSharedPublisherEntry(
+		AActor* Actor,
+		const FGameplayTag& Tag);
+
+	/**
+	 * Shared Publisher用: Actorのファミリーrootの Entry を検索する。Entry が無ければ null。
+	 * For Shared Publisher: Find an entry for the actor family root. Returns null when no entry exists.
+	 */
+	TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> FindSharedPublisherEntry(
+		AActor* Actor,
+		const FGameplayTag& Tag) const;
+
+	/**
 	 * Entry の Tick 専有データから診断情報を詰める（GameThread 専用。テストから直接呼べるよう static）
 	 * Fill diagnostics from an entry's tick-owned data (GameThread only; static so tests can call it directly)
 	 */
 	static void FillSimpleWorldCollisionDebugInfo(const FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
-	                                              FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo);
+	                                              FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo,
+	                                              const FKawaiiPhysicsSimpleWorldRegistryKey* Key = nullptr);
 
 	/**
 	 * Entry の収集済み形状を Shape Slot へ Publish する（GameThread 専用。テストから直接呼べるよう static）
 	 * Publish gathered shapes from Entry to the shape slot (GameThread only; static so tests can call it directly)
 	 */
 	static void PublishSimpleWorldShapeLimits(FKawaiiPhysicsSimpleWorldCollisionEntry& Entry, float BoxEnableThreshold);
+
+	/**
+	 * Provider disabled 中に形状 Slot と Ground Slot を必要な場合だけ空 Publish する（GameThread 専用）。
+	 * Publishes empty shape and ground slots only when needed while the provider is disabled (GameThread only).
+	 */
+	static void PublishSimpleWorldEmptyLimits(FKawaiiPhysicsSimpleWorldCollisionEntry& Entry, float BoxEnableThreshold);
 
 	/**
 	 * Entry の地面 Box を Ground Slot へ Publish する（GameThread 専用。テストから直接呼べるよう static）
@@ -446,6 +566,8 @@ public:
 	 * (OutInfo is reset with bHasEntry=false). GameThread only. Always false in Shipping builds.
 	 */
 	bool BuildSimpleWorldCollisionDebugInfo(const USkeletalMeshComponent* SkelComp,
+	                                        FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo) const;
+	bool BuildSimpleWorldCollisionDebugInfo(const FKawaiiPhysicsSimpleWorldRegistryKey& Key,
 	                                        FKawaiiPhysicsSimpleWorldCollisionDebugInfo& OutInfo) const;
 
 	// USubsystem interface
@@ -492,7 +614,10 @@ private:
 		int32 EffectiveMaxPhysicsAssetBodies,
 		int32 EffectiveMaxConvexPlanes,
 		bool bUseMovementGround,
-		bool bBuildConvexDebugGeometry);
+		bool bBuildConvexDebugGeometry,
+		const TArray<TWeakObjectPtr<const USkeletalMeshComponent>>& MemberSkelComps,
+		const TSet<TWeakObjectPtr<const USkeletalMeshComponent>>& MemberSkelCompSet,
+		const TSet<TWeakObjectPtr<const AActor>>& MemberOwners);
 	void UpdateSimpleWorldGround(
 		FKawaiiPhysicsSimpleWorldCollisionEntry& Entry,
 		const USkeletalMeshComponent& SkelComp,
@@ -511,6 +636,8 @@ private:
 	 */
 	TSharedPtr<FKawaiiPhysicsSharedCollisionEntry> FindEntryByKey(const FRegistryKey& Key) const;
 
+	TSharedPtr<FKawaiiPhysicsSharedPublisherEntry> FindSharedPublisherEntryByKey(const FRegistryKey& Key) const;
+
 	/** レジストリ: (ActorFamilyRoot, Tag) → Entry / Registry: (ActorFamilyRoot, Tag) -> Entry */
 	TMap<FRegistryKey, TSharedPtr<FKawaiiPhysicsSharedCollisionEntry>> Registry;
 
@@ -520,11 +647,19 @@ private:
 	 *  Lock order is always Registry -> Slots (Tick holds this while taking an Entry's SlotsLock); never the reverse. */
 	mutable FRWLock RegistryLock;
 
-	/** SimpleWorldレジストリ: SkelComp → Entry / SimpleWorld registry: SkelComp -> Entry
+	/** SimpleWorldレジストリ: (KeyObject, Tag) → Entry / SimpleWorld registry: (KeyObject, Tag) -> Entry
 	 *  ロック順序は SimpleWorldRegistryLock → Entry内ロック。既存RegistryLock/SlotsLockとは同時取得しない。
 	 *  Lock order is SimpleWorldRegistryLock -> entry-internal locks. Do not hold it with RegistryLock/SlotsLock. */
-	TMap<TWeakObjectPtr<const USkeletalMeshComponent>, TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>> SimpleWorldRegistry;
+	TMap<FKawaiiPhysicsSimpleWorldRegistryKey, TSharedPtr<FKawaiiPhysicsSimpleWorldCollisionEntry>> SimpleWorldRegistry;
 	mutable FRWLock SimpleWorldRegistryLock;
+
+	/** SharedPublisherレジストリ: (ActorFamilyRoot, Tag) → Entry / SharedPublisher registry: (ActorFamilyRoot, Tag) -> Entry
+	 *  ロック順序は SharedPublisherRegistryLock → StateLock / GustMutex。StateLock と GustMutex は同時取得しない。
+	 *  既存RegistryLock/SlotsLock/SimpleWorldRegistryLockとは同時取得しない。
+	 *  Lock order is SharedPublisherRegistryLock -> StateLock / GustMutex. Do not hold StateLock and GustMutex together.
+	 *  Do not hold it with RegistryLock/SlotsLock/SimpleWorldRegistryLock. */
+	TMap<FRegistryKey, TSharedPtr<FKawaiiPhysicsSharedPublisherEntry>> SharedPublisherRegistry;
+	mutable FRWLock SharedPublisherRegistryLock;
 
 	/** クリーンアップ間隔制御 / Cleanup interval control */
 	float CleanupAccumulator = 0.0f;

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedPublisherTypes.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedPublisherTypes.h
@@ -1,0 +1,208 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HAL/CriticalSection.h"
+#include "Misc/Optional.h"
+#include "KawaiiPhysicsSimpleWorldCollision.h"
+#include "ExternalForces/KawaiiPhysicsExternalForce_ProceduralWind.h"
+
+#include <atomic>
+
+#include "KawaiiPhysicsSharedPublisherTypes.generated.h"
+
+/**
+ * Shared Publisher が持つ Simple World Collision の収集設定。
+ * Simple World Collision gather settings owned by a Shared Publisher.
+ */
+USTRUCT(BlueprintType)
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionSettings
+{
+	GENERATED_BODY()
+
+	/**
+	 * GameThreadで定期収集したレベル上のsimple collisionをトレースなしで共有 publish します。World Collisionより大幅に低負荷ですが、薄い壁・高速移動では World Collision(sweep) の併用を推奨します。
+	 * Publishes level simple collision gathered periodically on the GameThread without traces. Much cheaper than World Collision, but using it with World Collision (sweep) is recommended for thin walls or fast movement.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (DisplayName = "Enabled"))
+	bool bEnabled = true;
+
+	/**
+	 * Simple World Collision の収集中心と半径を決める範囲。SkeletalMeshComponent はそのメッシュの Bounds、ActorFamily は同じ Entry に参加する全メッシュの Bounds の合成を使います。
+	 * Scope used to choose the Simple World Collision gather center and radius. SkeletalMeshComponent uses that mesh's Bounds; ActorFamily uses the combined Bounds of all meshes participating in the same Entry.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (EditCondition = "bEnabled", DisplayName = "Gather Scope"))
+	EKawaiiPhysicsSimpleWorldGatherScope GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+
+	/**
+	 * シンプルワールドコリジョンの収集間隔（秒）。0の場合は毎フレーム収集します。収集済みコンポーネントの位置更新は毎フレーム行われます。
+	 * Gather interval for Simple World Collision in seconds. 0 gathers every frame. Already gathered component transforms are updated every frame.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", ClampMin = "0.0", ClampMax = "10.0",
+		DisplayName = "Gather Interval", Units = "s"))
+	float GatherInterval = 0.2f;
+
+	/**
+	 * シンプルワールドコリジョンが反応するオブジェクトタイプ。空の場合は WorldStatic + WorldDynamic を使用します。収集されるのは、これらのタイプに属し、かつ所有 SkeletalMeshComponent の ObjectType（Override SkelComp Collision Params 有効時はその ObjectType）を Block するコンポーネントだけです。Overlap / Ignore 応答（トリガー等）は収集しません。bGatherFamilyMembers を使うときは Pawn を含める必要があります。
+	 * Object types used by Simple World Collision. Empty means WorldStatic + WorldDynamic. Only components of these types that Block the owning SkeletalMeshComponent's ObjectType (or the ObjectType from Override SkelComp Collision Params when enabled) are gathered. Overlap / Ignore responses (triggers, etc.) are never gathered. Include Pawn when using bGatherFamilyMembers.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", DisplayName = "Object Types"))
+	TArray<TEnumAsByte<EObjectTypeQuery>> ObjectTypes;
+
+	/**
+	 * Simple World Collision で Convex コリジョンに使う形状。既定の Convex Hull は実形状の平面セットをそのまま使い、ハル情報を取得できない場合や平面数が Max Convex Planes を超える場合は Bounding Box で代用します。
+	 * Shape used for convex collision in Simple World Collision. The default Convex Hull uses the actual plane set, falling back to the bounding box when hull data is unavailable or the plane count exceeds Max Convex Planes.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", DisplayName = "Convex Shape"))
+	EKawaiiPhysicsSimpleWorldConvexFallbackShape ConvexFallbackShape =
+		EKawaiiPhysicsSimpleWorldConvexFallbackShape::ConvexHull;
+
+	/**
+	 * シンプルワールドコリジョンの収集半径を上書きする。
+	 * Overrides the Simple World Collision gather radius.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (PinHiddenByDefault, InlineEditConditionToggle))
+	bool bOverrideGatherRadius = false;
+
+	/**
+	 * シンプルワールドコリジョンの収集半径のオーバーライド。無効時は SkeletalMesh の Bounds から自動算出します。
+	 * Override for the Simple World Collision gather radius. When disabled, it is calculated automatically from SkeletalMesh bounds.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bOverrideGatherRadius", ClampMin = "0",
+		DisplayName = "Gather Radius", Units = "cm"))
+	float GatherRadius = 200.0f;
+
+	/**
+	 * 所有 Actor の地面情報（IKawaiiPhysicsGroundProvider → CharacterMovementComponent の CurrentFloor）があればそれを使い、無ければ下方向トレース 1 本で地面を求め、薄い Box コリジョンとして扱います。Landscape や Complex コリジョンのみの床でも有効です。
+	 * Uses the owner's ground info when available (IKawaiiPhysicsGroundProvider, then CharacterMovementComponent CurrentFloor); otherwise fires one downward trace. The ground is treated as a thin box collision. Works on Landscape and complex-collision-only floors.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", DisplayName = "Ground Collision"))
+	bool bGroundCollision = true;
+
+	/**
+	 * Simple World Collision で収集した周囲の SkeletalMeshComponent との当たり方。None / Bounding Box / Physics Asset から選びます。
+	 * How Simple World Collision collides with gathered SkeletalMeshComponents: None, Bounding Box, or Physics Asset.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", DisplayName = "Skeletal Mesh Collision"))
+	EKawaiiPhysicsSimpleWorldSkeletalMeshCollision SkeletalMeshCollision =
+		EKawaiiPhysicsSimpleWorldSkeletalMeshCollision::None;
+
+	/**
+	 * Simple World Collision の Collision Channel を上書きする。
+	 * Overrides the Simple World Collision collision channel.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (PinHiddenByDefault, InlineEditConditionToggle))
+	bool bOverrideCollisionChannel = false;
+
+	/**
+	 * Simple World Collision の問い合わせ側 Collision Channel。上書きが無効な場合は所有 SkeletalMeshComponent の ObjectType を使います。
+	 * Query-side collision channel for Simple World Collision. When the override is disabled, the owning SkeletalMeshComponent ObjectType is used.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bOverrideCollisionChannel", DisplayName = "Collision Channel"))
+	TEnumAsByte<ECollisionChannel> CollisionChannel = ECC_Pawn;
+
+	/**
+	 * 同じ Entry に参加する他のメッシュ（ファミリー内メンバー）も Skeletal Mesh Collision のモードで収集し、各ノードは自分以外のメンバーの形状と衝突します。Object Types に Pawn を含める必要があります。
+	 * Also gathers other meshes participating in the same Entry (family members) with the Skeletal Mesh Collision mode, so each node collides with member shapes except its own. Object Types must include Pawn.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,
+		meta = (PinHiddenByDefault, EditCondition = "bEnabled", DisplayName = "Gather Family Members"))
+	bool bGatherFamilyMembers = false;
+};
+
+/**
+ * Shared Publisher が共有する風の状態。
+ * Wind state shared by a Shared Publisher.
+ */
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSharedWindState
+{
+	bool bPublisherWindEnabled = false;
+	FKawaiiProceduralWindDynamicParams Params;
+	float Time = 0.0f;
+	float PublisherTimeScale = 1.0f;
+	FKawaiiProceduralWindActiveGust ActiveGust;
+};
+
+/**
+ * Shared Publisher が 1 フレームに publish する全状態。
+ * Complete state published by a Shared Publisher for one frame.
+ */
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSharedPublisherState
+{
+	bool bSimpleWorldEnabled = false;
+	EKawaiiPhysicsSimpleWorldGatherScope GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::ActorFamily;
+	FKawaiiPhysicsSimpleWorldCollisionDesc SimpleWorldDesc;
+	FKawaiiPhysicsSharedWindState Wind;
+};
+
+/**
+ * Shared Publisher の突風開始 / 停止リクエスト。
+ * Gust start / stop request for a Shared Publisher.
+ */
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSharedPublisherGustRequest
+{
+	bool bStop = false;
+	float Strength = 0.0f;
+	float RiseTime = 0.0f;
+	float DecayTime = 0.0f;
+	float HoldTime = 0.0f;
+	float BlendOutTime = 0.0f;
+};
+
+/**
+ * Shared Publisher が GameplayTag ごとに publish する状態 Entry。
+ * State entry published by a Shared Publisher for a GameplayTag.
+ */
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSharedPublisherEntry
+{
+	struct FPendingPublisherRequests
+	{
+		TOptional<bool> Enabled;
+		TOptional<FKawaiiPhysicsSimpleWorldCollisionSettings> SimpleWorldSettings;
+	};
+
+	/**
+	 * 1 フレーム分の状態を publish する。期限切れ（MarkExpired 済み）の Entry では何も書き換えずに false を返す。
+	 * provider ID 0 は拒否する。
+	 * Publishes one frame of state. Returns false without touching an entry that has already been expired (MarkExpired).
+	 * A provider ID of 0 is rejected.
+	 */
+	bool PublishState(const FKawaiiPhysicsSharedPublisherState& InState, uint64 InProviderID, uint64 CurrentFrame,
+	                  uint64 ProviderMaxAgeFrames);
+	uint64 ReadState(FKawaiiPhysicsSharedPublisherState& Out) const;
+	uint64 ReadWindState(FKawaiiPhysicsSharedWindState& Out) const;
+	uint64 GetPublishSerial() const;
+	uint64 GetProviderID() const;
+	uint64 GetLastPublishFrame() const;
+	bool IsExpired(uint64 CurrentFrame, uint64 MaxAgeFrames) const;
+	void MarkExpired();
+
+	void RequestGust(float Strength, float RiseTime, float DecayTime, float HoldTime);
+	void RequestGustStop(float BlendOutTime);
+	void ConsumePendingGustRequests(TArray<FKawaiiPhysicsSharedPublisherGustRequest>& Out);
+
+	void RequestPublisherEnabled(bool bEnabled);
+	void RequestSimpleWorldSettings(const FKawaiiPhysicsSimpleWorldCollisionSettings& Settings);
+	bool ConsumePendingPublisherRequests(FPendingPublisherRequests& Out);
+
+private:
+	FKawaiiPhysicsSharedPublisherState State;
+	mutable FRWLock StateLock;
+	std::atomic<uint64> PublishSerial{0};
+	std::atomic<uint64> LastPublishFrame{0};
+	uint64 ProviderID = 0;
+	bool bExpired = false;
+
+	FCriticalSection GustMutex;
+	TArray<FKawaiiPhysicsSharedPublisherGustRequest> PendingGusts;
+	TOptional<bool> PendingPublisherEnabled;
+	TOptional<FKawaiiPhysicsSimpleWorldCollisionSettings> PendingSimpleWorldSettings;
+};

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedTags.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSharedTags.h
@@ -1,0 +1,8 @@
+// Copyright 2019-2026 pafuhana1213. All Rights Reserved.
+
+#pragma once
+
+#include "NativeGameplayTags.h"
+
+/** Shared Publisher と消費側ノードが既定で使う共有グループ Tag / Default shared group tag used by Shared Publisher and consuming nodes. */
+KAWAIIPHYSICS_API UE_DECLARE_GAMEPLAY_TAG_EXTERN(TAG_KawaiiPhysics_Shared_Default);

--- a/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
+++ b/Plugins/KawaiiPhysics/Source/KawaiiPhysics/Public/KawaiiPhysicsSimpleWorldCollision.h
@@ -44,6 +44,74 @@ enum class EKawaiiPhysicsSimpleWorldSkeletalMeshCollision : uint8
 	PhysicsAsset UMETA(DisplayName = "Physics Asset", ToolTip = "PhysicsAsset の Body をボーン追従で変換します。上限は Max PhysicsAsset Bodies で、PhysicsAsset 無しは Bounding Box 相当、PhysicsAsset があって有効な body が無い場合は収集しません。ポーズは 1 フレーム遅れ得ます。アニメ由来のボーンスケールは形状サイズへ反映しません。 / Transform PhysicsAsset bodies by following bones. Limited by Max PhysicsAsset Bodies; no PhysicsAsset behaves like Bounding Box, and when a PhysicsAsset exists but has no valid body, it is not gathered. Pose data may be one frame late. Bone scale from animation is not applied to shape sizes."),
 };
 
+/**
+ * Simple World Collision の収集中心と半径を決める範囲。SkeletalMeshComponent はそのメッシュの Bounds、ActorFamily は同じ Entry に参加する全メッシュの Bounds の合成を使います。
+ * Scope used to choose the Simple World Collision gather center and radius. SkeletalMeshComponent uses that mesh's Bounds; ActorFamily uses the combined Bounds of all meshes participating in the same Entry.
+ */
+UENUM(BlueprintType)
+enum class EKawaiiPhysicsSimpleWorldGatherScope : uint8
+{
+	/** その SkeletalMeshComponent の Bounds を使います / Use the owning SkeletalMeshComponent Bounds. */
+	SkeletalMeshComponent = 0 UMETA(DisplayName = "Skeletal Mesh Component"),
+	/** 同じ Entry に参加する全メッシュの Bounds 合成を使います / Use the combined Bounds of all meshes participating in the same Entry. */
+	ActorFamily = 1 UMETA(DisplayName = "Actor Family"),
+};
+
+struct FKawaiiPhysicsSimpleWorldCollisionSettings;
+
+/**
+ * シンプルワールドコリジョン収集設定
+ * Simple-world collision gather settings
+ */
+struct KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDesc
+{
+	float GatherIntervalSec = 0.2f;
+	float GatherRadiusOverride = 0.0f;
+	// Merge の出力: 全 Desc が GatherRadiusOverride を指定していれば true。ノード側は false のまま / Merge output: true when every Desc specifies GatherRadiusOverride. Node-built Descs leave it false
+	bool bGatherRadiusAllOverridden = false;
+	// ECC_MAX は所有 SkeletalMeshComponent の ObjectType を使う指定 / ECC_MAX means using the owning SkeletalMeshComponent's ObjectType.
+	TEnumAsByte<ECollisionChannel> CollisionChannel = ECC_MAX;
+	TArray<TEnumAsByte<EObjectTypeQuery>> ObjectTypes;
+	EKawaiiPhysicsSimpleWorldConvexFallbackShape ConvexFallbackShape = EKawaiiPhysicsSimpleWorldConvexFallbackShape::ConvexHull;
+	EKawaiiPhysicsSimpleWorldSkeletalMeshCollision SkeletalMeshCollision = EKawaiiPhysicsSimpleWorldSkeletalMeshCollision::None;
+	bool bGroundCollision = true;
+	EKawaiiPhysicsSimpleWorldGatherScope GatherScope = EKawaiiPhysicsSimpleWorldGatherScope::SkeletalMeshComponent;
+	bool bGatherFamilyMembers = false;
+	bool bProviderDisabled = false;
+
+	/**
+	 * 複数ノードの収集設定を SkelComp 単位の1設定へマージする。
+	 * Merge multiple node gather settings into one SkelComp-level setting.
+	 *
+	 * 規則 / Rules:
+	 * - GatherIntervalSec は最小値。0以下は毎フレーム収集で最優先。
+	 * - GatherIntervalSec uses the minimum value. <= 0 means gather every frame and has highest priority.
+	 * - GatherRadiusOverride は Override 指定の最大値（指定なしは 0）。bGatherRadiusAllOverridden は全 Desc が Override 指定の時だけ true。
+	 * - GatherRadiusOverride is the max of the specified overrides (0 when none). bGatherRadiusAllOverridden is true only when every Desc specifies an override.
+	 * - CollisionChannel は ECC_MAX 以外（World Collision の Override 指定）を持つ Desc のうち、最も早く登録されたノードの値を採用。全て ECC_MAX なら ECC_MAX。
+	 * - CollisionChannel uses the value of the earliest-registered Desc whose value is not ECC_MAX (World Collision override). If all values are ECC_MAX, it stays ECC_MAX.
+	 * - ObjectTypes は union。空配列は WorldStatic + WorldDynamic の意味なので、空 Desc がある場合はそれらを明示的に union へ含める。
+	 * - ObjectTypes are unioned. Empty means WorldStatic + WorldDynamic, so those are explicitly included when any Desc is empty.
+	 * - ConvexFallbackShape は宣言順（高精度が先）の優先。
+	 * - ConvexFallbackShape priority follows declaration order (more accurate first).
+	 * - SkeletalMeshCollision は PhysicsAsset > BoundingBox > None の優先。
+	 * - SkeletalMeshCollision priority is PhysicsAsset > BoundingBox > None.
+	 * - bGroundCollision は OR。
+	 * - bGroundCollision is OR.
+	 * - GatherScope は ActorFamily 優先、bGatherFamilyMembers は OR、bProviderDisabled は AND。
+	 * - GatherScope prefers ActorFamily, bGatherFamilyMembers uses OR, and bProviderDisabled uses AND.
+	 */
+	static FKawaiiPhysicsSimpleWorldCollisionDesc Merge(const TArray<FKawaiiPhysicsSimpleWorldCollisionDesc>& Descs);
+
+	/**
+	 * Desc の変更が収集結果（Overlap 対象・形状変換・地面・半径）に影響するか。GatherIntervalSec だけの変化は false。
+	 * Whether a Desc change affects the gather result (overlap set, shape conversion, ground, radius). Interval-only changes return false.
+	 */
+	static bool DoesChangeRequireRegather(const FKawaiiPhysicsSimpleWorldCollisionDesc& Old, const FKawaiiPhysicsSimpleWorldCollisionDesc& New);
+
+	bool operator==(const FKawaiiPhysicsSimpleWorldCollisionDesc& Other) const;
+};
+
 namespace KawaiiPhysicsSimpleWorldCollision
 {
 	/**
@@ -229,4 +297,19 @@ namespace KawaiiPhysicsSimpleWorldCollision
 		const FTransform& ComponentTM,
 		FKawaiiPhysicsSharedCollisionData& OutWorldLimits,
 		float BoxEnableThreshold = 0.5f);
+
+	/**
+	 * メンバー Bounds 配列を SimpleWorld 収集用 Bounds に合成します。空なら false を返します。
+	 * Combines member Bounds into gather Bounds for SimpleWorld. Returns false for an empty input.
+	 */
+	KAWAIIPHYSICS_API bool ComputeSimpleWorldGatherBounds(
+		TArrayView<const FBoxSphereBounds> MemberBounds,
+		FBoxSphereBounds& OutBounds);
+
+	/**
+	 * Shared Publisher の設定から Simple World Collision Desc を作ります。
+	 * Builds a Simple World Collision Desc from Shared Publisher settings.
+	 */
+	KAWAIIPHYSICS_API FKawaiiPhysicsSimpleWorldCollisionDesc BuildSimpleWorldCollisionDesc(
+		const FKawaiiPhysicsSimpleWorldCollisionSettings& Settings);
 }


### PR DESCRIPTION
## 概要
Simple World Collision の収集 Entry を SkeletalMeshComponent 単位から `(KeyObject, Tag)` キー＋provider / reader 方式へ一般化し、Actor ファミリー単位の収集と Shared Publisher（次段で追加する ABP 上の共有ノード）の backend を追加しました。この PR にはユーザー向けの UPROPERTY / Blueprint API / ノードは含まれず、既存の Local 経路（各ノードが自分のメッシュで登録）は挙動同一です。

## 変更内容
- Registry キー `FKawaiiPhysicsSimpleWorldRegistryKey`（`MakeLocalKey(SkelComp)` = 従来、`MakeSharedKey(FamilyRoot, Tag)` = 共有）。`FindOrCreateSimpleWorldEntry(Key, …, bProvider)` / `FindSimpleWorldEntry(Key)`。旧シグネチャは Local キーへ転送
- Entry の provider / reader 化: `FDescSlot` に SkelComp と provider フラグ、`AddReaderMember` / `RemoveReaderMember` / `MarkReaderRead`（provider 生存中は disabled でも true、不在・期限切れで false）、`GetPrimarySkelComp`（登録順最小の provider）、`CollectMemberSkelComps`。`BuildMergedDesc` は provider のみ、Cleanup は provider も reader も無い Entry だけ除去
- Desc に `GatherScope`（ActorFamily 優先）/ `bGatherFamilyMembers`（OR）/ `bProviderDisabled`（AND）を追加し、変化で再収集。`FKawaiiPhysicsSimpleWorldCollisionDesc` は include 循環回避のため `KawaiiPhysicsSimpleWorldCollision.h` へ移動
- Tick のファミリー収集: 全メンバー SkelComp の Bounds 合成（`ComputeSimpleWorldGatherBounds`）で中心・半径、ActorFamily ではメンバー Owner を無視。`bGatherFamilyMembers` ではメンバー SkelComp（primary 含む）を `Skeletal Mesh Collision` のモードで収集してメンバー別 Slot（`MemberSlots`）へ publish し、reader は `AppendFamilyMemberLimits` で自分以外を読む。`bProviderDisabled` は空を 1 回だけ publish
- DebugInfo に `GatherScope` / `GroupTag` / `KeyObjectName` / `NumReaders` / `bProviderDisabled` / `bGatherFamilyMembers` / `NumMemberSlots`、STAT `NumMemberSlots`
- Shared Publisher backend: `KawaiiPhysicsSharedPublisherTypes.h`（`FKawaiiPhysicsSimpleWorldCollisionSettings` USTRUCT、風・状態・突風リクエストの型、`FKawaiiPhysicsSharedPublisherEntry`：provider 排他の `PublishState`、serial 付き `ReadState` / `ReadWindState`、突風キューと制御キュー）、`KawaiiPhysicsSharedTags.h`（`KawaiiPhysics.Shared.Default`）、Subsystem の `SharedPublisherRegistry`（`FindOrCreateSharedPublisherEntry` / `FindSharedPublisherEntry`、Cleanup / Deinitialize / IsTickable 連携）、`BuildSimpleWorldCollisionDesc(Settings)`
- ノード側 reader 経路（内部実装、テストハーネスからのみ有効化）: reader 登録、`MarkReaderRead` 失敗時の解放と再登録リトライ（60 回で 1 回だけ警告）、provider 無効時の配列クリア、serial ゲートにメンバー Slot の serial 合計を追加、半径チェックは reader では省略。公開アクセサ `GetSharedCollisionSubsystem` / `GetSharedCollisionOwnerActor`。CVar `a.AnimNode.KawaiiPhysics.SharedPublisher.ReaderReleaseMaxAge`（既定 60 フレーム）
- Local 経路の修正: Desc 再送時に必ず自分の SkelComp を渡す（provider slot の期限切れ後に設定変更があっても収集が止まらない）
- Worker から呼ぶ登録・読み取り API（`FindOrCreateSimpleWorldEntry` / `SetDesc` / `AddReaderMember` / `AppendFamilyMemberLimits` とキー判定）は弱参照ベースに統一し、`TWeakObjectPtr::Get()` や既定の `IsValid()` を使わない（`IsValid(false, true)` と弱参照比較のみ。reader 警告用の名前は GameThread でキャッシュ）
- Publisher Entry は期限切れ（Cleanup で Registry から外れた）Entry と provider ID 0 への `PublishState` を拒否し、地面トレースは Overlap とは別の無視設定で自分と家族のメッシュを常に無視
- テスト: `SimpleWorld.*` 17 本（`RegistryKey` / `ProviderDescWins` / `ReaderMembersLifecycle` / `ReaderReleasedWhenProviderExpires` / `ReaderKeepsMembershipWhenProviderDisabled` / `PrimaryIsProviderSkelComp` / `DescMergeGatherScope` / `GatherBoundsUnion` / `FamilyMemberSlotsExcludeSelf` / `MemberSlotRemovedWithMember` / `DebugInfoSharedFields` / `ProviderDisabledPublishesEmpty` / `SharedReaderConsumesInjectedState` / `SharedReaderClearsWhenProviderDisabled` / `SharedReaderReleasesWhenProviderGone` / `SharedReaderSkipsRadiusCheck` / `LocalProviderKeepsSkelCompAfterExpiry`）、`SharedPublisher.*` 3 本（`EntryPublishRead` / `GustQueue` / `PublisherRequestQueue`）。ハーネスに `InjectSharedPublisherState` ほか

## 確認
- ビルド: KawaiiPhysicsSampleEditor (UE 5.8) OK
- ヘッドレステスト: 274/274（フィルタ: KawaiiPhysics）、`Simulation.GoldenPositions` bit 一致
- 規約リンタ: Tools/lint-kp.ps1 -Base master → ERROR 0 件 / WARN 0 件
- PIE: 未（docs/pie/SimpleWorldSharedRegistry_PIE_Checklist.md、INDEX.md に登録済。Shared 経路の目視は PR-4 の Publisher ノード後）
- 性能: ホットパスの変更は Local 経路で serial ゲートの比較 1 項目追加のみ。ベンチ `Perf.SimpleWorldRead.*` / `Perf.Chain` / `Perf.Collision` に回帰なし（master を同日・同環境で 3 run ずつ計測して比較、WARN 0 / NOISY 0）
